### PR TITLE
Handle quote variants.

### DIFF
--- a/app/src/lib/parser/tokenize.js
+++ b/app/src/lib/parser/tokenize.js
@@ -5,10 +5,21 @@ import {TOKEN_TYPE, create_token} from './token'
 import {ERRORS} from './error_messages'
 
 /**
+ * 
+ * @param {string} text 
+ * @returns {string}
+ */
+function normalize_input(text) {
+	return text.replaceAll(/[“”]/g, '"').replaceAll(/’/g, '\'')
+}
+
+/**
  * @param {string} text
  * @returns {Token[]}
  */
 export function tokenize_input(text = '') {
+	text = normalize_input(text)
+
 	/** @type {Array<[() => boolean, () => Token]>} */
 	const parsers = [
 		[() => match(REGEXES.WORD_START_CHAR), word],

--- a/app/src/lib/parser/tokenize.test.js
+++ b/app/src/lib/parser/tokenize.test.js
@@ -335,12 +335,29 @@ describe('tokenize_input', () => {
 		const INPUT = "Paul's Paul’s Jesus’ Jesus' sons’-C you(Paul’s)"
 
 		const EXPECTED_OUTPUT = [
-			create_word_token("Paul's", 'Paul'),
-			create_word_token('Paul’s', 'Paul'),
-			create_word_token('Jesus’', 'Jesus'),
+			create_word_token('Paul\'s', 'Paul'),
+			create_word_token('Paul\'s', 'Paul'),
+			create_word_token('Jesus\'', 'Jesus'),
 			create_word_token("Jesus'", 'Jesus'),
-			create_word_token('sons’-C', 'sons-C'),
-			create_pronoun_token('you', 'Paul’s', 'Paul'),
+			create_word_token('sons\'-C', 'sons-C'),
+			create_pronoun_token('you', 'Paul\'s', 'Paul'),
+		]
+
+		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
+	})
+
+	test('double quote variants', () => {
+		const INPUT = "[“Yes.”] \" “"
+
+		const EXPECTED_OUTPUT = [
+			create_token('[', TOKEN_TYPE.PUNCTUATION),
+			create_token('"', TOKEN_TYPE.PUNCTUATION),
+			create_word_token('Yes'),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
+			create_token('"', TOKEN_TYPE.PUNCTUATION),
+			create_token(']', TOKEN_TYPE.PUNCTUATION),
+			create_token('"', TOKEN_TYPE.PUNCTUATION),
+			create_token('"', TOKEN_TYPE.PUNCTUATION),
 		]
 
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)

--- a/app/src/lib/regexes.js
+++ b/app/src/lib/regexes.js
@@ -15,11 +15,11 @@ const CLOSING_PAREN = /\)/
 const FORWARD_SLASH = /\//
 
 // Could be you(son) your(son's) your(sons') you(son-C) your(son's-C) your(sons'-C)
-const EXTRACT_PRONOUN_REFERENT = /^(.+)\(([\w'’-]+)\)$/
+const EXTRACT_PRONOUN_REFERENT = /^(.+)\(([\w'-]+)\)$/
 
 // Could be son son's sons' son-C son's-C sons'-C
 // This pulls out the stem and sense, which will then need to be put back together
-const EXTRACT_WORD_REFERENT = /^(.+?)(?:['’]s|['’])?(-[A-Z])?$/
+const EXTRACT_WORD_REFERENT = /^(.+?)(?:'s|')?(-[A-Z])?$/
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class
 const SENTENCE_ENDING_PUNCTUATION = /^[.?!]/
@@ -27,7 +27,7 @@ const CLAUSE_ENDING_PUNCTUATION = /[\]"]/
 
 const TOKEN_END_BOUNDARY = /[\s.,!?:"\]]/
 const WORD_START_CHAR = /[a-zA-Z0-9-]/
-const WORD_CHAR = /[a-zA-Z0-9-'’]/
+const WORD_CHAR = /[a-zA-Z0-9-']/
 const STARTS_LOWERCASE = /^[a-z]/
 
 /**

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -15,6 +15,14 @@ const transform_rules_json = [
 		'transform': { 'function': 'auxilliary' },
 	},
 	{
+		'name': 'do in a question becomes an auxilliary',
+		'trigger': { 'stem': 'do' },
+		'context': {
+			'followedby': [{ 'category': 'Verb', 'skip': 'all' }, { 'token': '?', 'skip': 'all' }],
+		},
+		'transform': { 'function': 'auxilliary' },
+	},
+	{
 		'name': 'most before adjective or adverb becomes a function word',
 		'trigger': { 'stem': 'most' },
 		'context': {

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -12,15 +12,15 @@ const transform_rules_json = [
 		'context': {
 			'followedby': { 'token': 'not' },
 		},
-		'transform': { 'function': 'auxilliary' },
+		'transform': { 'function': 'auxiliary' },
 	},
 	{
-		'name': 'do in a question becomes an auxilliary',
+		'name': 'do in a question becomes an auxiliary',
 		'trigger': { 'stem': 'do' },
 		'context': {
 			'followedby': [{ 'category': 'Verb', 'skip': 'all' }, { 'token': '?', 'skip': 'all' }],
 		},
-		'transform': { 'function': 'auxilliary' },
+		'transform': { 'function': 'auxiliary' },
 	},
 	{
 		'name': 'most before adjective or adverb becomes a function word',
@@ -39,7 +39,7 @@ const transform_rules_json = [
 				'skip': { 'token': 'to' },
 			},
 		},
-		'transform': { 'function': 'auxilliary|inceptive_aspect' },
+		'transform': { 'function': 'auxiliary|inceptive_aspect' },
 	},
 	{
 		'name': 'stop before a verb becomes a function word',
@@ -47,7 +47,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': { 'category': 'Verb' },
 		},
-		'transform': { 'function': 'auxilliary|cessative_aspect' },
+		'transform': { 'function': 'auxiliary|cessative_aspect' },
 	},
 	{
 		'name': 'continue before a verb becomes a function word',
@@ -55,7 +55,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': { 'category': 'Verb' },
 		},
-		'transform': { 'function': 'auxilliary|continuative_aspect' },
+		'transform': { 'function': 'auxiliary|continuative_aspect' },
 	},
 	{
 		'name': 'finish before a verb becomes a function word',
@@ -63,7 +63,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': { 'category': 'Verb' },
 		},
-		'transform': { 'function': 'auxilliary|completive_aspect' },
+		'transform': { 'function': 'auxiliary|completive_aspect' },
 	},
 	{
 		'name': 'be before a past participle Verb indicates passive',
@@ -75,7 +75,7 @@ const transform_rules_json = [
 				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
 			},
 		},
-		'transform': { 'function': 'auxilliary|passive' },
+		'transform': { 'function': 'auxiliary|passive' },
 	},
 	{
 		'name': 'be before a participle Verb indicates imperfective',
@@ -87,18 +87,18 @@ const transform_rules_json = [
 				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
 			},
 		},
-		'transform': { 'function': 'auxilliary|imperfective_aspect' },
+		'transform': { 'function': 'auxiliary|imperfective_aspect' },
 	},
 	{
-		'name': 'be before an auxilliary becomes an auxilliary',
+		'name': 'be before an auxiliary becomes an auxiliary',
 		'trigger': { 'stem': 'be' },
 		'context': {
 			'followedby': {
-				'tag': 'auxilliary',
+				'tag': 'auxiliary',
 				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
 			},
 		},
-		'transform': { 'function': 'auxilliary' },
+		'transform': { 'function': 'auxiliary' },
 	},
 	{
 		'name': 'have before a past participle Verb indicates flashback/perfect',
@@ -110,7 +110,7 @@ const transform_rules_json = [
 				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
 			},
 		},
-		'transform': { 'function': 'auxilliary|flashback' },
+		'transform': { 'function': 'auxiliary|flashback' },
 	},
 	{
 		'name': 'be before an adjective becomes be-D',

--- a/app/src/routes/form-lookup/+server.js
+++ b/app/src/routes/form-lookup/+server.js
@@ -66,7 +66,7 @@ function get_form_matches(db) {
 
 		const matched_forms = result.inflections.split('|')
 			.filter(inflection => inflection !== '')
-			.map((inflection, index) => inflection === term ? index : -1)
+			.map((inflection, index) => inflection.toLowerCase() === term.toLowerCase() ? index : -1)
 			.filter(index => index >= 0)
 			.map(index => form_names[index])
 			.join('|')


### PR DESCRIPTION
Fixes #52 

- Normalize input as first step of tokenize
- Fix issue with 'Did' in a question (found during testing)
-- Another case issue, 'Did' did not match 'did', so it didn't get the right form, and falsely triggering the imperative checks. Now it recognizes it as an auxiliary in a question.

`“ Did Yahweh bring us(Gideon) from Egypt? ”`
Before:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/792e5d9b-d976-4725-b5f1-c050fe2bbaf1)

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/6938ac37-1035-46d3-98b8-e99695484f92)
