### PR TITLE
Start including categorization checks

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -34,6 +34,7 @@ type OntologyResult = {
 	part_of_speech: string
 	level: number
 	gloss: string
+	categorization: string
 }
 
 type FormResult = {

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -1,3 +1,5 @@
+import {REGEXES} from '$lib/regexes'
+
 /** @type {TokenType} */
 const PUNCTUATION = 'Punctuation'
 
@@ -107,16 +109,26 @@ export function check_token_lookup(lookup_check) {
  * @returns {Token}
  */
 export function set_token_concept(token, concept) {
-	const [stem, sense] = split_concept()
+	// If a specific sense is already selected, don't overwrite it
+	if (token.lookup_results.length <= 1 || REGEXES.HAS_SENSE.test(token.lookup_term)) {
+		return token
+	}
+
+	const {stem, sense} = split_stem_and_sense(concept)
 	token.lookup_term = concept
 	token.lookup_results = token.lookup_results.filter(result => result.stem === stem && result.sense === sense)
 	return token
 
-	function split_concept() {
-		const dash = concept.lastIndexOf('-')
-		const stem = concept.substring(0, dash)
-		const sense = concept.substring(dash+1)
-		return [stem, sense]
+	/**
+	 * 
+	 * @param {string} term 
+	 * @returns {{stem: string, sense: string}}
+	 */
+	function split_stem_and_sense(term) {
+		/** @type {RegExpMatchArray} */
+		// @ts-ignore the match will always succeed
+		const match = term.match(REGEXES.EXTRACT_STEM_AND_SENSE)
+		return {stem: match[1], sense: match[2] ?? ''}
 	}
 }
 

--- a/app/src/lib/regexes.js
+++ b/app/src/lib/regexes.js
@@ -21,6 +21,8 @@ const EXTRACT_PRONOUN_REFERENT = /^(.+)\(([\w'-]+)\)$/
 // This pulls out the stem and sense, which will then need to be put back together
 const EXTRACT_LOOKUP_TERM = /^(.+?)(?:'s|')?(-[A-Z])?$/
 const HAS_POSSESSIVE = /^(.+?)('s|')(-[A-Z])?$/
+const HAS_SENSE = /^(.+?)(-[A-Z])$/
+const EXTRACT_STEM_AND_SENSE = /^(.+?)(?:-([A-Z]))?$/
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class
 const SENTENCE_ENDING_PUNCTUATION = /^[.?!]/
@@ -44,6 +46,8 @@ export const REGEXES = {
 	EXTRACT_PRONOUN_REFERENT,
 	EXTRACT_LOOKUP_TERM,
 	HAS_POSSESSIVE,
+	HAS_SENSE,
+	EXTRACT_STEM_AND_SENSE,
 	SENTENCE_ENDING_PUNCTUATION,
 	CLAUSE_ENDING_PUNCTUATION,
 	OPENING_BRACKET,

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -1,30 +1,8 @@
 import {ERRORS} from '$lib/parser/error_messages'
-import {TOKEN_TYPE, check_token_lookup} from '$lib/parser/token'
-import {create_context_filter, create_token_filter, create_token_modify_action, parse_checker_rule} from './rules_parser'
+import {TOKEN_TYPE, check_token_lookup, convert_to_error_token, create_added_token} from '$lib/parser/token'
+import {create_context_filter, create_token_filter, create_token_modify_action} from './rules_parser'
 
 const checker_rules_json = [
-	{
-		'name': 'Expect a [ before a relative clause',
-		'trigger': { 'tag': 'relativizer' },
-		'context': {
-			'precededby': { 'category': 'Noun' },
-		},
-		'require': {
-			'precededby': '[',
-			'message': 'Missing bracket before relative or complement clause.',
-		},
-	},
-	{
-		'name': 'Expect a [ before a quote',
-		'trigger': { 'token': ',' },
-		'context': {
-			'followedby': { 'token': '"' },
-		},
-		'require': {
-			'followedby': '[',
-			'message': 'Missing bracket before an opening quote',
-		},
-	},
 	{
 		'name': 'Speak does not use quotes',
 		'trigger': { 'stem': 'speak' },
@@ -51,7 +29,7 @@ const checker_rules_json = [
 		'name': 'Suggest avoiding the Perfect aspect',
 		'trigger': { 'tag': 'flashback' },
 		'suggest': {
-			'message': 'If possible, consider using \'already\' or just the simple past instead of the perfect with \'have\'.',
+			'message': 'The perfect is only allowed if it would have the right meaning if changed to the simple past tense with "recently" or "previously".',
 		},
 	},
 	{
@@ -149,6 +127,63 @@ const checker_rules_json = [
 			'message': 'Try using more specific units of time (eg. \'for many years\') or express it in a different way (eg. \'for much time\').',
 		},
 	},
+	{
+		'name': 'Suggest a comma after "One day..."',
+		'trigger': { 'stem': 'day' },
+		'context': {
+			'precededby': { 'token': 'One' },
+			'followedby': [{ 'token': 'that' }, { 'category': 'Noun' }],
+		},
+		'suggest': {
+			'followedby': ',',
+			'message': 'Add a comma after \'One day\' so the \'that\' doesn\'t confuse the Analyzer.',
+		},
+		'comment': 'The Analyzer messes up "One day that man...", but it works fine with a comma. TODO handle other phrases too?',
+	},
+	{
+		'name': 'Expect a [ before a relative clause',
+		'trigger': { 'tag': 'relativizer' },
+		'context': {
+			'precededby': { 'category': 'Noun' },
+		},
+		'require': {
+			'precededby': '[',
+			'message': 'Missing bracket before relative or complement clause.',
+		},
+	},
+	{
+		'name': 'Expect a [ before an adverbial clause',
+		'trigger': { 'category': 'Adposition', 'usage': 'C' },
+		'context': {
+			'notprecededby': { 'token': '[' },
+		},
+		'require': {
+			'precededby': '[',
+			'message': 'Missing bracket before adverbial clause.',
+		},
+	},
+	{
+		'name': 'Expect a [ before a quote',
+		'trigger': { 'token': ',' },
+		'context': {
+			'followedby': { 'token': '"' },
+		},
+		'require': {
+			'followedby': '[',
+			'message': 'Missing bracket before an opening quote',
+		},
+	},
+	{
+		'name': '\'so\' in an Adverbial clause should be followed by \'that\'',
+		'trigger': { 'token': 'so', 'category': 'Adposition' },
+		'context': {
+			'notfollowedby': { 'token': 'that' },
+		},
+		'suggest': {
+			'followedby': 'that',
+			'message': 'Add \'that\' after \'so\' so that it doesn\'t get mistaken for the Conjunction.',
+		},
+	},
 ]
 
 /** @type {BuiltInRule[]} */
@@ -221,6 +256,71 @@ const builtin_checker_rules = [
 		},
 	},
 ]
+
+/**
+ *
+ * @param {any} rule_json
+ * @returns {TokenRule}
+ */
+export function parse_checker_rule(rule_json) {
+	const trigger = create_token_filter(rule_json['trigger'])
+	const context = create_context_filter(rule_json['context'])
+
+	// one of these has to be present, but not both
+	const require_json = rule_json['require']
+	const suggest_json = rule_json['suggest']
+	const action = require_json ? checker_require_action(require_json) : checker_suggest_action(suggest_json)
+
+	return {
+		trigger,
+		context,
+		action,
+	}
+
+	/**
+	 * 
+	 * @param {CheckerAction} require
+	 * @returns {RuleAction}
+	 */
+	function checker_require_action(require) {
+		return (tokens, trigger_index) => {
+			// The action will have a precededby, followedby, or neither. Never both.
+			if (require.precededby) {
+				tokens.splice(trigger_index, 0, create_added_token(require.precededby, {error: require.message}))
+				return trigger_index + 2
+			}
+			if (require.followedby) {
+				tokens.splice(trigger_index + 1, 0, create_added_token(require.followedby, {error: require.message}))
+				return trigger_index + 2
+			}
+
+			tokens[trigger_index] = convert_to_error_token(tokens[trigger_index], require.message)
+			return trigger_index + 1
+		}
+	}
+
+	/**
+	 * suggest only applies on the trigger token (for now)
+	 * @param {CheckerAction} suggest
+	 * @returns {RuleAction}
+	 */
+	function checker_suggest_action(suggest) {
+		return (tokens, trigger_index) => {
+			// The action will have a precededby, followedby, or neither. Never both.
+			if (suggest.precededby) {
+				tokens.splice(trigger_index, 0, create_added_token(suggest.precededby, {suggest: suggest.message}))
+				return trigger_index + 2
+			}
+			if (suggest.followedby) {
+				tokens.splice(trigger_index + 1, 0, create_added_token(suggest.followedby, {suggest: suggest.message}))
+				return trigger_index + 2
+			}
+
+			tokens[trigger_index] = {...tokens[trigger_index], suggest_message: suggest.message}
+			return trigger_index + 1
+		}
+	}
+}
 
 export const CHECKER_RULES = builtin_checker_rules.map(({rule}) => rule).concat(checker_rules_json.map(parse_checker_rule))
 

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -180,8 +180,7 @@ const checker_rules_json = [
 			'notfollowedby': { 'token': 'that' },
 		},
 		'suggest': {
-			'followedby': 'that',
-			'message': 'Add \'that\' after \'so\' so that it doesn\'t get mistaken for the Conjunction.',
+			'message': 'Use \'so-that\' so-that it doesn\'t get mistaken for the Conjunction.',
 		},
 	},
 ]

--- a/app/src/lib/rules/checker_rules.test.js
+++ b/app/src/lib/rules/checker_rules.test.js
@@ -56,6 +56,7 @@ function create_lookup_result(stem, {sense='A', part_of_speech='Noun', level=1}=
 		part_of_speech,
 		level,
 		gloss: '',
+		categorization: '',
 	}
 }
 

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -1,4 +1,4 @@
-import {parse_lookup_rule} from '$lib/rules/rules_parser'
+import {apply_token_transforms, create_context_filter, create_token_filter, create_token_transform} from '$lib/rules/rules_parser'
 import {TOKEN_TYPE} from '../parser/token'
 
 /**
@@ -21,11 +21,9 @@ const lookup_rules_json = [
 		'combine': 2,
 	},
 	{
-		'name': 'so-that',
-		'trigger': { 'token': 'so' },
-		'context': { 'followedby': {'token': 'that'} },
-		'lookup': 'so-that',
-		'combine': 1,
+		'name': 'so-that becomes so for lookup purposes',
+		'trigger': { 'token': 'so-that' },
+		'lookup': 'so',
 	},
 	{
 		'name': 'just-like',
@@ -114,5 +112,55 @@ const lookup_rules_json = [
 		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
 	},
 ]
+
+/**
+ *
+ * @param {any} rule_json
+ * @returns {TokenRule}
+ */
+export function parse_lookup_rule(rule_json) {
+	const trigger = create_token_filter(rule_json['trigger'])
+	const context = create_context_filter(rule_json['context'])
+
+	const lookup_term = rule_json['lookup']
+	const combine = rule_json['combine'] ?? 0
+
+	// TODO support multiple transforms if context requires multiple tokens
+	const context_transforms = [create_token_transform(rule_json['context_transform'])]
+
+	return {
+		trigger,
+		context,
+		action: lookup_rule_action,
+	}
+
+	/**
+	 * 
+	 * @param {Token[]} tokens 
+	 * @param {number} trigger_index 
+	 * @param {number[]} context_indexes 
+	 * @returns {number}
+	 */
+	function lookup_rule_action(tokens, trigger_index, context_indexes) {
+		tokens[trigger_index] = {...tokens[trigger_index], lookup_term}
+
+		if (context_indexes.length === 0) {
+			return trigger_index + 1
+		}
+
+		// apply possible context transforms
+		apply_token_transforms(tokens, context_indexes, context_transforms)
+
+		if (combine === 0 || context_indexes[combine-1] !== trigger_index + combine) {
+			return trigger_index + 1
+		}
+		
+		// combine context tokens into one
+		const tokens_to_combine = tokens.splice(trigger_index, combine + 1)
+		const new_token_value = tokens_to_combine.map(token => token.token).join(' ')
+		tokens.splice(trigger_index, 0, {...tokens_to_combine[0], token: new_token_value})
+		return trigger_index + combine + 1
+	}
+}
 
 export const LOOKUP_RULES = lookup_rules_json.map(parse_lookup_rule)

--- a/app/src/lib/rules/rules_parser.test.js
+++ b/app/src/lib/rules/rules_parser.test.js
@@ -368,6 +368,27 @@ describe('context filters', () => {
 	})
 })
 
+/**
+ * 
+ * @param {string} stem
+ * @param {Object} [data={}] 
+ * @param {string} [data.sense='A'] 
+ * @param {string} [data.part_of_speech='Noun'] 
+ * @param {number} [data.level=1] 
+ * @returns {OntologyResult}
+ */
+function create_lookup_result(stem, {sense='A', part_of_speech='Noun', level=1}={}) {
+	return {
+		id: '0',
+		stem: stem,
+		sense,
+		part_of_speech,
+		level,
+		gloss: '',
+		categorization: '',
+	}
+}
+
 describe('token transforms', () => {
 	test('type', () => {
 		const transform_json = { 'type': TOKEN_TYPE.FUNCTION_WORD }
@@ -388,7 +409,7 @@ describe('token transforms', () => {
 		const result = transform(token)
 		expect(result.token).toBe(token.token)
 		expect(result.type).toBe(token.type)
-		expect(result.lookup_term).toBe('concept-A')
+		expect(result.lookup_term).toBe('token')
 		expect(result.lookup_results.length).toBe(0)
 		expect(result.error_message).toBe(token.error_message)
 	})
@@ -398,22 +419,8 @@ describe('token transforms', () => {
 
 		const token = create_token('token', TOKEN_TYPE.LOOKUP_WORD, {lookup_term: 'token'})
 		token.lookup_results = [
-			{
-				id: '0',
-				stem: 'concept',
-				sense: 'A',
-				part_of_speech: 'Noun',
-				level: 1,
-				gloss: '',
-			},
-			{
-				id: '0',
-				stem: 'concept',
-				sense: 'B',
-				part_of_speech: 'Noun',
-				level: 1,
-				gloss: '',
-			},
+			create_lookup_result('concept', {'sense': 'A', 'part_of_speech': 'Noun'}),
+			create_lookup_result('concept', {'sense': 'B', 'part_of_speech': 'Noun'}),
 		]
 
 		const result = transform(token)
@@ -424,15 +431,15 @@ describe('token transforms', () => {
 		expect(result.lookup_results[0].sense).toBe('A')
 		expect(result.error_message).toBe(token.error_message)
 	})
-	test('type and concept', () => {
-		const transform_json = { 'type': TOKEN_TYPE.LOOKUP_WORD, 'concept': 'concept-A' }
+	test('type and tag', () => {
+		const transform_json = { 'type': TOKEN_TYPE.FUNCTION_WORD, 'tag': 'tag' }
 		const transform = create_token_transform(transform_json)
 
-		const token = create_token('token', TOKEN_TYPE.FUNCTION_WORD)
+		const token = create_token('token', TOKEN_TYPE.LOOKUP_WORD)
 		const result = transform(token)
 		expect(result.token).toBe(token.token)
-		expect(result.type).toBe(TOKEN_TYPE.LOOKUP_WORD)
-		expect(result.lookup_term).toBe('concept-A')
+		expect(result.type).toBe(TOKEN_TYPE.FUNCTION_WORD)
+		expect(result.tag).toBe('tag')
 		expect(result.error_message).toBe(token.error_message)
 	})
 	test('unrecognized', () => {

--- a/app/src/lib/rules/syntax_rules.test.js
+++ b/app/src/lib/rules/syntax_rules.test.js
@@ -82,6 +82,7 @@ function create_lookup_result(stem, {sense='A', part_of_speech='Noun', level=1}=
 		part_of_speech,
 		level,
 		gloss: '',
+		categorization: '',
 	}
 }
 

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -103,7 +103,7 @@ const transform_rules_json = [
 			'precededby': {'stem': 'so', 'category': 'Adposition'},
 		},
 		'transform': { 'tag': '' },
-		'comment': 'both "so that" and "so-that" are supported and map to the Adposition "so"'
+		'comment': 'both "so that" and "so-that" are supported and map to the Adposition "so"',
 	},
 	{
 		'name': 'Adposition \'so\' followed by \'would\' becomes so-C',
@@ -127,7 +127,7 @@ const transform_rules_json = [
 		'trigger': { 'stem': 'be' },
 		'context': {
 			'followedby': [
-				{ 'token': 'like', 'skip': {'token': 'not'} }
+				{ 'token': 'like', 'skip': {'token': 'not'} },
 			],
 		},
 		'transform': { 'concept': 'be-U' },

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -1,9 +1,12 @@
-import {parse_transform_rule} from './rules_parser'
+import {apply_token_transforms, create_context_filter, create_token_filter, create_token_transform} from './rules_parser'
 
 /**
  * These are words that may change their underlying data based on the context around them.
  * These can look at the lookup results of the surrounding tokens (ie syntactic category)
  * and can be used to decide between senses.
+ * 
+ * TODO Move the sense-determining/case frame rules to a different file and/or create a different type of rule for them
+ * 
  */
 const transform_rules_json = [
 	{
@@ -71,6 +74,171 @@ const transform_rules_json = [
 		'transform': { 'function': 'auxiliary|completive_aspect' },
 	},
 	{
+		'name': '\'named\' before a name and after a Verb becomes a function word',
+		'trigger': { 'token': 'named' },
+		'context': {
+			'precededby': { 'category': 'Verb', 'skip': 'all' },
+			'followedby': { 'level': '4' },
+		},
+		'transform': { 'function': '-Name' },
+	},
+	{
+		'name': '\'named\' before a name and before a Verb becomes a function word',
+		'trigger': { 'token': 'named' },
+		'context': {
+			'followedby': [{ 'level': '4' }, { 'category': 'Verb', 'skip': 'all' }],
+		},
+		'transform': { 'function': '-Name' },
+	},
+	{
+		'name': '\'of\' after group/crowd becomes a function word',
+		'trigger': { 'token': 'of' },
+		'context': { 'precededby': {'stem': 'group|crowd'} },
+		'transform': { 'function': '-Group' },
+	},
+	{
+		'name': '\'that\' followed by the Adposition \'so\' does not have any function',
+		'trigger': { 'token': 'that' },
+		'context': {
+			'precededby': {'stem': 'so', 'category': 'Adposition'},
+		},
+		'transform': { 'tag': '' },
+		'comment': 'both "so that" and "so-that" are supported and map to the Adposition "so"'
+	},
+	{
+		'name': 'Adposition \'so\' followed by \'would\' becomes so-C',
+		'trigger': { 'stem': 'so', 'category': 'Adposition' },
+		'context': {
+			'followedby': { 'tag': 'conditional_would', 'skip': 'all' },
+		},
+		'transform': { 'concept': 'so-C' },
+	},
+	{
+		'name': 'be after \'there\' becomes be-E (existential)',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'precededby': { 'token': 'There|there' },
+		},
+		'transform': { 'concept': 'be-E' },
+		'context_transform': { 'function': 'existential' },
+	},
+	{
+		'name': 'be before \'like\' becomes be-U',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': [
+				{ 'token': 'like', 'skip': {'token': 'not'} }
+			],
+		},
+		'transform': { 'concept': 'be-U' },
+		'context_transform': { 'function': 'state_role' },
+	},
+	{
+		'name': 'be before \'for\' becomes be-G',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': { 'token': 'for', 'skip': {'token': 'not'} },
+		},
+		'transform': { 'concept': 'be-G' },
+		'context_transform': { 'function': 'state_role' },
+	},
+	{
+		'name': 'be before \'with\' becomes be-I',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': { 'token': 'with', 'skip': {'token': 'not'} },
+		},
+		'transform': { 'concept': 'be-I' },
+		'context_transform': { 'function': 'state_role' },
+	},
+	{
+		'name': 'be before \'about\' becomes be-P',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': { 'token': 'about', 'skip': {'token': 'not'} },
+		},
+		'transform': { 'concept': 'be-P' },
+		'context_transform': { 'function': 'state_role' },
+	},
+	{
+		'name': 'be before an adposition and temporal words becomes be-H',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': [
+				{ 'stem': 'in|on|before|after' },
+				{ 'stem': 'day|morning|afternoon|evening|Sabbath', 'skip': [{'token': 'the'}, {'category': 'Adjective'}] },
+			],
+		},
+		'transform': { 'concept': 'be-H' },
+	},
+	{
+		'name': 'be before an adposition becomes be-F',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': {
+				'category': 'Adposition',
+				'usage': 'A|a',
+				'skip': [{ 'token': 'not' }, { 'category': 'Adverb'}],
+			},
+		},
+		'transform': { 'concept': 'be-F' },
+	},
+	{
+		'name': 'be after \'date\' becomes be-J',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'precededby': { 'token': 'date' },
+		},
+		'transform': { 'concept': 'be-J' },
+	},
+	{
+		'name': 'be after \'time\' becomes be-N',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'precededby': { 'token': 'time' },
+		},
+		'transform': { 'concept': 'be-N' },
+		'context_transform': { 'concept': 'time-A' },
+	},
+	{
+		'name': 'be after \'weather\' becomes be-O',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'precededby': { 'token': 'weather' },
+		},
+		'transform': { 'concept': 'be-O' },
+	},
+	{
+		'name': 'be after the noun \'name\' becomes be-K',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'precededby': { 'category': 'Noun', 'stem': 'name', 'skip': 'all' },
+		},
+		'transform': { 'concept': 'be-K' },
+	},
+	{
+		'name': 'be before an adjective becomes be-D if can be used predicatively',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': {
+				'category': 'Adjective',
+				'skip': [{ 'token': 'not|very|extremely' }, { 'category': 'Adverb' }],
+			},
+		},
+		'transform': { 'concept': 'be-D' },
+	},
+	{
+		'name': 'become before an adjective becomes become-A',
+		'trigger': { 'stem': 'become' },
+		'context': {
+			'followedby': {
+				'category': 'Adjective',
+				'skip': { 'token': 'very|extremely' },
+			},
+		},
+		'transform': { 'concept': 'become-A' },
+	},
+	{
 		'name': 'be before any verb becomes an auxiliary',
 		'trigger': { 'stem': 'be' },
 		'context': {
@@ -127,29 +295,6 @@ const transform_rules_json = [
 		'transform': { 'function': 'auxiliary' },
 	},
 	{
-		'name': '\'named\' before a name and after a Verb becomes a function word',
-		'trigger': { 'token': 'named' },
-		'context': {
-			'precededby': { 'category': 'Verb', 'skip': 'all' },
-			'followedby': { 'level': '4' },
-		},
-		'transform': { 'function': '-Name' },
-	},
-	{
-		'name': '\'named\' before a name and before a Verb becomes a function word',
-		'trigger': { 'token': 'named' },
-		'context': {
-			'followedby': [{ 'level': '4' }, { 'category': 'Verb', 'skip': 'all' }],
-		},
-		'transform': { 'function': '-Name' },
-	},
-	{
-		'name': '\'of\' after group/crowd becomes a function word',
-		'trigger': { 'token': 'of' },
-		'context': { 'precededby': {'stem': 'group|crowd'} },
-		'transform': { 'function': '-Group' },
-	},
-	{
 		'name': 'by preceded by a passive be indicates the agent',
 		'trigger': { 'stem': 'by' },
 		'context': {
@@ -161,36 +306,48 @@ const transform_rules_json = [
 		'transform': { 'function': 'agent_of_passive' },
 	},
 	{
-		'name': 'be before an adjective becomes be-D',
-		'trigger': { 'stem': 'be' },
+		'name': 'Select Adverbial senses of adpositions when first word of a subordinate clause',
+		'trigger': { 'category': 'Adposition' },
 		'context': {
-			'followedby': {
-				'category': 'Adjective',
-				'skip': [{ 'token': 'not|very|extremely' }, { 'category': 'Adverb' }],
-			},
+			'precededby': {'token': '['},
 		},
-		'transform': { 'concept': 'be-D' },
-	},
-	{
-		'name': 'become before an adjective becomes become-A',
-		'trigger': { 'stem': 'become' },
-		'context': {
-			'followedby': {
-				'category': 'Adjective',
-				'skip': { 'token': 'very|extremely' },
-			},
-		},
-		'transform': { 'concept': 'become-A' },
-	},
-	{
-		'name': 'be after \'there\' becomes be-E (existential)',
-		'trigger': { 'stem': 'be' },
-		'context': {
-			'precededby': { 'token': 'There|there' },
-		},
-		'transform': { 'concept': 'be-E' },
-		'context_transform': { 'function': 'existential' },
+		'transform': { 'usage': 'C' },
+		'comment': 'C means "Always in an Adverbial clause". eg by-A (Adverbial - C) vs by-B (Adjunct - A)',
 	},
 ]
+
+/**
+ *
+ * @param {any} rule_json
+ * @returns {TokenRule}
+ */
+export function parse_transform_rule(rule_json) {
+	const trigger = create_token_filter(rule_json['trigger'])
+	const context = create_context_filter(rule_json['context'])
+	const transform = create_token_transform(rule_json['transform'])
+
+	// TODO support multiple transforms if context requires multiple tokens
+	const context_transforms = [create_token_transform(rule_json['context_transform'])]
+
+	return {
+		trigger,
+		context,
+		action: transform_rule_action,
+	}
+
+	/**
+	 * 
+	 * @param {Token[]} tokens 
+	 * @param {number} trigger_index 
+	 * @param {number[]} context_indexes 
+	 * @returns {number}
+	 */
+	function transform_rule_action(tokens, trigger_index, context_indexes) {
+		const transforms = [transform, ...context_transforms]
+		const indexes = [trigger_index, ...context_indexes]
+		apply_token_transforms(tokens, indexes, transforms)
+		return trigger_index + 1
+	}
+}
 
 export const TRANSFORM_RULES = transform_rules_json.map(parse_transform_rule)


### PR DESCRIPTION
**Add categorization and simple rules using it**
- select the correct sense of words like by/after/before when in an Adverbial clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7241487a-853b-44bb-94f4-6fabe3ef6bf9)

- Check for brackets before adpositions that always start an adverbial clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/45b64be4-2a76-455b-914c-07396bd8fbee)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/c1a6c89d-c12f-4c37-baac-8e7d69de08dd)

**Rules for determining more senses of be (including 'be like')**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/a676a649-f1e3-4449-8609-cf03c6d1556d)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b9e3214e-50c7-433c-9706-54156095157b)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b29dbaa3-0892-4c5a-aba0-9e49d6bccbf9)

**Fixed issues found with 'so'/'so-that' while testing**
- 'so-that' should be accepted as the Adposition 'so'
- 'would' within the clause indicates so-C
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/d6d3440d-576f-431b-8657-5f0d6e5c9662)

- 'So' at the beginning of the sentence is recognized as the conjunction
- 'so' in the subordinate clause confuses the Analyzer, so suggest using 'so-that'
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7c4840ab-ebd4-43cf-bd6f-1912b3e94683)

- 'so that' is also accepted
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/d0d96e15-9557-4e12-8a5a-e5464750b6bd)

**Fix lookup issue with 'following' and other potential multi-part-of-speech words**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/63b19638-10f4-453a-8fc6-42a7494fb458)
