### PR TITLE
Add link to ontology for lookup tokens.

### DIFF
--- a/app/src/lib/app.postcss
+++ b/app/src/lib/app.postcss
@@ -54,3 +54,18 @@ body {
 	background-color: #6b2f30;
 	border-color: whitesmoke;
 }
+.L0-text {
+	color: whitesmoke;
+}
+.L1-text {
+	color: darkblue;
+}
+.L2-text {
+	color: yellow;
+}
+.L3-text {
+	color: whitesmoke;
+}
+.L4-text {
+	color: whitesmoke;
+}

--- a/app/src/lib/tokens/Result.svelte
+++ b/app/src/lib/tokens/Result.svelte
@@ -1,4 +1,5 @@
 <script>
+	import {PUBLIC_ONTOLOGY_API_HOST} from '$env/static/public'
 	import TokenDisplay from './TokenDisplay.svelte'
 
 	/** @type {Token} */
@@ -8,6 +9,8 @@
 	// TODO: more work needed to handle multiple matches with possibly different levels, e.g., son
 	const concept = token.concept || token.lookup_results[0]
 	const tooltip = token.concept ? display_concept(token.concept) : token.lookup_results.map(display_concept).join('; ')
+
+	const lookup_term = token.concept ? display_concept(token.concept) : token.lookup_results[0].stem
 
 	/**
 	 * @param {OntologyResult} concept
@@ -19,6 +22,8 @@
 
 <div class='tooltip' data-tip={tooltip}>
 	<TokenDisplay classes="{classes} L{concept.level}">
-		{token.token}
+		<a class="link link-hover not-prose L{concept.level}-text" href={`${PUBLIC_ONTOLOGY_API_HOST}/?q=${lookup_term}`} target="_blank">
+			{token.token}
+		</a>
 	</TokenDisplay>
 </div>


### PR DESCRIPTION
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b8d9472d-1562-4269-9d8a-3c271ebab189)

Sentence for testing:
John went-A to the store. John said, ["Go".]

went-A - links to 'go-A' (uses stem with sense)
said - links to 'say' (uses stem from inflection lookup)
store - links to 'store'