### PR TITLE
Fix tokenizing issues.

### DIFF
--- a/app/src/lib/parser/error_messages.js
+++ b/app/src/lib/parser/error_messages.js
@@ -6,7 +6,6 @@ const MISSING_CLOSING_BRACKET = 'Missing a closing bracket in the previous sente
 const NO_SPACE_BEFORE_OPENING_BRACKET = 'Missing a space before [.'
 
 const INVALID_PAIRING_SYNTAX = 'Pairings should have the form simple/complex, e.g., follower/disciple.'
-const NO_SPACE_AFTER_CLAUSE_NOTATION = 'Must include a space after a clause notation.'
 const UNRECOGNIZED_CLAUSE_NOTATION = 'This clause notation is not recognized.'
 const NO_SPACE_BEFORE_UNDERSCORE = 'Notes notation should have a space before the underscore, e.g., ⎕_implicit.'
 const UNRECOGNIZED_CHAR = 'Unrecognized character.'
@@ -28,7 +27,6 @@ export const ERRORS = {
     MISSING_OPENING_BRACKET,
     MISSING_CLOSING_BRACKET,
     NO_SPACE_BEFORE_OPENING_BRACKET,
-    NO_SPACE_AFTER_CLAUSE_NOTATION,
 	MISSING_PERIOD,
 	FIRST_WORD_NOT_CAPITALIZED,
     UNRECOGNIZED_CLAUSE_NOTATION,

--- a/app/src/lib/parser/tokenize.test.js
+++ b/app/src/lib/parser/tokenize.test.js
@@ -169,13 +169,17 @@ describe('tokenize_input', () => {
 	})
 
 	test('valid clause notation', () => {
-		const INPUT = "(imp) (implicit-situational) [(imp)"
+		const INPUT = "(imp) (implicit-situational) [(imp) (imp)] (imp)."
 
 		const EXPECTED_OUTPUT = [
 			create_token('(imp)', TOKEN_TYPE.NOTE),
 			create_token('(implicit-situational)', TOKEN_TYPE.NOTE),
 			create_token('[', TOKEN_TYPE.PUNCTUATION),
 			create_token('(imp)', TOKEN_TYPE.NOTE),
+			create_token('(imp)', TOKEN_TYPE.NOTE),
+			create_token(']', TOKEN_TYPE.PUNCTUATION),
+			create_token('(imp)', TOKEN_TYPE.NOTE),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
 		]
 
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
@@ -199,7 +203,7 @@ describe('tokenize_input', () => {
 			create_error_token('(imp', ERRORS.MISSING_CLOSING_PAREN),
 			create_error_token('imp)', ERRORS.MISSING_OPENING_PAREN),
 			create_word_token('token(imp)', 'imp'),		// tokenizing at this time does not differentiate from a pronoun referent
-			create_error_token('(imp)token', ERRORS.NO_SPACE_AFTER_CLAUSE_NOTATION),
+			create_error_token('(imp)token', ERRORS.INVALID_TOKEN_END('(imp)')),
 			create_error_token('(implicit_situational)', ERRORS.UNRECOGNIZED_CLAUSE_NOTATION),
 			create_error_token('(imperative)', ERRORS.UNRECOGNIZED_CLAUSE_NOTATION),
 			create_error_token("(Paul's)", ERRORS.UNRECOGNIZED_CLAUSE_NOTATION),
@@ -261,7 +265,7 @@ describe('tokenize_input', () => {
 	})
 
 	test('invalid opening brackets', () => {
-		const INPUT = ".[ ,[ ?[ ][ token["
+		const INPUT = ".[ ,[ ?[ ][ token[ :["
 
 		const EXPECTED_OUTPUT = [
 			create_error_token('.[', ERRORS.NO_SPACE_BEFORE_OPENING_BRACKET),
@@ -269,13 +273,14 @@ describe('tokenize_input', () => {
 			create_error_token('?[', ERRORS.NO_SPACE_BEFORE_OPENING_BRACKET),
 			create_error_token('][', ERRORS.NO_SPACE_BEFORE_OPENING_BRACKET),
 			create_error_token('token[', ERRORS.NO_SPACE_BEFORE_OPENING_BRACKET),
+			create_error_token(':[', ERRORS.NO_SPACE_BEFORE_OPENING_BRACKET),
 		]
 
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
 	})
 
 	test('valid punctuation', () => {
-		const INPUT = '." ". ?"] token]". "], token]] token,'
+		const INPUT = '." ". ?"] token]". "], token]] token, 5:5'
 
 		const EXPECTED_OUTPUT = [
 			create_token('.', TOKEN_TYPE.PUNCTUATION),
@@ -297,6 +302,9 @@ describe('tokenize_input', () => {
 			create_token(']', TOKEN_TYPE.PUNCTUATION),
 			create_word_token('token'),
 			create_token(',', TOKEN_TYPE.PUNCTUATION),
+			create_word_token('5'),
+			create_token(':', TOKEN_TYPE.PUNCTUATION),
+			create_word_token('5'),
 		]
 
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)


### PR DESCRIPTION
- Allow punctuation after clause notation
- Allow digits after a colon

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0effcf56-9bff-4898-8fb0-0e650103bb6b)
