### PR TITLE
Move lookups into pipeline

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -7,6 +7,8 @@ type Token = {
 	lookup_term: string;
 	pairing_left: Token?;
 	pairing_right: Token?;
+	concept: OntologyResult?;
+	lookup_results: OntologyResult[]
 }
 
 type LookupTerm = string
@@ -33,6 +35,7 @@ type DbRowInflection = {
 }
 
 type TokenFilter = (token: Token) => boolean
+type LookupFilter = (concept: OntologyResult) => boolean
 
 type TokenContextFilter = (tokens: Token[], trigger_index: number) => boolean
 

--- a/app/src/lib/lookups.js
+++ b/app/src/lib/lookups.js
@@ -7,10 +7,7 @@ import {TOKEN_TYPE} from "./parser/token"
 export async function perform_ontology_lookups(tokens) {
 	const lookup_tokens = tokens.flatMap(get_lookup_tokens)
 
-	const lookup_promises = lookup_tokens.map(check_ontology)
-
-	// TODO handle errors
-	await Promise.all(lookup_promises)
+	await Promise.all(lookup_tokens.map(check_ontology))
 
 	return tokens
 
@@ -20,9 +17,9 @@ export async function perform_ontology_lookups(tokens) {
 	 * @returns {Token[]}
 	 */
 	function get_lookup_tokens(token) {
-		if (token.type == TOKEN_TYPE.LOOKUP_WORD) {
+		if (token.type === TOKEN_TYPE.LOOKUP_WORD) {
 			return [token]
-		} else if (token.type == TOKEN_TYPE.PAIRING) {
+		} else if (token.type === TOKEN_TYPE.PAIRING) {
 			// @ts-ignore
 			return [token.pairing_left, token.pairing_right]
 		} else {

--- a/app/src/lib/lookups.js
+++ b/app/src/lib/lookups.js
@@ -1,8 +1,46 @@
+import {TOKEN_TYPE} from "./parser/token"
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ */
+export async function perform_ontology_lookups(tokens) {
+	const lookup_tokens = tokens.flatMap(get_lookup_tokens)
+
+	const lookup_promises = lookup_tokens.map(check_ontology)
+
+	// TODO handle errors
+	await Promise.all(lookup_promises)
+
+	return tokens
+
+	/**
+	 * 
+	 * @param {Token} token 
+	 * @returns {Token[]}
+	 */
+	function get_lookup_tokens(token) {
+		if (token.type == TOKEN_TYPE.LOOKUP_WORD) {
+			return [token]
+		} else if (token.type == TOKEN_TYPE.PAIRING) {
+			// @ts-ignore
+			return [token.pairing_left, token.pairing_right]
+		} else {
+			return []
+		}
+	}
+}
+
 /**
  * @param {Token} lookup_token
- * @returns {Promise<LookupResult<OntologyResult>>}
  */
-export async function check_ontology(lookup_token) {
+async function check_ontology(lookup_token) {
 	const response = await fetch(`/lookup?word=${lookup_token.lookup_term}`)
-	return await response.json()
+
+	/** @type {LookupResult<OntologyResult>} */
+	const results = await response.json()
+
+	lookup_token.lookup_results = results.matches
+
+	lookup_token.concept = results.matches.length === 1 ? results.matches[0] : null
 }

--- a/app/src/lib/parser/index.js
+++ b/app/src/lib/parser/index.js
@@ -27,6 +27,8 @@ export async function parse(text) {
 }
 
 /**
+ * TODO: temporary... need to build e2e testing infrastructure
+ * 
  * @param {string} text
  * @returns {Token[]}
  */

--- a/app/src/lib/parser/index.js
+++ b/app/src/lib/parser/index.js
@@ -3,17 +3,40 @@ import {tokenize_input} from './tokenize'
 import {check_syntax} from './syntax'
 import {use_alternate_lookups} from './alternate_lookups'
 import {apply_transform_rules, apply_checker_rules} from '../rules/rules_processor'
+import {perform_ontology_lookups} from '$lib/lookups'
+import {check_pairings} from './pairings'
+
+/**
+ * @param {string} text
+ * @returns {Promise<Token[]>}
+ */
+export async function parse(text) {
+	const pre_lookups = pipe(
+		tokenize_input,
+		check_syntax,
+		use_alternate_lookups,
+	)(text)
+
+	const with_lookups = await perform_ontology_lookups(pre_lookups)
+
+	return pipe(
+		apply_transform_rules,
+		apply_checker_rules,
+		check_pairings,
+	)(with_lookups)
+}
 
 /**
  * @param {string} text
  * @returns {Token[]}
  */
-export function parse(text) {
+export function parse_for_test(text) {
 	return pipe(
 		tokenize_input,
 		check_syntax,
 		use_alternate_lookups,
 		apply_transform_rules,
 		apply_checker_rules,
+		check_pairings,
 	)(text)
 }

--- a/app/src/lib/parser/index.test.js
+++ b/app/src/lib/parser/index.test.js
@@ -1,4 +1,4 @@
-import {parse} from '.'
+import {parse_for_test} from '.'
 import {describe, expect, test} from 'vitest'
 import {TOKEN_TYPE, create_token} from './token'
 import {ERRORS} from './error_messages'
@@ -16,22 +16,22 @@ function create_word_token(token, lookup_term=null) {
 describe('parse', () => {
 	describe('no problems', () => {
 		test('empty string', () => {
-			expect(parse('')).toEqual([])
+			expect(parse_for_test('')).toEqual([])
 		})
 
 		test('whitespace', () => {
-			expect(parse(' ')).toEqual([])
+			expect(parse_for_test(' ')).toEqual([])
 		})
 
 		test('Token.', () => {
-			expect(parse('Token.')).toEqual([
+			expect(parse_for_test('Token.')).toEqual([
 				create_word_token('Token'),
 				create_token('.', TOKEN_TYPE.PUNCTUATION),
 			])
 		})
 
 		test('Token1 token2.', () => {
-			expect(parse('Token1 token2.')).toEqual([
+			expect(parse_for_test('Token1 token2.')).toEqual([
 				create_word_token('Token1'),
 				create_word_token('token2'),
 				create_token('.', TOKEN_TYPE.PUNCTUATION),
@@ -39,7 +39,7 @@ describe('parse', () => {
 		})
 
 		test('Ok _notesNotation [fixedbracket you(Paul)].', () => {
-			const results = parse('Ok _notesNotation [fixedbracket you(Paul)].')
+			const results = parse_for_test('Ok _notesNotation [fixedbracket you(Paul)].')
 
 			expect(results).length(7)
 			expect(results[0].token).toBe('Ok')
@@ -66,7 +66,7 @@ describe('parse', () => {
 		})
 
 		test('[Paul explained [the Christ needed to become alive again]].', () => {
-			const results = parse('[Paul explained [the Christ needed to become alive again]].')
+			const results = parse_for_test('[Paul explained [the Christ needed to become alive again]].')
 
 			expect(results).length(14)
 			expect(results[0].token).toBe('[')
@@ -100,7 +100,7 @@ describe('parse', () => {
 		})
 
 		test('You(people) are being stupid/foolish."', () => {
-			const results = parse('You(people) are being stupid/foolish."')
+			const results = parse_for_test('You(people) are being stupid/foolish."')
 
 			expect(results).length(6)
 			expect(results[0].token).toBe('You(people)')
@@ -124,7 +124,7 @@ describe('parse', () => {
 		})
 
 		test('John said, ["What do you(person) want?"] Then that person took the book [that John had].', () => {
-			const results = parse('John said, ["What do you(person) want?"] Then that person took the book [that John had].')
+			const results = parse_for_test('John said, ["What do you(person) want?"] Then that person took the book [that John had].')
 
 			expect(results).length(24)
 			for (let token of results) {
@@ -135,7 +135,7 @@ describe('parse', () => {
 
 	describe('problems detected', () => {
 		test('bad_notesNotation[badbracket you', () => {
-			const results = parse('bad_notesNotation[badbracket you')
+			const results = parse_for_test('bad_notesNotation[badbracket you')
 
 			expect(results).length(4)
 			expect(results[0].token).toBe('bad_notesNotation[badbracket')
@@ -149,7 +149,7 @@ describe('parse', () => {
 		})
 
 		test('Ok _notesNotation text[badbracket you', () => {
-			const results = parse('Ok _notesNotation text[badbracket you')
+			const results = parse_for_test('Ok _notesNotation text[badbracket you')
 
 			expect(results).length(7)
 			expect(results[0].token).toBe('Ok')
@@ -169,7 +169,7 @@ describe('parse', () => {
 		})
 
 		test('Ok _notesNotation [fixedbracket you', () => {
-			const results = parse('Ok _notesNotation [fixedbracket you')
+			const results = parse_for_test('Ok _notesNotation [fixedbracket you')
 
 			expect(results).length(7)
 			expect(results[0].token).toBe('Ok')
@@ -189,7 +189,7 @@ describe('parse', () => {
 		})
 
 		test('Ok _notesNotation [fixedbracket you(Paul', () => {
-			const results = parse('Ok _notesNotation [fixedbracket you(Paul')
+			const results = parse_for_test('Ok _notesNotation [fixedbracket you(Paul')
 
 			expect(results).length(7)
 			expect(results[0].token).toBe('Ok')
@@ -209,7 +209,7 @@ describe('parse', () => {
 		})
 
 		test('Ok _notesNotation [fixedbracket you(Paul).', () => {
-			const results = parse('Ok _notesNotation [fixedbracket you(Paul)')
+			const results = parse_for_test('Ok _notesNotation [fixedbracket you(Paul)')
 
 			expect(results).length(7)
 			expect(results[0].token).toBe('Ok')
@@ -229,7 +229,7 @@ describe('parse', () => {
 		})
 
 		test('Paul explained [the Christ needed to become alive again]].', () => {
-			const results = parse('Paul explained [the Christ needed to become alive again]].')
+			const results = parse_for_test('Paul explained [the Christ needed to become alive again]].')
 
 			expect(results).length(14)
 			expect(results[0].token).toBe('[')
@@ -263,7 +263,7 @@ describe('parse', () => {
 		})
 
 		test('John said, ["what do you(person) want?" then that person took the book that John had]', () => {
-			const results = parse('John said, ["what do you(person) want?" then that person took the book that John had]')
+			const results = parse_for_test('John said, ["what do you(person) want?" then that person took the book that John had]')
 	
 			expect(results).length(24)
 			expect(results[0].token).toBe('John')
@@ -319,7 +319,7 @@ describe('parse', () => {
 
 	describe('alternate lookups', () => {
 		test('alternate lookups', () => {
-			const results = parse('John ran [in order to escape many bears].')
+			const results = parse_for_test('John ran [in order to escape many bears].')
 
 			expect(results).length(9)
 			expect(results[0].token).toBe('John')

--- a/app/src/lib/parser/pairings.js
+++ b/app/src/lib/parser/pairings.js
@@ -1,0 +1,28 @@
+import { REGEXES } from "$lib/regexes"
+import { create_error_token, check_token_lookup, TOKEN_TYPE } from "./token"
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @returns {Token[]}
+ */
+export function check_pairings(tokens) {
+	tokens.filter(token => token.type === TOKEN_TYPE.PAIRING).forEach(check_pairing)
+
+	return tokens
+
+	/**
+	 * 
+	 * @param {Token} token 
+	 */
+	function check_pairing(token) {
+		if (token.pairing_left &&
+			check_token_lookup((concept) => REGEXES.IS_LEVEL_COMPLEX.test(`${concept.level}`))(token.pairing_left)) {
+			token.pairing_left = create_error_token(token.pairing_left.token, 'Word must be a level 0 or 1')
+		}
+		if (token.pairing_right &&
+			check_token_lookup((concept) => REGEXES.IS_LEVEL_SIMPLE.test(`${concept.level}`))(token.pairing_right)) {
+			token.pairing_right = create_error_token(token.pairing_right.token, 'Word must be a level 2 or 3')
+		}
+	}
+}

--- a/app/src/lib/parser/pairings.js
+++ b/app/src/lib/parser/pairings.js
@@ -1,5 +1,5 @@
-import { REGEXES } from "$lib/regexes"
-import { create_error_token, check_token_lookup, TOKEN_TYPE } from "./token"
+import {REGEXES} from '$lib/regexes'
+import {create_error_token, check_token_lookup, TOKEN_TYPE} from './token'
 
 /**
  * 
@@ -17,11 +17,11 @@ export function check_pairings(tokens) {
 	 */
 	function check_pairing(token) {
 		if (token.pairing_left &&
-			check_token_lookup((concept) => REGEXES.IS_LEVEL_COMPLEX.test(`${concept.level}`))(token.pairing_left)) {
+			check_token_lookup(concept => REGEXES.IS_LEVEL_COMPLEX.test(`${concept.level}`))(token.pairing_left)) {
 			token.pairing_left = create_error_token(token.pairing_left.token, 'Word must be a level 0 or 1')
 		}
 		if (token.pairing_right &&
-			check_token_lookup((concept) => REGEXES.IS_LEVEL_SIMPLE.test(`${concept.level}`))(token.pairing_right)) {
+			check_token_lookup(concept => REGEXES.IS_LEVEL_SIMPLE.test(`${concept.level}`))(token.pairing_right)) {
 			token.pairing_right = create_error_token(token.pairing_right.token, 'Word must be a level 2 or 3')
 		}
 	}

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -17,12 +17,12 @@ const LOOKUP_WORD = 'Word'
 const PAIRING = 'Pairing'
 
 export const TOKEN_TYPE = {
-    ERROR,
-    PUNCTUATION,
-    NOTE,
-    FUNCTION_WORD,
-    LOOKUP_WORD,
-    PAIRING,
+	ERROR,
+	PUNCTUATION,
+	NOTE,
+	FUNCTION_WORD,
+	LOOKUP_WORD,
+	PAIRING,
 }
 
 /**
@@ -34,16 +34,19 @@ export const TOKEN_TYPE = {
  * @param {string} [other_data.lookup_term=''] 
  * @param {Token?} [other_data.pairing_left=null] 
  * @param {Token?} [other_data.pairing_right=null] 
+ * @return {Token}
  */
 export function create_token(token, type, {message='', lookup_term='', pairing_left=null, pairing_right=null}={}) {
-    return {
-        token,
-        type,
-        message,
-        lookup_term,
-        pairing_left,
-        pairing_right,
-    }
+	return {
+		token,
+		type,
+		message,
+		lookup_term,
+		pairing_left,
+		pairing_right,
+		concept: null,
+		lookup_results: []
+	}
 }
 
 /**
@@ -53,5 +56,42 @@ export function create_token(token, type, {message='', lookup_term='', pairing_l
  * @returns {Token}
  */
 export function create_error_token(token, message) {
-    return create_token(token, TOKEN_TYPE.ERROR, { message })
+	return create_token(token, TOKEN_TYPE.ERROR, { message })
+}
+
+/**
+ * 
+ * @param {Token} token 
+ * @returns 
+ */
+export function token_has_concept(token) {
+	return token.concept || token.lookup_results.length > 0
+}
+
+/**
+ * 
+ * @param {LookupFilter} lookup_check 
+ * @returns {TokenFilter}
+ */
+export function check_token_lookup(lookup_check) {
+	return (token) => {
+		if (token.concept) {
+			return lookup_check(token.concept)
+		} else if (token.lookup_results.length > 0) {
+			return token.lookup_results.every(concept => lookup_check(concept))
+		} else {
+			return false
+		}
+	}
+}
+
+/**
+ * 
+ * @param {Token} token 
+ * @returns {boolean}
+ */
+export function token_has_error(token) {
+	return token.type === TOKEN_TYPE.ERROR
+		|| token.pairing_left?.type === TOKEN_TYPE.ERROR
+		|| token.pairing_right?.type === TOKEN_TYPE.ERROR
 }

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -62,10 +62,10 @@ export function create_error_token(token, message) {
 /**
  * 
  * @param {Token} token 
- * @returns 
+ * @returns {boolean}
  */
 export function token_has_concept(token) {
-	return token.concept || token.lookup_results.length > 0
+	return token.concept !== null || token.lookup_results.length > 0
 }
 
 /**
@@ -74,7 +74,7 @@ export function token_has_concept(token) {
  * @returns {TokenFilter}
  */
 export function check_token_lookup(lookup_check) {
-	return (token) => {
+	return token => {
 		if (token.concept) {
 			return lookup_check(token.concept)
 		} else if (token.lookup_results.length > 0) {

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -6,7 +6,7 @@ const checker_rules_json = [
 	// 	'name': 'Expect a [ before a relative clause',
 	// 	'trigger': { 'token': 'that|who|whom|which' },
 	// 	'context': {
-	// 		'precededby': { 'category': 'noun' },
+	// 		'precededby': { 'category': 'Noun' },
 	// 	},
 	// 	'require': {
 	// 		'precededby': '[',

--- a/app/src/lib/tokens/Pairing.svelte
+++ b/app/src/lib/tokens/Pairing.svelte
@@ -1,14 +1,15 @@
 <script>
-	import Error from './Error.svelte'
-	import Loading from './Loading.svelte'
-	import NotFound from './NotFound.svelte'
-	import Result from './Result.svelte'
 	import TokenDisplay from './TokenDisplay.svelte'
-	import {check_ontology} from '$lib/lookups'
-	import {REGEXES} from '$lib/regexes'
+    import Word from './Word.svelte';
 
 	/** @type {Token} */
 	export let token
+
+	/**
+	 * scenarios:
+	 * good: follower follower/disciple
+	 * bad: /disciple follower/ disciple/disciple disciple/follower /
+	 */
 
 	// At this point the pairing tokens will never be null
 	/** @type {Token} */
@@ -18,60 +19,12 @@
 	/** @type {Token} */
 	// @ts-ignore
 	$: right_token = token.pairing_right
-
-	/**
-	 *
-	 * @param {Token} left
-	 * @param {Token} right
-	 */
-	async function lookup(left, right) {
-		return Promise.all([
-			check_ontology(left),
-			check_ontology(right)
-		])
-	}
 </script>
 
-{#await lookup(left_token, right_token)}
-	<Loading {token} />
-{:then [left_result, right_result]}
-	<!--
-		scenarios:
-			good: follower follower/disciple
-			bad: /disciple follower/ disciple/disciple disciple/follower /
-	-->
+<div class="join">
+	<Word token={left_token} classes="join-item" />
 
-	<!-- TODO: consider multiple matches where the levels are different, e.g., son -->
-	{@const left_match = left_result.matches?.[0]}
-	{@const right_match = right_result.matches?.[0]}
+	<TokenDisplay classes="!px-1.5 [font-family:cursive] join-item">/</TokenDisplay>
 
-	<div class="join">
-		{#if left_match}
-			{#if REGEXES.IS_LEVEL_SIMPLE.test(`${left_match.level}`)}
-				<Result token={left_token} result={left_result} classes="join-item" />
-			{:else}
-				{@const error = {...left_token, message: 'Word must be a level 0 or 1'}}
-
-				<Error token={error} classes="join-item" />
-			{/if}
-		{:else}
-			<NotFound token={left_token} classes="join-item" />
-		{/if}
-
-		<TokenDisplay classes="!px-1.5 [font-family:cursive] join-item">/</TokenDisplay>
-
-		{#if right_match}
-			{#if REGEXES.IS_LEVEL_COMPLEX.test(`${right_match.level}`)}
-				<Result token={right_token} result={right_result} classes="join-item" />
-			{:else}
-				{@const error = {...right_token, message: 'Word must be a level 2 or 3'}}
-
-				<Error token={error} classes="join-item" />
-			{/if}
-		{:else}
-			<NotFound token={right_token} classes="join-item" />
-		{/if}
-	</div>
-{:catch}
-	<NotFound {token} />
-{/await}
+	<Word token={right_token} classes="join-item" />
+</div>

--- a/app/src/lib/tokens/Result.svelte
+++ b/app/src/lib/tokens/Result.svelte
@@ -6,7 +6,7 @@
 	export let classes = ''
 
 	// TODO: more work needed to handle multiple matches with possibly different levels, e.g., son
-	let concept = token.concept || token.lookup_results[0]
+	const concept = token.concept || token.lookup_results[0]
 </script>
 
 <TokenDisplay classes="{classes} L{concept.level}">

--- a/app/src/lib/tokens/Result.svelte
+++ b/app/src/lib/tokens/Result.svelte
@@ -3,15 +3,12 @@
 
 	/** @type {Token} */
 	export let token
-	/** @type {LookupResult<OntologyResult>} */
-	export let result
-
 	export let classes = ''
 
 	// TODO: more work needed to handle multiple matches with possibly different levels, e.g., son
-	const match = result.matches[0]
+	let concept = token.concept || token.lookup_results[0]
 </script>
 
-<TokenDisplay classes="{classes} L{match?.level}">
+<TokenDisplay classes="{classes} L{concept.level}">
 	{token.token}
 </TokenDisplay>

--- a/app/src/lib/tokens/Word.svelte
+++ b/app/src/lib/tokens/Word.svelte
@@ -1,8 +1,8 @@
 <script>
-    import {TOKEN_TYPE, token_has_concept} from '$lib/parser/token';
+	import {TOKEN_TYPE, token_has_concept} from '$lib/parser/token'
 	import Error from './Error.svelte'
-	import NotFound from "./NotFound.svelte"
-	import Result from "./Result.svelte"
+	import NotFound from './NotFound.svelte'
+	import Result from './Result.svelte'
 
 	/** @type {Token} */
 	export let token

--- a/app/src/lib/tokens/Word.svelte
+++ b/app/src/lib/tokens/Word.svelte
@@ -1,17 +1,18 @@
 <script>
-	import { check_ontology } from "$lib/lookups"
-	import Loading from "./Loading.svelte"
+    import {TOKEN_TYPE, token_has_concept} from '$lib/parser/token';
+	import Error from './Error.svelte'
 	import NotFound from "./NotFound.svelte"
 	import Result from "./Result.svelte"
 
 	/** @type {Token} */
 	export let token
+	export let classes = ''
 </script>
 
-{#await check_ontology(token)}
-	<Loading {token} />
-{:then result}
-	<Result {token} {result} />
-{:catch}
-	<NotFound {token} />
-{/await}
+{#if token.type === TOKEN_TYPE.ERROR}
+	<Error {token} {classes} />
+{:else if token_has_concept(token)}
+	<Result {token} {classes} />
+{:else}
+	<NotFound {token} {classes} />
+{/if}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -29,7 +29,7 @@
 </form>
 
 {#await tokens_promise}
-	<div><span class="loading loading-ring loading-lg absolute" />Checking Ontology...</div>
+	<div class="divider my-12 divider-warning">Checking Ontology...</div>
 {:then tokens} 
 	{@const has_error = tokens.some(token_has_error)}
 	{@const success = tokens.length > 0 && !has_error}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -6,7 +6,6 @@
 	import {token_has_error} from '$lib/parser/token'
 
 	let entered_text = ''
-	$: tokens_promise = parse(entered_text)
 	$: english_back_translation = backtranslate(entered_text)
 	$: english_back_translation && reset_copied()
 
@@ -28,17 +27,19 @@
 	<textarea bind:value={entered_text} rows="5" autofocus class="textarea textarea-bordered textarea-lg w-4/5" />
 </form>
 
-{#await tokens_promise}
-	<div class="divider my-12 divider-warning">Checking Ontology...</div>
+{#await parse(entered_text)}
+	<div class="divider my-12 divider-warning">
+		<Icon icon="line-md:loading-twotone-loop" class="h-16 w-16 text-warning" />
+	</div>
 {:then tokens} 
 	{@const has_error = tokens.some(token_has_error)}
 	{@const success = tokens.length > 0 && !has_error}
 
 	<div class="divider my-12" class:divider-success={success} class:divider-error={has_error}>
 		{#if success}
-			<Icon icon={`mdi:check-circle`} class="h-16 w-16 text-success" />
+			<Icon icon="mdi:check-circle" class="h-16 w-16 text-success" />
 		{:else if has_error}
-			<Icon icon={`mdi:close-circle`} class="h-16 w-16 text-error" />
+			<Icon icon="mdi:close-circle" class="h-16 w-16 text-error" />
 		{/if}
 	</div>
 


### PR DESCRIPTION
The changes here also fix Issue #20:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/62d5bd97-de30-476a-8191-a80ba6c3d6dc)

Also, I made any check on a lookup word have to be true for all lookup results for a word. Because of this, the pairing level check is satisfied if any senses of the word are the right level. This inadvertently and temporarily 'fixes' Issue #25, in that it no longer results in an error:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7456b16f-f6be-4cb3-b35d-9d68719e2409)

#25 should stay open though because the root of the issue still needs fixing.