### PR TITLE
Fix handling of apostrophe variant.

### DIFF
--- a/app/src/lib/parser/tokenize.test.js
+++ b/app/src/lib/parser/tokenize.test.js
@@ -304,6 +304,21 @@ describe('tokenize_input', () => {
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
 	})
 
+	test('single quote variants', () => {
+		const INPUT = "Paul's Paul’s Jesus’ Jesus' sons’-C you(Paul’s)"
+		
+		const EXPECTED_OUTPUT = [
+			create_word_token("Paul's", 'Paul'),
+			create_word_token("Paul’s", 'Paul'),
+			create_word_token("Jesus’", 'Jesus'),
+			create_word_token("Jesus'", 'Jesus'),
+			create_word_token("sons’-C", 'sons-C'),
+			create_word_token("you(Paul’s)", 'Paul'),
+		]
+		
+		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
+	})
+
 	test('invalid single characters', () => {
 		const INPUT = "( ) / * + ;"
 		

--- a/app/src/lib/regexes.js
+++ b/app/src/lib/regexes.js
@@ -15,11 +15,11 @@ const CLOSING_PAREN = /\)/
 const FORWARD_SLASH = /\//
 
 // Could be you(son) your(son's) your(sons') you(son-C) your(son's-C) your(sons'-C)
-const EXTRACT_PRONOUN_REFERENT = /^\w+\(([\w'-]+)\)$/
+const EXTRACT_PRONOUN_REFERENT = /^\w+\(([\w'’-]+)\)$/
 
 // Could be son son's sons' son-C son's-C sons'-C
 // This pulls out the stem and sense, which will then need to be put back together
-const EXTRACT_WORD_REFERENT = /^(.+?)(?:'s|')?(-[A-Z])?$/
+const EXTRACT_WORD_REFERENT = /^(.+?)(?:['’]s|['’])?(-[A-Z])?$/
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class
 const OPENING_OR_CLOSING_BRACKET = /[[\]]/
@@ -27,7 +27,7 @@ const OPENING_OR_CLOSING_BRACKET_G = /[[\]]/g
 
 const TOKEN_END_BOUNDARY = /[\s.,!?:"\]]/
 const WORD_START_CHAR = /[a-zA-Z0-9-]/
-const WORD_CHAR = /[a-zA-Z0-9-']/
+const WORD_CHAR = /[a-zA-Z0-9-'’]/
 
 const IS_LEVEL_SIMPLE = /[01]/
 const IS_LEVEL_COMPLEX = /[23]/


### PR DESCRIPTION
Another option would be to convert all ’ to ' before tokenization.