### PR TITLE
Improve pronoun check and functionality

### DIFF
--- a/app/src/lib/parser/pronoun_rules.js
+++ b/app/src/lib/parser/pronoun_rules.js
@@ -1,9 +1,30 @@
-export const PRONOUN_RULES = new Map()
-
-const FIRST_PERSON = ['i', 'me', 'my', 'mine', 'myself', 'we', 'us', 'our', 'ours', 'ourselves']
-const SECOND_PERSON = ['you', 'your', 'yours', 'yourself']
+const FIRST_PERSON = ['i', 'me', 'my', 'myself', 'we', 'us', 'our', 'ourselves']
+const SECOND_PERSON = ['you', 'your', 'yourself', 'yourselves']
 const THIRD_PERSON = ['he', 'him', 'his', 'himself', 'she', 'her', 'hers', 'herself', 'it', 'its', 'itself', 'they', 'them', 'their', 'theirs', 'themselves']
 
-PRONOUN_RULES.set(FIRST_PERSON, 'First person pronouns require their respective Noun in parentheses, e.g., I(Paul).')
-PRONOUN_RULES.set(SECOND_PERSON, 'Second person pronouns require their respective Noun in parentheses, e.g., you(Paul).')
-PRONOUN_RULES.set(THIRD_PERSON, 'Third person pronouns should be replaced with the Noun they represent, e.g., Paul (instead of him).')
+/** @type {Map<string, string>} */
+export const PRONOUN_MESSAGES = new Map([
+	['mine', '"mine" should be replaced with "my() X", e.g., That book is my(Paul\'s) book.'],
+	['ours', '"ours" should be replaced with "our() X", e.g., That book is our(Paul\'s) book.'],
+	['yours', '"yours" should be replaced with "your() X", e.g., That book is your(Paul\'s) book.'],
+	['each-other', '"each-other" requires its respective Noun in parentheses, e.g., each-other(people).'],
+])
+FIRST_PERSON.forEach(p => PRONOUN_MESSAGES.set(p, 'First person pronouns require their respective Noun in parentheses, e.g., I(Paul).'))
+SECOND_PERSON.forEach(p => PRONOUN_MESSAGES.set(p, 'Second person pronouns require their respective Noun in parentheses, e.g., you(Paul).'))
+THIRD_PERSON.forEach(p => PRONOUN_MESSAGES.set(p, 'Third person pronouns should be replaced with the Noun they represent, e.g., Paul (instead of him).'))
+
+export const PRONOUN_TAGS = new Map([
+	['i', 'first_person|singular'],
+	['me', 'first_person|singular'],
+	['my', 'first_person|singular'],
+	['myself', 'first_person|singular|reflexive'],
+	['we', 'first_person|plural'],
+	['us', 'first_person|plural'],
+	['our', 'first_person|plural'],
+	['ourselves', 'first_person|plural|reflexive'],
+	['you', 'second_person'],
+	['your', 'second_person'],
+	['yourself', 'second_person|singular|reflexive'],
+	['yourselves', 'second_person|plural|reflexive'],
+	['each-other', 'reciprocal'],
+])

--- a/app/src/lib/parser/tokenize.js
+++ b/app/src/lib/parser/tokenize.js
@@ -201,7 +201,7 @@ export function tokenize_input(text = '') {
 	 */
 	function lookup_token(text) {
 		// The lookup term could be in a pronoun referent
-		const lookup_term = text.match(REGEXES.EXTRACT_PRONOUN_REFERENT)?.[1] ?? text
+		const lookup_term = text.match(REGEXES.EXTRACT_PRONOUN_REFERENT)?.[2] ?? text
 		const lookup_match = lookup_term.match(REGEXES.EXTRACT_WORD_REFERENT)
 
 		// combine stem and sense

--- a/app/src/lib/regexes.js
+++ b/app/src/lib/regexes.js
@@ -15,7 +15,7 @@ const CLOSING_PAREN = /\)/
 const FORWARD_SLASH = /\//
 
 // Could be you(son) your(son's) your(sons') you(son-C) your(son's-C) your(sons'-C)
-const EXTRACT_PRONOUN_REFERENT = /^\w+\(([\w'’-]+)\)$/
+const EXTRACT_PRONOUN_REFERENT = /^(.+)\(([\w'’-]+)\)$/
 
 // Could be son son's sons' son-C son's-C sons'-C
 // This pulls out the stem and sense, which will then need to be put back together

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -48,6 +48,17 @@ const checker_rules_json = [
 			'message': 'Missing agent of passive verb. Use _implicitActiveAgent if necessary.',
 		},
 	},
+	{
+		'name': 'each other must be hyphenated',
+		'trigger': { 'stem': 'each' },
+		'context': {
+			'followedby': { 'stem': 'other' },
+			'notfollowedby': { 'category': 'Noun', 'skip': { 'category': 'Adjective' } },
+		},
+		'require': {
+			'message': 'Reciprocal each-other must be hyphenated.',
+		},
+	},
 ]
 
 export const CHECKER_RULES = checker_rules_json.map(parse_checker_rule)


### PR DESCRIPTION
Fixes #36 and other pronoun issues.

Each-other must be hyphenated and used with a referent:
`The people fight each other. The people fight each-other. The people fight each-other(people).`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b611b530-b67b-4a59-9a42-f42dee59ce1e)

Can't use possessive mine/yours/ours. Can't use third person pronouns with a referent. Must use a recognized pronoun:
`That book is mine. John saw her(Mary). John saw asdf(person).`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b1fa2213-5a0e-4cc7-bc2b-82bb974f504d)