### PR TITLE
Resolve minor requests for the back translation.

### DIFF
--- a/app/src/lib/backtranslator/index.js
+++ b/app/src/lib/backtranslator/index.js
@@ -16,8 +16,18 @@ export function backtranslate(input) {
 		.replace(/> </g, ' ')
 		.replace(/ _1stAs3rd([ .?!])/g, '$1')
 
+		// replace certain words
+		.replace(/([ .?!]*)God's book([ .?!]*)/g, '$1the Scriptures$2')
+		.replace(/([ .?!]*)2([ .?!]*)/g, '$1two$2')
+		.replace(/([ .?!]*)3([ .?!]*)/g, '$1three$2')
+		.replace(/([ .?!]*)4([ .?!]*)/g, '$1four$2')
+		.replace(/([ .?!]*)5([ .?!]*)/g, '$1five$2')
+
 		// verbs that take a clausal argument that are often translated as 'that....'
 		.replace(/(see|saw|know|knew|say|said) \[/g, '$1 that [')
+
+		// surround descriptive relative clauses with commas
+		.replace(/([ .?!]*) \[([^[.?!]*)_descriptive (.*?)\]/g, '$1, $2 $3,')
 
 		.replace(/\[([^[.?!]*) \(implicit-situational\) (.*?)\]/g, '<<$1 $2>>')
 		.replace(/\[([^[.?!]*) \(implicit-background\) (.*?)\]/g, '<<$1 $2>>')
@@ -33,6 +43,7 @@ export function backtranslate(input) {
 		.replace(/You \(imp\) ([a-z])/g, (match, p1) => p1.toUpperCase())
 		.replace(/You \(imp\) /g, '')
 		.replace(/you \(imp\) /g, '')
+		.replace(/_paragraph /g, '(paragraph) ')
 		.replace(/_excl([ .?!])/g, '$1')
 		.replace(/ _inLDV([ .!?,])/g, '$1')
 		.replace(/_restrictive /g, '')
@@ -53,6 +64,7 @@ export function backtranslate(input) {
 		.replace(/the ([^ ]*?) of (.+?) _metonymy/g, '<<$2 of>> the $1')
 		.replace(/([^ ]*?) of (.+?) _metonymy/g, '<<$2 of>> $1')
 		.replace(/ named /g, ' named& ')
+		.replace(/(tribe|region|city|country) named& ([^&]+?)/g, '$1 of $2')
 		.replace(/([^ ]*?) named& ([^&]+?) _explainName/g, '<<$2 of>> $1')
 		.replace(/([^ ]*?) named& ([^&]+?) _implicitExplainName/g, '<<$2 of>> $1')
 		.replace(/&/g, '')

--- a/app/src/lib/backtranslator/index.js
+++ b/app/src/lib/backtranslator/index.js
@@ -64,7 +64,7 @@ export function backtranslate(input) {
 		.replace(/the ([^ ]*?) of (.+?) _metonymy/g, '<<$2 of>> the $1')
 		.replace(/([^ ]*?) of (.+?) _metonymy/g, '<<$2 of>> $1')
 		.replace(/ named /g, ' named& ')
-		.replace(/(tribe|region|city|country) named& ([^&]+?)/g, '$1 of $2')
+		.replace(/(tribe|region|city|town|country) named& ([^&]+?)/g, '$1 of $2')
 		.replace(/([^ ]*?) named& ([^&]+?) _explainName/g, '<<$2 of>> $1')
 		.replace(/([^ ]*?) named& ([^&]+?) _implicitExplainName/g, '<<$2 of>> $1')
 		.replace(/&/g, '')

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -82,6 +82,18 @@ const transform_rules_json = [
 		'transform': { 'function': 'auxilliary|imperfective_aspect' },
 	},
 	{
+		'name': 'have before a past participle Verb indicates flashback/perfect',
+		'trigger': { 'stem': 'have' },
+		'context': {
+			'followedby': {
+				'category': 'Verb',
+				'form': 'past participle',
+				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
+			},
+		},
+		'transform': { 'function': 'auxilliary|flashback' },
+	},
+	{
 		'name': 'be before an auxilliary becomes an auxilliary',
 		'trigger': { 'stem': 'be' },
 		'context': {
@@ -93,16 +105,16 @@ const transform_rules_json = [
 		'transform': { 'function': 'auxilliary' },
 	},
 	{
-		'name': 'have before a past participle Verb indicates flashback/perfect',
-		'trigger': { 'stem': 'have' },
-		'context': {
-			'followedby': {
-				'category': 'Verb',
-				'form': 'past participle',
-				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
-			},
-		},
-		'transform': { 'function': 'auxilliary|flashback' },
+		'name': '\'named\' after a place becomes a function word',
+		'trigger': { 'token': 'named' },
+		'context': { 'precededby': {'stem': 'tribe|region|city|town|country'} },
+		'transform': { 'function': '-Name' },
+	},
+	{
+		'name': '\'of\' after group/crowd becomes a function word',
+		'trigger': { 'token': 'of' },
+		'context': { 'precededby': {'stem': 'group|crowd'} },
+		'transform': { 'function': '-Group' },
 	},
 	{
 		'name': 'be before an adjective becomes be-D',


### PR DESCRIPTION
- `_paragraph` becomes `(paragraph)`
- `God's book` becomes `the Scriptures`
- relative clauses marked with `_descriptive` get surrounded in commas (proper nouns without `_descriptive` is more complicated)
- `town//region//city//town//country named Y` becomes `X of Y`
- numbers 2/3/4/5 become two/three/four/five, respectively
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f2982d02-ed15-4f8c-8f07-7dd17eb6014a)

Addresses most of but not all requests from #23. The others are more complex and may require using the tokenized text.

Also added a rule to fix an issue with 'named' that I discovered.
