### PR TITLE
Start adding checks from the P1 checklist

### DIFF
--- a/app/src/lib/parser/function_words.js
+++ b/app/src/lib/parser/function_words.js
@@ -31,7 +31,7 @@ export const FUNCTION_WORDS = new Map([
 	['would', 'conditional_would|modal'],
 	['who', 'interrogative_person|relativizer'],
 	['whom', 'relativizer'],
-	['what', 'interrogative_thing|relativizer'],
+	['what', 'interrogative_thing'],
 	['which', 'interrogative_which|relativizer'],
 ])
 

--- a/app/src/lib/parser/function_words.js
+++ b/app/src/lib/parser/function_words.js
@@ -29,9 +29,8 @@ export const FUNCTION_WORDS = new Map([
 	['very', 'intensified_degree'],
 	['will', 'future_time|modal'],
 	['would', 'conditional_would|modal'],
-	['who', 'interrogative_person|relativizer'],
+	['who', 'relativizer'],
 	['whom', 'relativizer'],
-	['what', 'interrogative_thing'],
 	['which', 'interrogative_which|relativizer'],
 ])
 

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -63,12 +63,11 @@ const checker_rules_json = [
 		'trigger': { 'category': 'Verb' },
 		'context': {
 			'precededby': { 'category': 'Verb', 'skip': 'all' },
-			'notprecededby': { 'token': '[' },
 		},
 		'require': {
 			'message': 'Cannot have multiple verbs in the same clause. Check for an unbracketed subordinate clause or consider splitting the sentence.',
 		},
-		'comment': 'Check for a [ error token in case an earlier check already identified a potential subordinate clause.',
+		'comment': 'See section 0.3 of the Phase 1 checklist',
 	},
 	{
 		'name': 'Check for an Imperative Verb with no subject at the beginning of a sentence',
@@ -110,11 +109,74 @@ const checker_rules_json = [
 		},
 	},
 	{
+		'name': 'Check for "Let\'s"',
+		'trigger': { 'token': 'Let\'s|let\'s' },
+		'require': {
+			'message': 'Write \'We(X) go _suggestiveLets\' instead. See P1 Checklist section 15.',
+		},
+	},
+	{
+		'name': 'Check for \'Let X...\'',
+		'trigger': { 'token': 'Let' },
+		'context': {
+			'followedby': { 'category': 'Noun' },
+		},
+		'require': {
+			'message': 'For the jussive write \'X (jussive) ...\' instead of \'Let X...\'. Or use \'(imp)\' for expressing permission. See P1 Checklist section 15.',
+		},
+	},
+	{
+		'name': 'Check for \'May X...\'',
+		'trigger': { 'token': 'May' },
+		'context': {
+			'followedby': { 'category': 'Noun' },
+		},
+		'require': {
+			'message': 'Write \'I(X) pray-hope [Y...]\' instead. See P1 Checklist section 15.',
+		},
+	},
+	{
 		'name': 'Avoid using \'way\'',
 		'trigger': { 'stem': 'way' },
 		'suggest': {
 			'message': 'Consider rewording to avoid the use of \'way\'. If that is impossible, you can still use it in the sense of means or method.',
 		},
+		'comment': 'See section X of the Phase 1 checklist',
+	},
+	{
+		'name': 'Cannot use \'even\'',
+		'trigger': { 'stem': 'even' },
+		'require': {
+			'message': 'Cannot use \'even\'. Simply omit it or reword the sentence to get the right emphasis. See P1 Checklist section 17.',
+		},
+		'comment': 'See section 17 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Cannot use \'any\'',
+		'trigger': { 'stem': 'any' },
+		'require': {
+			'message': 'Cannot use \'any\'. Simply use \'a\' instead. See P1 Checklist section 17.',
+		},
+		'comment': 'See section 17 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Cannot use \'really\'',
+		'trigger': { 'token': 'really' },
+		'require': {
+			'message': 'Cannot use \'really\'. Use \'actually\', \'truly\', \'very\', or \'much\' instead.',
+		},
+		'comment': 'See section 1 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Cannot say "X\'s own Y"',
+		'trigger': { 'token': 'own' },
+		'context': {
+			'precededby': { 'tag': 'genitive_saxon', 'skip': { 'token': 'very' } },
+		},
+		'require': {
+			'message': 'Cannot write "X\'s own Y". Simply omit \'own\' or write "X\'s _emphasized Y" if desired. See P1 Checklist section 17.',
+		},
+		'comment': 'See section 17 of the Phase 1 checklist',
 	},
 	{
 		'name': 'Avoid vague units of time',
@@ -261,6 +323,117 @@ const checker_rules_json = [
 		'require': {
 			'message': 'TBTA does not use the plural \'troubles\'. Use \'trouble _plural\' to indicate plurality.',
 		},
+	},
+	{
+		'name': 'Don\'t allow \'what\' as a relativizer',
+		'trigger': { 'token': 'what' },
+		'context': {
+			'precededby': { 'token': '[' },
+			'notfollowedby': { 'token': '?', 'skip': 'all' },
+		},
+		'require': {
+			'message': 'Cannot use \'what\' as a relativizer. Use \'the thing [that...]\' instead.',
+		},
+		'comment': 'See section 0.41 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Warn about using \'what\' instead of \'which thing\'',
+		'trigger': { 'token': 'What|what' },
+		'suggest': {
+			'message': '\'what\' always becomes \'which thing-A\'. Consider writing \'which X\' if you want something different.',
+		},
+		'comment': 'See section 0.41 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Don\'t allow \'where\' as a relativizer',
+		'trigger': { 'token': 'where' },
+		'context': {
+			'precededby': { 'token': '[' },
+			'notfollowedby': { 'token': '?', 'skip': 'all' },
+		},
+		'require': {
+			'message': 'Cannot use \'where\' as a relativizer. Use \'the place [that...]\' instead.',
+		},
+		'comment': 'See section 0.8 of the Phase 1 checklist',
+	},
+	// TODO Look outside the subordinate clause for 'time'. Currently this falsely flags a 'when' adverbial clause. 
+	// {
+	// 	'name': 'Don\'t allow \'when\' as a relativizer',
+	// 	'trigger': { 'token': 'when' },
+	// 	'context': {
+	// 		'precededby': { 'token': '[' },
+	// 		'notfollowedby': { 'token': '?', 'skip': 'all' },
+	// 	},
+	// 	'require': {
+	// 		'message': 'Cannot use \'when\' as a relativizer. Use \'the time [that...]\' instead.',
+	// 	},
+	// 	'comment': 'See section 0.8 of the Phase 1 checklist.',
+	// },
+	{
+		'name': 'Don\'t allow \'whose\' as a relativizer',
+		'trigger': { 'token': 'whose' },
+		'require': {
+			'message': 'Cannot use \'whose\'. Use \'X [who had...]\' instead. See P1 Checklist section 6.',
+		},
+		'comment': 'See section 6 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Use \'all of\' rather than \'all\' for non-generic Nouns',
+		'trigger': { 'token': 'all' },
+		'context': {
+			'notfollowedby': [
+				{ 'token': 'of|_generic', 'skip': [
+					{ 'token': 'the|those|these' },
+					{ 'category': 'Noun' },
+				]},
+			],
+		},
+		'suggest': {
+			'followedby': 'of',
+			'message': 'Use \'all of\' unless the modified Noun should be generic, in which case add \'_generic\' after the Noun. See P1 Checklist 0.17.',
+		},
+		'comment': 'See section 0.17 of the Phase 1 checklist',
+	},
+	{
+		'name': 'Cannot use aspect auxilliaries (eg start) without another Verb',
+		'trigger': { 'stem': 'start|stop|continue|finish' },
+		'context': {
+			'notfollowedby': { 'category': 'Verb', 'skip': 'all' },
+		},
+		'require': {
+			'message': 'Must use start/stop/continue/finish with another Verb. See P1 Checklist 0.19.',
+		},
+		'comment': 'See section 0.19 of the Phase 1 checklist.',
+	},
+	{
+		'name': 'Must use \'X is able to\' instead of \'X can\'',
+		'trigger': { 'token': 'can' },
+		'require': {
+			'message': 'Use \'be able [to...]\' instead of \'can\'. See P1 Checklist 2.1.',
+		},
+		'comment': 'See section 2.1 of the Phase 1 checklist.',
+	},
+	{
+		'name': 'Cannot use \'could\' unless in a \'so\' adverbial clause',
+		'trigger': { 'token': 'could' },
+		'context': {
+			'notprecededby': [{ 'token': '[' }, { 'stem': 'so', 'skip': 'all' }],
+		},
+		'require': {
+			'message': 'Use \'be able [to...]\' instead of \'could\', unless in a \'so-that\' clause. See P1 Checklist 2.1.',
+		},
+		'comment': 'See section 2.1 of the Phase 1 checklist.',
+	},
+	{
+		'name': 'Cannot use \'is going to\' as a future marker',
+		'trigger': { 'stem': 'go' },
+		'context': {
+			'followedby': [{ 'token': 'to' }, { 'category': 'Verb' }],
+		},
+		'require': {
+			'message': 'Use \'will\' instead of \'going to\' to express future tense. See P1 Checklist 0.28.',
+		},
+		'comment': 'See section 0.28 of the Phase 1 checklist.',
 	},
 ]
 

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -311,7 +311,7 @@ const checker_rules_json = [
 		'name': 'Check for unhyphenated Verbs with \'up\'',
 		'trigger': { 'token': 'up' },
 		'context': {
-			'precededby': { 'stem': 'pick|run|sit|stand|wake|walk', 'category': 'Verb', 'skip': 'all' },
+			'precededby': { 'stem': 'go|pick|run|sit|stand|wake|walk', 'category': 'Verb', 'skip': 'all' },
 		},
 		'require': {
 			'message': '\'up\' must be hyphenated with the Verb (e.g. pick-up). DO NOT inflect the Verb (e.g. NOT picked-up).',
@@ -434,6 +434,26 @@ const checker_rules_json = [
 			'message': 'Use \'will\' instead of \'going to\' to express future tense. See P1 Checklist 0.28.',
 		},
 		'comment': 'See section 0.28 of the Phase 1 checklist.',
+	},
+	{
+		'name': 'Cannot use \'is to {Verb}\' as an obligation',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': [{ 'token': 'to' }, { 'category': 'Verb' }],
+		},
+		'require': {
+			'message': 'Use \'will\', \'must\', or \'should\' instead of \'is to...\' to express a future obligation.',
+		},
+	},
+	{
+		'name': 'Cannot use \'have to {Verb}\' as an obligation',
+		'trigger': { 'stem': 'have' },
+		'context': {
+			'followedby': [{ 'token': 'to' }, { 'category': 'Verb' }],
+		},
+		'require': {
+			'message': 'Use \'must\' or \'should\' instead of \'have to...\' to express an obligation.',
+		},
 	},
 ]
 

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -131,6 +131,18 @@ const lookup_rules_json = [
 		'lookup': 'worry',		// TODO make this a case frame rule
 		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
 	},
+	{
+		'name': 'what becomes thing-A in a question',
+		'trigger': { 'token': 'What|what' },
+		'context': { 'followedby': { 'token': '?', 'skip': 'all' } },
+		'lookup': 'thing-A',
+	},
+	{
+		'name': 'who becomes person-A in a question',
+		'trigger': { 'token': 'Who|who' },
+		'context': { 'followedby': { 'token': '?', 'skip': 'all' } },
+		'lookup': 'person-A',
+	},
 ]
 
 /**
@@ -162,7 +174,7 @@ export function parse_lookup_rule(rule_json) {
 	 * @returns {number}
 	 */
 	function lookup_rule_action(tokens, trigger_index, context_indexes) {
-		tokens[trigger_index] = { ...tokens[trigger_index], lookup_terms: [lookup_term] }
+		tokens[trigger_index] = { ...tokens[trigger_index], type: TOKEN_TYPE.LOOKUP_WORD, lookup_terms: [lookup_term] }
 
 		if (context_indexes.length === 0) {
 			return trigger_index + 1

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -110,6 +110,15 @@ const part_of_speech_rules_json = [
 		'comment': 'Dan. 1:12 Please give only(Adj/Adv) vegetables ...  Paul like most(Adj/Adv) books.',
 	},
 	{
+		'name': 'If Adverb-Adjective followed by Verb, remove Adjective',
+		'category': 'Adverb|Adjective',
+		'context': {
+			'followedby': { 'category': 'Verb' },
+		},
+		'remove': 'Adjective',
+		'comment': 'John only(Adv/Adj) saw a book.',
+	},
+	{
 		'name': 'If Verb-Adjective preceded by an article or possessive, remove Verb',
 		'category': 'Verb|Adjective',
 		'context': {

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -106,6 +106,15 @@ const transform_rules_json = [
 		'comment': 'both "so that" and "so-that" are supported and map to the Adposition "so"',
 	},
 	{
+		'name': '\'who\'/\'what\' gets tagged with interrogative_which when in a question',
+		'trigger': { 'token': 'Who|who|What|what' },
+		'context': {
+			'followedby': { 'token': '?', 'skip': 'all' },
+		},
+		'transform': { 'tag': 'interrogative_which' },
+		'comment': '"who/what" becomes "which person-A/thing-A" respectively when in a question',
+	},
+	{
 		'name': 'Adposition \'so\' followed by \'would\' becomes so-C',
 		'trigger': { 'stem': 'so', 'category': 'Adposition' },
 		'context': {

--- a/app/src/lib/tokens/Result.svelte
+++ b/app/src/lib/tokens/Result.svelte
@@ -61,7 +61,7 @@
 								</tr>
 
 								<tr slot="entry_row" let:entry>
-									{#if has_structure}<td class="whitespace-nowrap">{entry.structure}</td>{/if}
+									{#if has_structure}<td>{entry.structure}</td>{/if}
 									{#if has_pairing}<td>{entry.pairing}</td>{/if}
 									{#if has_explication}<td>{entry.explication}</td>{/if}
 									{#if !(entry.structure || entry.pairing || entry.explication)}


### PR DESCRIPTION
Added checker rules that check for simple things from the Phase 1 checklist. This is just a start.

1. Catch use of `Let's ...` for suggestive let's
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/da2bf933-34d7-4632-bb15-b1265b62758a)

2. Catch use of `Let X...` as jussive
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/bcae2a40-4fbd-4299-baba-5a230b785610)

3. Catch use of `May X...`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/9ddaafcc-84d1-4378-a688-8b7a87c34dd4)

4. Catch use of `even`, `any`, and `really`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/276f2ecb-cde1-4b69-b511-c8f85fbff026)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0ac4e3c1-c7f9-404f-a47a-8b18e38b0760)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/52c292f9-141e-430b-a673-f81886154a76)

6. Catch use of `X's own Y`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/01669931-8474-44ac-87cd-46c1e0469568)

7. Catch use of `what` as a relativizer
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/2f7c6127-af2a-4674-8e65-6db421114394)

8. Warn about using `what` in other situations
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/87680e71-2c60-47b5-8e22-18ce36c4c436)

9. Catch `where` and `whose` as relativizers
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/cb8b81e5-e5cb-4f53-8d47-7acf1319d5ad)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/a2d2d684-cf2e-4bdb-ab13-7ba28478d8c0)

10. Suggest `all of` before non-generic nouns
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/6bb23d46-0717-4226-9e02-97ee44e3082c)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/141bb4b8-33de-4124-9789-770f3b3fde28)

11. Catch use of aspect auxilliaries with no other verb
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/151c313f-fb0c-458c-806c-bc930954b8f0)

12. Catch use of `can`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/cf13d02a-db68-4c2c-9453-79c3ce726a88)

13. Catch use of `could` unless in `so-that` clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/5151942a-4a5a-40cf-84a6-d11e64423ce1)

14. Catch use of `is going to...` for future tense
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/73c6c89b-07fd-4021-8cbf-7f132c527fb2)

15. Catch use of `has to...` or `is to...` for obligation
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/3071e078-6d5a-4cb4-a9f2-22fadc169ea7)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/6bcc9ac7-6061-4b2e-a9db-392df3ead7d7)

16. who/what now become person-A/thing-A respectively when in questions
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/abbc8a96-7fd8-4ee8-a742-9d025ff95c85)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/ae40c22a-03dd-48ea-9039-ea19b1899150)
