### PR TITLE
Fix some false errors

### DIFF
--- a/app/src/lib/parser/tokenize.test.js
+++ b/app/src/lib/parser/tokenize.test.js
@@ -347,7 +347,7 @@ describe('tokenize_input', () => {
 	})
 
 	test('double quote variants', () => {
-		const INPUT = "[“Yes.”] \" “"
+		const INPUT = '[“Yes.”] " “'
 
 		const EXPECTED_OUTPUT = [
 			create_token('[', TOKEN_TYPE.PUNCTUATION),

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -42,9 +42,11 @@ const lookup_rules_json = [
 		'combine': 1,
 	},
 	{
-		'name': 'much becomes much-many',
+		'name': 'much becomes much-many if followed by a Noun',
 		'trigger': { 'token': 'much' },
+		'context': { 'followedby': {'category': 'Noun'} },
 		'lookup': 'much-many',
+		'comment': 'something like "There is much water"',
 	},
 	{
 		'name': 'many becomes much-many',

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -36,26 +36,26 @@ const lookup_rules_json = [
 	},
 	{
 		'name': 'even-if',
-		'trigger': { 'token': 'even' },
+		'trigger': { 'token': 'Even|even' },
 		'context': { 'followedby': {'token': 'if'} },
 		'lookup': 'even-if',
 		'combine': 1,
 	},
 	{
 		'name': 'much becomes much-many if followed by a Noun',
-		'trigger': { 'token': 'much' },
+		'trigger': { 'token': 'Much|much' },
 		'context': { 'followedby': {'category': 'Noun'} },
 		'lookup': 'much-many',
 		'comment': 'something like "There is much water"',
 	},
 	{
 		'name': 'many becomes much-many',
-		'trigger': { 'token': 'many' },
+		'trigger': { 'token': 'Many|many' },
 		'lookup': 'much-many',
 	},
 	{
 		'name': 'every becomes each',
-		'trigger': { 'token': 'every' },
+		'trigger': { 'token': 'Every|every' },
 		'lookup': 'each',
 	},
 	{
@@ -65,7 +65,7 @@ const lookup_rules_json = [
 	},
 	{
 		'name': 'one tenth of',
-		'trigger': { 'token': 'one' },
+		'trigger': { 'token': 'One|one' },
 		'context': { 'followedby': [{'token': 'tenth'}, {'token': 'of'}] },
 		'lookup': '.1',
 		'combine': 2,

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -242,6 +242,7 @@ export function create_token_filter(filter_json) {
 	}
 
 	add_lookup_filter('category', concept => concept.part_of_speech)
+	add_lookup_filter('level', concept => `${concept.level}`)
 
 	if (filters.length === 0) {
 		return () => false

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -40,6 +40,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'function': 'auxiliary|inceptive_aspect' },
+		'comment': 'support both "started eating" and "started to eat"'
 	},
 	{
 		'name': 'stop before a verb becomes a function word',
@@ -53,9 +54,13 @@ const transform_rules_json = [
 		'name': 'continue before a verb becomes a function word',
 		'trigger': { 'stem': 'continue' },
 		'context': {
-			'followedby': { 'category': 'Verb' },
+			'followedby': {
+				'category': 'Verb',
+				'skip': { 'token': 'to' },
+			},
 		},
 		'transform': { 'function': 'auxiliary|continuative_aspect' },
+		'comment': 'support both "continued eating" and "continued to eat"'
 	},
 	{
 		'name': 'finish before a verb becomes a function word',
@@ -113,9 +118,20 @@ const transform_rules_json = [
 		'transform': { 'function': 'auxiliary' },
 	},
 	{
-		'name': '\'named\' after a place becomes a function word',
+		'name': '\'named\' before a name and after a Verb becomes a function word',
 		'trigger': { 'token': 'named' },
-		'context': { 'precededby': {'stem': 'tribe|region|city|town|country'} },
+		'context': {
+			'precededby': { 'category': 'Verb', 'skip': 'all' },
+			'followedby': { 'level': '4' },
+		},
+		'transform': { 'function': '-Name' },
+	},
+	{
+		'name': '\'named\' before a name and before a Verb becomes a function word',
+		'trigger': { 'token': 'named' },
+		'context': {
+			'followedby': [{ 'level': '4' }, { 'category': 'Verb', 'skip': 'all' }],
+		},
 		'transform': { 'function': '-Name' },
 	},
 	{
@@ -141,7 +157,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': {
 				'category': 'Adjective',
-				'skip': { 'token': 'not|very|extremely' },
+				'skip': [{ 'token': 'not|very|extremely' }, { 'category': 'Adverb' }],
 			},
 		},
 		'transform': { 'concept': 'be-D' },

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -40,7 +40,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'function': 'auxiliary|inceptive_aspect' },
-		'comment': 'support both "started eating" and "started to eat"'
+		'comment': 'support both "started eating" and "started to eat"',
 	},
 	{
 		'name': 'stop before a verb becomes a function word',
@@ -60,7 +60,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'function': 'auxiliary|continuative_aspect' },
-		'comment': 'support both "continued eating" and "continued to eat"'
+		'comment': 'support both "continued eating" and "continued to eat"',
 	},
 	{
 		'name': 'finish before a verb becomes a function word',

--- a/app/src/routes/form-lookup/+server.js
+++ b/app/src/routes/form-lookup/+server.js
@@ -48,7 +48,7 @@ function get_form_matches(db) {
 		/** @type {import('@cloudflare/workers-types').D1Result<DbRowInflection>} https://developers.cloudflare.com/d1/platform/client-api/#return-object */
 		const {results} = await db.prepare(sql).bind(`%|${word}|%`, word).all()
 
-		return results.map(result => transform_db_result(result, term))
+		return results.map(result => transform_db_result(result, word))
 	}
 
 	/**


### PR DESCRIPTION
- 'continued to' is now recognized as the aspect marker
`Moses continued to speak to the Israelites.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/ca14bdcb-982c-4150-9252-e3da7ae14cf9)

- 'named' better recognizes when it is not the Verb
`A man named John obeys God named Yahweh.
John named John's son Paul.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/95aa534c-8e6d-4a50-81a6-1f0f9e2f2dd3)

- improve handling of 'much'. previously it always assumed it meant much-many (an adjective), but now it only assumes much-many when followed by a Noun. So now in the following sentence, 'much' is recognized as an adverb, which in turn makes 'be' be recognized as an auxiliary, which in turn no longer flags the 'two verbs' check (which is what happened in Richard's example)
`John will be much respected by people.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/44c62f70-0c1c-47f7-a0c3-d34a65f8f44a)

- allow level 3 words within a complex alternate or pairing. 
`(complex) Those people had faith. Those people had faith. Those people had hope/faith.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/da379075-b74c-4eb4-a8d7-bee4c9464ac4)

- form lookup now works properly for words with a sense (e.g. teaching-B). previously it didn't recognize the form so the 'be' auxiliary rule wasn't getting triggered.
`I(John) am teaching-B.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/36299805-7e55-4a1e-9ad4-168790b96e2c)
