### PR TITLE
Enhance and refactor rules.

### DIFF
--- a/app/src/lib/parser/clausify.js
+++ b/app/src/lib/parser/clausify.js
@@ -69,9 +69,7 @@ export function clausify(tokens) {
 			end_clause()
 		}
 
-		const clause = create_clause()
-		clause.tag = 'main_clause'
-		sentences.push({ clause })
+		sentences.push({ clause: create_clause('main_clause') })
 	}
 
 	function start_clause() {
@@ -85,12 +83,17 @@ export function clausify(tokens) {
 			return
 		}
 
-		add_token_to_clause(create_clause())
+		add_token_to_clause(create_clause('subordinate_clause'))
 	}
 
-	function create_clause() {
+	/**
+	 * 
+	 * @param {string} tag 
+	 * @returns {Clause}
+	 */
+	function create_clause(tag) {
 		// @ts-ignore
-		return create_clause_token(clause_tokens.pop())
+		return create_clause_token(clause_tokens.pop(), tag)
 	}
 
 	/**

--- a/app/src/lib/parser/clausify.test.js
+++ b/app/src/lib/parser/clausify.test.js
@@ -20,7 +20,7 @@ function create_tokens(tokens) {
  * @returns {Sentence}
  */
 function create_sentence(tokens) {
-	return {clause: create_clause_token(tokens, 'main_clause') }
+	return { clause: create_clause_token(tokens, 'main_clause') }
 }
 
 /**

--- a/app/src/lib/parser/clausify.test.js
+++ b/app/src/lib/parser/clausify.test.js
@@ -20,9 +20,7 @@ function create_tokens(tokens) {
  * @returns {Sentence}
  */
 function create_sentence(tokens) {
-	const clause = create_clause_token(tokens)
-	clause.tag = 'main_clause'
-	return { clause }
+	return {clause: create_clause_token(tokens, 'main_clause') }
 }
 
 /**

--- a/app/src/lib/parser/function_words.js
+++ b/app/src/lib/parser/function_words.js
@@ -18,7 +18,7 @@ export const FUNCTION_WORDS = new Map([
 	['probably', 'probable_mood|modal'],
 	['should', 'should_mood|modal'],
 	['than', 'comparative_degree'],
-	['that', 'remote_demonstrative|relativizer|complementizer'],
+	['that', 'remote_demonstrative|relativizer'],
 	['the', 'definite_article'],
 	['there', 'at_that_place'],
 	['these', 'near_demonstrative'],

--- a/app/src/lib/parser/index.js
+++ b/app/src/lib/parser/index.js
@@ -2,7 +2,7 @@ import { pipe } from '$lib/pipeline'
 import { tokenize_input } from './tokenize'
 import { perform_form_lookups, perform_ontology_lookups } from '$lib/lookups'
 import { clausify, flatten_sentences } from './clausify'
-import { CHECKER_RULES, LOOKUP_RULES, PART_OF_SPEECH_RULES, SYNTAX_RULES, TRANSFORM_RULES, PRONOUN_RULES, rules_applier } from '$lib/rules'
+import { RULES, rules_applier } from '$lib/rules'
 
 /**
  * @param {string} text
@@ -12,18 +12,17 @@ export async function parse(text) {
 	const pre_lookups = pipe(
 		tokenize_input,
 		clausify,
-		rules_applier(PRONOUN_RULES),
+		rules_applier(RULES.SYNTAX),
 	)(text)
 
 	const with_forms = await perform_form_lookups(pre_lookups)
-	const with_transformed_lookups = rules_applier(LOOKUP_RULES)(with_forms)
+	const with_transformed_lookups = rules_applier(RULES.LOOKUP)(with_forms)
 	const with_lookups = await perform_ontology_lookups(with_transformed_lookups)
 
 	return pipe(
-		rules_applier(SYNTAX_RULES),
-		rules_applier(PART_OF_SPEECH_RULES),
-		rules_applier(TRANSFORM_RULES),
-		rules_applier(CHECKER_RULES),
+		rules_applier(RULES.PART_OF_SPEECH),
+		rules_applier(RULES.TRANSFORM),
+		rules_applier(RULES.CHECKER),
 		flatten_sentences,
 	)(with_lookups)
 }
@@ -38,12 +37,11 @@ export function parse_for_test(text) {
 	return pipe(
 		tokenize_input,
 		clausify,
-		rules_applier(PRONOUN_RULES),
-		rules_applier(LOOKUP_RULES),
-		rules_applier(SYNTAX_RULES),
-		rules_applier(PART_OF_SPEECH_RULES),
-		rules_applier(TRANSFORM_RULES),
-		rules_applier(CHECKER_RULES.slice(0,4)),	// TODO remove slice when e2e testing is set up (skips the 'no lookup' check)
+		rules_applier(RULES.SYNTAX),
+		rules_applier(RULES.LOOKUP),
+		rules_applier(RULES.PART_OF_SPEECH),
+		rules_applier(RULES.TRANSFORM),
+		rules_applier(RULES.CHECKER.slice(0,4)),	// TODO remove slice when e2e testing is set up (skips the 'no lookup' check)
 		flatten_sentences,
 	)(text)
 }

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -81,9 +81,10 @@ export function convert_to_error_token(token, message) {
 /**
  * 
  * @param {Token[]} sub_tokens 
+ * @param {string} tag
  */
-export function create_clause_token(sub_tokens) {
-	return create_token('', TOKEN_TYPE.CLAUSE, { sub_tokens })
+export function create_clause_token(sub_tokens, tag='subordinate_clause') {
+	return create_token('', TOKEN_TYPE.CLAUSE, { sub_tokens, tag })
 }
 
 /**
@@ -99,8 +100,11 @@ export function set_token_concept(token, concept) {
 	}
 
 	const { stem, sense } = split_stem_and_sense(concept)
-	token.lookup_terms = [concept]
-	token.lookup_results = token.lookup_results.filter(result => result.stem === stem && result.concept?.sense === sense)
+	const concept_index = token.lookup_results.findIndex(result => result.stem === stem && result.concept?.sense === sense)
+	const selected_result = token.lookup_results.splice(concept_index, 1)
+
+	// put the selected sense at the top
+	token.lookup_results = [...selected_result, ...token.lookup_results]
 	return token
 }
 
@@ -141,6 +145,15 @@ export function token_has_error(token) {
  */
 export function token_has_message(token) {
 	return token.error_message.length > 0 || token.suggest_message.length > 0
+}
+
+/**
+ * 
+ * @param {Token} token 
+ * @param {string} tag 
+ */
+export function add_tag_to_token(token, tag) {
+	token.tag = token.tag ? `${token.tag}|${tag}` : tag
 }
 
 /**

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -382,10 +382,13 @@ const checker_rules_json = [
 		'trigger': { 'token': 'all' },
 		'context': {
 			'notfollowedby': [
-				{ 'token': 'of|_generic', 'skip': [
-					{ 'token': 'the|those|these' },
-					{ 'category': 'Noun' },
-				]},
+				{
+					'token': 'of|_generic',
+					'skip': [
+						{ 'token': 'the|those|these' },
+						{ 'category': 'Noun' },
+					],
+				},
 			],
 		},
 		'suggest': {

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -534,25 +534,29 @@ const builtin_checker_rules = [
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
 			context: create_context_filter({}),
 			action: create_token_modify_action(token => {
-				check_has_ontology_results(token)
+				check_lookup_results(token)
 
 				if (token.complex_pairing) {
-					check_has_ontology_results(token.complex_pairing)
+					check_lookup_results(token.complex_pairing)
 				}
 				
 				/**
 				 * 
 				 * @param {Token} token 
 				 */
-				function check_has_ontology_results(token) {
-					if (token.lookup_results.some(result => result.concept)) {
+				function check_lookup_results(token) {
+					if (token.lookup_results.some(result => result.concept !== null && result.concept.id !== '0')) {
 						return
 					}
 
-					token.suggest_message = 'This word is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.'
-	
-					if (token.lookup_results.some(result => result.how_to.length > 0)) {
+					if (token.lookup_results.at(0)?.concept?.id === '0') {
+						token.suggest_message = 'This word is not yet in the Ontology, but should be soon. Consult the How-To document for more info.'
+
+					} else if (token.lookup_results.some(result => result.how_to.length > 0)) {
 						token.error_message = 'This word is not in the Ontology. Hover over the word for hints from the How-To document.'
+						
+					} else {
+						token.suggest_message = 'This word is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.'
 					}
 				}
 			}),

--- a/app/src/lib/rules/checker_rules.test.js
+++ b/app/src/lib/rules/checker_rules.test.js
@@ -34,9 +34,7 @@ function create_lookup_token(token, { lookup_results=[] }={}) {
  * @returns {Sentence}
  */
 function create_sentence(tokens) {
-	const clause = create_clause_token(tokens)
-	clause.tag = 'main_clause'
-	return { clause }
+	return { clause: create_clause_token(tokens, 'main_clause') }
 }
 
 /**

--- a/app/src/lib/rules/index.js
+++ b/app/src/lib/rules/index.js
@@ -6,12 +6,16 @@ import { rules_applier } from './rules_processor'
 import { TRANSFORM_RULES } from './transform_rules'
 import { PRONOUN_RULES } from './pronoun_rules'
 
+const RULES = {
+	PRONOUN: PRONOUN_RULES,
+	LOOKUP: LOOKUP_RULES,
+	SYNTAX: SYNTAX_RULES,
+	PART_OF_SPEECH: PART_OF_SPEECH_RULES,
+	TRANSFORM: TRANSFORM_RULES,
+	CHECKER: CHECKER_RULES,
+}
+
 export {
 	rules_applier,
-	PRONOUN_RULES,
-	LOOKUP_RULES,
-	PART_OF_SPEECH_RULES,
-	TRANSFORM_RULES,
-	CHECKER_RULES,
-	SYNTAX_RULES,
+	RULES,
 }

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -1,4 +1,4 @@
-import { apply_token_transforms, create_context_filter, create_token_filter, create_token_transform } from '$lib/rules/rules_parser'
+import { apply_token_transforms, create_context_filter, create_token_filter, create_token_transforms } from '$lib/rules/rules_parser'
 import { TOKEN_TYPE } from '../parser/token'
 
 /**
@@ -157,8 +157,7 @@ export function parse_lookup_rule(rule_json) {
 	const lookup_term = rule_json['lookup']
 	const combine = rule_json['combine'] ?? 0
 
-	// TODO support multiple transforms if context requires multiple tokens
-	const context_transforms = [create_token_transform(rule_json['context_transform'])]
+	const context_transforms = create_token_transforms(rule_json['context_transform'])
 
 	return {
 		trigger,

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -225,9 +225,6 @@ const builtin_part_of_speech_rules = [
 				const left_categories = new Set(left.lookup_results.map(result => result.part_of_speech))
 				const right_categories = new Set(right.lookup_results.map(result => result.part_of_speech))
 				const overlapping_categories = new Set([...left_categories].filter(x => right_categories.has(x)))
-				console.log(left_categories)
-				console.log(right_categories)
-				console.log(overlapping_categories)
 
 				if (overlapping_categories.size > 0) {
 					const category_filter = keep_parts_of_speech(overlapping_categories)

--- a/app/src/lib/rules/part_of_speech_rules.test.js
+++ b/app/src/lib/rules/part_of_speech_rules.test.js
@@ -1,0 +1,155 @@
+import { TOKEN_TYPE, create_clause_token, create_token, flatten_sentence } from '../parser/token'
+import { ERRORS } from '../parser/error_messages'
+import { apply_rules } from './rules_processor'
+import { describe, expect, test } from 'vitest'
+import { PART_OF_SPEECH_RULES } from './part_of_speech_rules'
+
+/**
+ * 
+ * @param {Token} left 
+ * @param {Token} right 
+ * @returns {Token}
+ */
+function create_pairing_token(left, right) {
+	left.complex_pairing = right
+	return left
+}
+
+/**
+ * 
+ * @param {string} token 
+ * @param {Object} [data={}] 
+ * @param {LookupResult[]} [data.lookup_results=[]] 
+ * @returns {Token}
+ */
+function create_lookup_token(token, { lookup_results=[] }={}) {
+	const lookup_token = create_token(token, TOKEN_TYPE.LOOKUP_WORD, { lookup_term: token })
+	lookup_token.lookup_results = lookup_results
+	return lookup_token
+}
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @returns {Sentence}
+ */
+function create_sentence(tokens) {
+	return { clause: create_clause_token(tokens, 'main_clause') }
+}
+
+/**
+ * 
+ * @param {string} stem
+ * @param {Object} [data={}] 
+ * @param {string} [data.sense='A'] 
+ * @param {string} [data.part_of_speech='Noun'] 
+ * @param {number} [data.level=1] 
+ * @returns {LookupResult}
+ */
+function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+	const concept = {
+		id: '0',
+		stem,
+		sense,
+		part_of_speech,
+		level,
+		gloss: '',
+		categorization: '',
+	}
+	return {
+		stem,
+		part_of_speech,
+		form: 'stem',
+		concept,
+		how_to: [],
+	}
+}
+
+describe('pairing part_of_speech disambiguation', () => {
+	test('both words fully match part_of_speech', () => {
+		const test_tokens = [create_sentence([
+			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
+			create_pairing_token(
+				create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
+				create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 2 })] }),
+			),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
+		])]
+
+		const checked_tokens = apply_rules(test_tokens, PART_OF_SPEECH_RULES)
+
+		expect(checked_tokens).toEqual(test_tokens)
+	})
+	test('overlap with one part_of_speech', () => {
+		const test_tokens = [create_sentence([
+			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
+			create_pairing_token(
+				create_lookup_token('first', { lookup_results: [
+					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
+					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
+				] }),
+				create_lookup_token('second', { lookup_results: [
+					create_lookup_result('second', { part_of_speech: 'Verb', level: 2 }),
+					create_lookup_result('second', { part_of_speech: 'Adjective', level: 2 }),
+				] }),
+			),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
+		])]
+
+		const checked_tokens = apply_rules(test_tokens, PART_OF_SPEECH_RULES).flatMap(flatten_sentence)
+
+		expect(checked_tokens[1].error_message).toBe('')
+		expect(checked_tokens[1].lookup_results.length).toBe(1)
+		expect(checked_tokens[1].lookup_results[0].part_of_speech).toBe('Verb')
+
+		expect(checked_tokens[1].complex_pairing?.error_message).toBe('')
+		expect(checked_tokens[1].complex_pairing?.lookup_results.length).toBe(1)
+		expect(checked_tokens[1].complex_pairing?.lookup_results[0].part_of_speech).toBe('Verb')
+	})
+	test('overlap with two part_of_speech', () => {
+		const test_tokens = [create_sentence([
+			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
+			create_pairing_token(
+				create_lookup_token('first', { lookup_results: [
+					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
+					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
+				] }),
+				create_lookup_token('second', { lookup_results: [
+					create_lookup_result('second', { part_of_speech: 'Verb', level: 2 }),
+					create_lookup_result('second', { part_of_speech: 'Noun', level: 2 }),
+				] }),
+			),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
+		])]
+
+		const checked_tokens = apply_rules(test_tokens, PART_OF_SPEECH_RULES)
+
+		expect(checked_tokens).toEqual(test_tokens)
+	})
+	test('overlap with no part_of_speech', () => {
+		const test_tokens = [create_sentence([
+			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
+			create_pairing_token(
+				create_lookup_token('first', { lookup_results: [
+					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
+					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
+				] }),
+				create_lookup_token('second', { lookup_results: [
+					create_lookup_result('second', { part_of_speech: 'Adjective', level: 2 }),
+					create_lookup_result('second', { part_of_speech: 'Adverb', level: 2 }),
+				] }),
+			),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
+		])]
+
+		const checked_tokens = apply_rules(test_tokens, PART_OF_SPEECH_RULES).flatMap(flatten_sentence)
+
+		expect(checked_tokens[1].error_message).toBe(ERRORS.PAIRING_DIFFERENT_PARTS_OF_SPEECH)
+		expect(checked_tokens[1].lookup_results.length).toBe(2)
+
+		expect(checked_tokens[1].complex_pairing?.error_message).toBe('')
+		expect(checked_tokens[1].complex_pairing?.lookup_results.length).toBe(2)
+	})
+})
+
+// TODO add tests for possessive and pronoun-based rules

--- a/app/src/lib/rules/pronoun_rules.js
+++ b/app/src/lib/rules/pronoun_rules.js
@@ -1,5 +1,5 @@
 import { create_context_filter, create_token_map_action } from './rules_parser'
-import { TOKEN_TYPE, convert_to_error_token, token_has_error } from '../parser/token'
+import { TOKEN_TYPE, add_tag_to_token, convert_to_error_token, token_has_error } from '../parser/token'
 
 const FIRST_PERSON = ['i', 'me', 'my', 'myself', 'we', 'us', 'our', 'ourselves']
 const SECOND_PERSON = ['you', 'your', 'yourself', 'yourselves']
@@ -31,6 +31,9 @@ export const PRONOUN_TAGS = new Map([
 	['each-other', 'reciprocal'],
 ])
 
+/**
+ * These rules are a subset of the syntax rules
+ */
 /** @type {BuiltInRule[]} */
 const builtin_pronoun_rules = [
 	{
@@ -67,7 +70,7 @@ const builtin_pronoun_rules = [
 				const tag = PRONOUN_TAGS.get(normalized_pronoun)
 				const message = PRONOUN_MESSAGES.get(normalized_pronoun)
 				if (tag) {
-					return { ...token, tag }
+					add_tag_to_token(token, tag)
 				} else if (message) {
 					token.pronoun = convert_to_error_token(pronoun, message)
 				} else {

--- a/app/src/lib/rules/rules_parser.test.js
+++ b/app/src/lib/rules/rules_parser.test.js
@@ -421,7 +421,7 @@ describe('token transforms', () => {
 		expect(result.error_message).toBe(token.error_message)
 	})
 	test('concept with lookup results', () => {
-		const transform_json = { 'concept': 'concept-A' }
+		const transform_json = { 'concept': 'concept-B' }
 		const transform = create_token_transform(transform_json)
 
 		const token = create_token('token', TOKEN_TYPE.LOOKUP_WORD, { lookup_term: 'token' })
@@ -434,9 +434,8 @@ describe('token transforms', () => {
 		expect(result.token).toBe(token.token)
 		expect(result.type).toBe(token.type)
 		expect(result.lookup_terms.length).toBe(1)
-		expect(result.lookup_terms[0]).toBe('concept-A')
-		expect(result.lookup_results.length).toBe(1)
-		expect(result.lookup_results[0].concept?.sense).toBe('A')
+		expect(result.lookup_results.length).toBe(2)
+		expect(result.lookup_results[0].concept?.sense).toBe('B')
 		expect(result.error_message).toBe(token.error_message)
 	})
 	test('type and tag', () => {

--- a/app/src/lib/rules/rules_processor.js
+++ b/app/src/lib/rules/rules_processor.js
@@ -32,33 +32,33 @@ export function apply_rules(sentences, rules) {
 
 		return tokens
 	}
+}
 
-	/**
-	 * 
-	 * @param {Token[]} tokens
-	 * @param {TokenRule} rule
-	 * @returns {Token[]}
-	 */
-	function apply_rule_to_tokens(tokens, rule) {
-		if (tokens.length === 0) {
-			return tokens
-		}
-
-		for (let i = 0; i < tokens.length;) {
-			tokens[i].sub_tokens = apply_rule_to_tokens(tokens[i].sub_tokens, rule)
-
-			if (!rule.trigger(tokens[i])) {
-				i++
-				continue
-			}
-			const context_result = rule.context(tokens, i)
-			if (!context_result.success) {
-				i++
-				continue
-			}
-			i = rule.action(tokens, i, context_result.indexes)
-		}
-
+/**
+ * 
+ * @param {Token[]} tokens
+ * @param {TokenRule} rule
+ * @returns {Token[]}
+ */
+export function apply_rule_to_tokens(tokens, rule) {
+	if (tokens.length === 0) {
 		return tokens
 	}
+
+	for (let i = 0; i < tokens.length;) {
+		tokens[i].sub_tokens = apply_rule_to_tokens(tokens[i].sub_tokens, rule)
+
+		if (!rule.trigger(tokens[i])) {
+			i++
+			continue
+		}
+		const context_result = rule.context(tokens, i)
+		if (!context_result.success) {
+			i++
+			continue
+		}
+		i = rule.action(tokens, i, context_result.indexes)
+	}
+
+	return tokens
 }

--- a/app/src/lib/rules/rules_processor.test.js
+++ b/app/src/lib/rules/rules_processor.test.js
@@ -149,17 +149,12 @@ describe('transform rules', () => {
 		expect(results[0].tag).toBe('tag')
 	})
 
-	test('concept does not get overwritten', () => {
+	test('concept selected is brought to top of results', () => {
 		const transform_rules = [
 			{
 				'trigger': { 'token': 'saw' },
 				'context': { 'followedby': 'all' },
-				'transform': { 'concept': 'see-A' },
-			},
-			{
-				'trigger': { 'token': 'saw' },
-				'context': { 'followedby': { 'token': 'cat', 'skip': 'all' } },
-				'transform': { 'concept': 'see-B' },
+				'transform': { 'concept': 'see-C' },
 			},
 		].map(parse_transform_rule)
 
@@ -180,7 +175,9 @@ describe('transform rules', () => {
 
 		const results = apply_rules(tokens, transform_rules).flatMap(flatten_sentence)
 
-		expect(results[1].lookup_terms[0]).toBe('see-A')
+		expect(results[1].lookup_results[0].concept?.stem).toBe('see')
+		expect(results[1].lookup_results[0].concept?.sense).toBe('C')
+		expect(results[1].lookup_results.length).toBe(3)
 	})
 
 	test('not triggered across sentences', () => {

--- a/app/src/lib/rules/syntax_rules.js
+++ b/app/src/lib/rules/syntax_rules.js
@@ -1,80 +1,27 @@
-import { create_context_filter, create_token_filter, create_token_modify_action } from './rules_parser'
-import { REGEXES } from '$lib/regexes'
-import { TOKEN_TYPE } from '$lib/parser/token'
 import { ERRORS } from '$lib/parser/error_messages'
+import { TOKEN_TYPE, add_tag_to_token } from '$lib/parser/token'
+import { REGEXES } from '$lib/regexes'
+import { PRONOUN_RULES } from './pronoun_rules'
+import { create_context_filter, create_token_filter, create_token_modify_action } from './rules_parser'
 
 /**
- * These rules are hardcoded because they shouldn't need to be edited or added to by the user.
- * They don't need to be extendable, but are still able to be used within the rule system.
+ * These rules are for tagging tokens based on the syntax. These cannot rely on any lookup data.
  */
 /** @type {BuiltInRule[]} */
 const builtin_syntax_rules = [
 	{
-		name: 'A subordinate clause is a Patient by default',
-		comment: '',
-		rule: {
-			trigger: token_is_subordinate_clause,
-			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				token.tag = 'patient_clause'
-			}),
-		},
-	},
-	{
 		name: 'Set tag for quote clauses',
 		comment: '',
 		rule: {
-			trigger: subordinate_clause_starts_with(create_token_filter({ 'token': '"' })),
-			context: create_context_filter({}),
+			trigger: create_token_filter({ 'tag': 'subordinate_clause' }),
+			context: create_context_filter({ 'subtokens': { 'token': '"', 'skip': { 'token': '[' } } }),
 			action: create_token_modify_action(token => {
 				token.tag = 'patient_clause|quote_begin'
 			}),
 		},
 	},
 	{
-		name: 'Set tag for relative clauses based on relativizer',
-		comment: 'removes extra tags for words like "who" and "which". "that" is handled again in the next rule',
-		rule: {
-			trigger: subordinate_clause_starts_with(create_token_filter({ 'tag': 'relativizer' })),
-			context: create_context_filter({ 'precededby': { 'category': 'Noun' } }),
-			action: create_token_modify_action(token => {
-				const relativizer = token.sub_tokens[1]
-				if (relativizer.token === 'that') {
-					// 'that' could also be a complementizer here
-					token.tag = 'relative_clause|patient_clause'
-					relativizer.tag = 'relativizer|complementizer'
-				} else {
-					token.tag = 'relative_clause'
-					relativizer.tag = 'relativizer'
-				}
-			}),
-		},
-	},
-	{
-		name: 'Set tag for "that" when not preceded by a Noun',
-		comment: '"that" can only be a complementizer in this case',
-		rule: {
-			trigger: subordinate_clause_starts_with(create_token_filter({ 'token': 'that' })),
-			context: create_context_filter({ 'notprecededby': { 'category': 'Noun' } }),
-			action: create_token_modify_action(token => {
-				token.tag = 'patient_clause'
-				token.sub_tokens[1].tag = 'complementizer'
-			}),
-		},
-	},
-	{
-		name: 'All Clauses that have adpositions are Adverbial clauses',
-		comment: '',
-		rule: {
-			trigger: subordinate_clause_starts_with(create_token_filter({ 'category': 'Adposition' })),
-			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				token.tag = 'adverbial_clause'
-			}),
-		},
-	},
-	{
-		name: 'Check capitalization for first word in a sentence or quote',
+		name: 'Set tag for first words of sentences',
 		comment: '',
 		rule: {
 			trigger: create_token_filter({ 'tag': 'main_clause|quote_begin' }),
@@ -86,9 +33,21 @@ const builtin_syntax_rules = [
 					return
 				}
 
-				word_token.tag = word_token.tag ? `${word_token.tag}|first_word` : 'first_word'
-				const token_to_test = word_token.pronoun ? word_token.pronoun : word_token
-
+				add_tag_to_token(word_token, 'first_word')
+			}),
+		},
+	},
+	{
+		name: 'Check capitalization for first word in a sentence or quote',
+		comment: '',
+		rule: {
+			trigger: create_token_filter({ 'tag': 'first_word' }),
+			context: create_context_filter({}),
+			action: create_token_modify_action(token => {
+				// While this check may make more sense in the checker rules, it must be done here
+				// before the 'first_word' tag possibly gets overwritten in the transform rules.
+				// TODO expand the 'tag' system so things don't get overwritten?
+				const token_to_test = token.pronoun ? token.pronoun : token
 				if (starts_lowercase(token_to_test.token)) {
 					token_to_test.error_message = token_to_test.error_message || ERRORS.FIRST_WORD_NOT_CAPITALIZED
 				}
@@ -96,100 +55,19 @@ const builtin_syntax_rules = [
 		},
 	},
 	{
-		name: 'Filter lookup results based on upper/lowercase for words not at the start of the sentence.',
-		comment: '',
-		rule: {
-			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && !token.tag.includes('first_word'),
-			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				filter_results_by_capitalization(token)
-				if (token.complex_pairing) {
-					filter_results_by_capitalization(token.complex_pairing)
-				}
-			}),
-		},
-	},
-	{
-		name: 'Words with a pronoun must be a noun.',
-		comment: '',
-		rule: {
-			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && token.pronoun !== null,
-			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				filter_results_by_part_of_speech(token, new Set(['Noun']))
-			}),
-		},
-	},
-	{
-		name: "Tag words with a possessive 's as genitive_saxon",
+		name: "Set tag for words with possessive 's  as genitive_saxon",
 		comment: '',
 		rule: {
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && REGEXES.HAS_POSSESSIVE.test(token.token),
 			context: create_context_filter({}),
 			action: create_token_modify_action(token => {
-				token.tag = token.tag ? `${token.tag}|genitive_saxon` : 'genitive_saxon'
-			}),
-		},
-	},
-	{
-		name: 'Filter lookup results for pairings based on part of speech',
-		comment: '',
-		rule: {
-			trigger: token => !!(token.lookup_results.length && token.complex_pairing?.lookup_results.length),
-			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				/** @type {Token[]} */
-				// @ts-ignore
-				const [left, right] = [token, token.complex_pairing]
-
-				// filter lookup results based on the overlap of the two concepts
-				const left_categories = new Set(left.lookup_results.map(result => result.part_of_speech))
-				const right_categories = new Set(right.lookup_results.map(result => result.part_of_speech))
-				const overlapping_categories = new Set([...left_categories].filter(x => right_categories.has(x)))
-
-				if (overlapping_categories.size > 0) {
-					filter_results_by_part_of_speech(left, overlapping_categories)
-					filter_results_by_part_of_speech(right, overlapping_categories)
-				} else {
-					left.error_message = ERRORS.PAIRING_DIFFERENT_PARTS_OF_SPEECH
-				}
-			}),
-		},
-	},
-	{
-		name: 'Remove lookup results for certain functional Adpositions (up, down, etc)',
-		comment: 'While these have an entry in the Ontoloy, they are only used in the Analyzer with specific Verbs. They should not be recognized as words on their own.',
-		rule: {
-			trigger: create_token_filter({ 'token': 'down|off|out|up' }),
-			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				token.lookup_results = []
+				add_tag_to_token(token, 'genitive_saxon')
 			}),
 		},
 	},
 ]
 
-export const SYNTAX_RULES = builtin_syntax_rules.map(({ rule }) => rule)
-
-/**
- * 
- * @param {Token} token 
- */
-function token_is_subordinate_clause(token) {
-	return token.type === TOKEN_TYPE.CLAUSE && !token.tag.includes('main_clause')
-}
-
-/**
- * 
- * @param {TokenFilter} first_token_filter 
- * @returns {TokenFilter}
- */
-function subordinate_clause_starts_with(first_token_filter) {
-	return clause => clause.type === TOKEN_TYPE.CLAUSE
-		&& !clause.tag.includes('main_clause')
-		&& clause.sub_tokens.length > 1
-		&& first_token_filter(clause.sub_tokens[1])		// skip the '['
-}
+export const SYNTAX_RULES = builtin_syntax_rules.map(({ rule }) => rule).concat(PRONOUN_RULES)
 
 /**
  * 
@@ -229,24 +107,4 @@ export function find_first_word(token) {
  */
 function starts_lowercase(text) {
 	return REGEXES.STARTS_LOWERCASE.test(text)
-}
-
-/**
- * 
- * @param {Token} token 
- */
-function filter_results_by_capitalization(token) {
-	// filter results based on capitalization
-	token.lookup_results = starts_lowercase(token.token)
-		? token.lookup_results.filter(result => starts_lowercase(result.stem))
-		: token.lookup_results.filter(result => !starts_lowercase(result.stem))
-}
-
-/**
- * 
- * @param {Token} token 
- * @param {Set<string>} parts_of_speech 
- */
-function filter_results_by_part_of_speech(token, parts_of_speech) {
-	token.lookup_results = token.lookup_results.filter(result => parts_of_speech.has(result.part_of_speech))
 }

--- a/app/src/lib/rules/syntax_rules.test.js
+++ b/app/src/lib/rules/syntax_rules.test.js
@@ -1,34 +1,137 @@
-import { TOKEN_TYPE, create_clause_token, create_token, flatten_sentence, token_has_error } from '../parser/token'
-import { ERRORS } from '../parser/error_messages'
+import { TOKEN_TYPE, create_clause_token, create_token, flatten_sentence } from '../parser/token'
 import { apply_rules } from './rules_processor'
 import { SYNTAX_RULES } from './syntax_rules'
 import { tokenize_input } from '$lib/parser/tokenize'
 import { clausify } from '$lib/parser/clausify'
 import { describe, expect, test } from 'vitest'
+import { ERRORS } from '$lib/parser/error_messages'
 
-/**
- *
- * @param {string[]} tokens
- * @returns {Token[]}
- */
-function create_tokens(tokens) {
-	return tokens.map(token => create_token(token, select_token_type(token)))
 
-	/**
-	 * 
-	 * @param {string} token 
-	 * @returns {TokenType}
-	 */
-	function select_token_type(token) {
-		if (token.length === 1) {
-			return TOKEN_TYPE.PUNCTUATION
-		}
-		if (token[0] === '_' || token[0] === '(') {
-			return TOKEN_TYPE.NOTE
-		}
-		return TOKEN_TYPE.LOOKUP_WORD
-	}
-}
+describe('sentence syntax: tag setting', () => {
+	test('quote_begin clause tag', () => {
+		const test_tokens = clausify(tokenize_input('People [] say [] person ["].'))
+
+		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES)
+		const clause_tokens = checked_tokens[0].clause.sub_tokens
+		
+		expect(clause_tokens[1].type).toBe(TOKEN_TYPE.CLAUSE)
+		expect(clause_tokens[1].tag).toBe('subordinate_clause')
+		expect(clause_tokens[3].type).toBe(TOKEN_TYPE.CLAUSE)
+		expect(clause_tokens[3].tag).toBe('subordinate_clause')
+		expect(clause_tokens[5].type).toBe(TOKEN_TYPE.CLAUSE)
+		expect(clause_tokens[5].tag).toBe('patient_clause|quote_begin')
+	})
+})
+
+describe('sentence syntax: first_word detection', () => {
+	test('. empty sentence', () => {
+		const test_tokens = clausify(tokenize_input('.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
+
+		expect(result_tokens).toEqual(test_tokens)
+	})
+	test('Token token.', () => {
+		const test_tokens = clausify(tokenize_input('Token token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toBe('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+	})
+	test('Token. Token.', () => {
+		const test_tokens = clausify(tokenize_input('Token. Token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toBe('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).toBe('first_word')
+		expect(result_tokens[3].tag).not.toBe('first_word')
+	})
+	test('.5 token. 100 token. numbers count as a word', () => {
+		const test_tokens = clausify(tokenize_input('.5 token. 100 token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toBe('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+		expect(result_tokens[3].tag).toBe('first_word')
+		expect(result_tokens[4].tag).not.toBe('first_word')
+		expect(result_tokens[5].tag).not.toBe('first_word')
+	})
+	test('_note Token. (imp) Token. notes get skipped over', () => {
+		const test_tokens = clausify(tokenize_input('_note Token. (imp) Token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).not.toBe('first_word')
+		expect(result_tokens[1].tag).toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+		expect(result_tokens[3].tag).not.toBe('first_word')
+		expect(result_tokens[4].tag).toBe('first_word')
+		expect(result_tokens[5].tag).not.toBe('first_word')
+	})
+	test('[Token] token. first word in nested clause', () => {
+		const test_tokens = clausify(tokenize_input('[Token] token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).not.toBe('first_word')
+		expect(result_tokens[1].tag).toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+		expect(result_tokens[3].tag).not.toBe('first_word')
+		expect(result_tokens[4].tag).not.toBe('first_word')
+	})
+	test('[[Token]] token. first word in double nested clause', () => {
+		const test_tokens = clausify(tokenize_input('[[Token]] token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).not.toBe('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).toBe('first_word')
+		expect(result_tokens[3].tag).not.toBe('first_word')
+		expect(result_tokens[4].tag).not.toBe('first_word')
+		expect(result_tokens[5].tag).not.toBe('first_word')
+		expect(result_tokens[6].tag).not.toBe('first_word')
+	})
+	test('A token. function words get tagged', () => {
+		const test_tokens = clausify(tokenize_input('A token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toContain('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+	})
+	test('Followers/disciples token. pairings get tagged', () => {
+		const test_tokens = clausify(tokenize_input('Followers/disciples token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toBe('first_word')
+		expect(result_tokens[0].complex_pairing?.tag).not.toBe('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+	})
+	test('You(token) token. pronoun referents get tagged', () => {
+		const test_tokens = clausify(tokenize_input('You(token) token.'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toContain('first_word')
+		expect(result_tokens[0].pronoun?.tag).not.toBe('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+	})
+	test('Token [token] ["Token"]. words in quote clauses get tagged, but not other subordinate clauses', () => {
+		const test_tokens = clausify(tokenize_input('Token [token] ["Token"].'))
+		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
+
+		expect(result_tokens[0].tag).toContain('first_word')
+		expect(result_tokens[1].tag).not.toBe('first_word')
+		expect(result_tokens[2].tag).not.toBe('first_word')
+		expect(result_tokens[3].tag).not.toBe('first_word')
+		expect(result_tokens[4].tag).not.toBe('first_word')
+		expect(result_tokens[5].tag).not.toBe('first_word')
+		expect(result_tokens[6].tag).toContain('first_word')
+		expect(result_tokens[7].tag).not.toBe('first_word')
+		expect(result_tokens[8].tag).not.toBe('first_word')
+		expect(result_tokens[9].tag).not.toBe('first_word')
+	})
+})
 
 /**
  * 
@@ -46,10 +149,11 @@ function create_pairing_token(left, right) {
  * @param {string} token 
  * @param {Object} [data={}] 
  * @param {LookupResult[]} [data.lookup_results=[]] 
+ * @param {string} [data.tag=''] 
  * @returns {Token}
  */
-function create_lookup_token(token, { lookup_results=[] }={}) {
-	const lookup_token = create_token(token, TOKEN_TYPE.LOOKUP_WORD, { lookup_term: token })
+function create_lookup_token(token, { lookup_results=[], tag='' }={}) {
+	const lookup_token = create_token(token, TOKEN_TYPE.LOOKUP_WORD, { lookup_term: token, tag })
 	lookup_token.lookup_results = lookup_results
 	return lookup_token
 }
@@ -60,448 +164,42 @@ function create_lookup_token(token, { lookup_results=[] }={}) {
  * @returns {Sentence}
  */
 function create_sentence(tokens) {
-	const clause = create_clause_token(tokens)
-	clause.tag = 'main_clause'
-	return { clause }
-}
-
-/**
- * 
- * @param {string} stem
- * @param {Object} [data={}] 
- * @param {string} [data.sense='A'] 
- * @param {string} [data.part_of_speech='Noun'] 
- * @param {number} [data.level=1] 
- * @returns {LookupResult}
- */
-function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
-	const concept = {
-		id: '0',
-		stem,
-		sense,
-		part_of_speech,
-		level,
-		gloss: '',
-		categorization: '',
-	}
-	return {
-		stem,
-		part_of_speech,
-		form: 'stem',
-		concept,
-		how_to: [],
-	}
-}
-
-/**
- *
- * @param {number} index
- * @param {string} message
- * @param {Token[]} tokens
- */
-function expect_error_at(index, message, tokens) {
-	for (let [i, token] of tokens.entries()) {
-		if (i === index) {
-			expect(token_has_error(token)).toBe(true)
-			expect(token.error_message).toEqual(message)
-		} else {
-			expect(token.error_message).toBe('')
-		}
-	}
+	return { clause: create_clause_token(tokens, 'main_clause') }
 }
 
 describe('sentence syntax: capitalization', () => {
-	describe('valid', () => {
-		test('. empty sentence', () => {
-			const test_tokens = [create_sentence([])]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('Token token.', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['Token', 'token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('Token. Token.', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['Token', '.'])),
-				create_sentence(create_tokens(['Token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('.5 token. numbers don\'t need to be checked', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['.5', 'token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('100 token. numbers don\'t need to be checked', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['100', 'token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('_note Token. notes get skipped over', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['_note', 'Token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('(imp) Token. notes get skipped over', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['(imp)', 'Token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('Token. _note Token.', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['Token', '.'])),
-				create_sentence(create_tokens(['_note', 'Token', '.'])),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('[Token] token. nested clauses get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_clause_token(create_tokens(['[', 'Token', ']'])),
-					...create_tokens(['token', '.']),
-				]),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('[[Token]] token. nested clauses get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_clause_token([
-						create_token('[', TOKEN_TYPE.PUNCTUATION),
-						create_clause_token(create_tokens(['[', 'Token', ']'])),
-						create_token(']', TOKEN_TYPE.PUNCTUATION),
-					]),
-					...create_tokens(['token', '.']),
-				]),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('To token. function words get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_token('To', TOKEN_TYPE.FUNCTION_WORD),
-					create_token('token', TOKEN_TYPE.LOOKUP_WORD),
-					create_token('.', TOKEN_TYPE.PUNCTUATION),
-				]),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-		test('Followers/disciples token. pairings get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_token('Followers', TOKEN_TYPE.LOOKUP_WORD, { pairing: create_token('disciples', TOKEN_TYPE.LOOKUP_WORD) }),
-					create_token('token', TOKEN_TYPE.LOOKUP_WORD),
-					create_token('.', TOKEN_TYPE.PUNCTUATION),
-				]),
-			]
-			const result_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-			expect(result_tokens).toEqual(test_tokens)
-		})
-	})
-
-	describe('invalid', () => {
-		test('token.', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['token', '.'])),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(2)
-			expect_error_at(0, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('Token. token.', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['Token', '.'])),
-				create_sentence(create_tokens(['token', '.'])),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(4)
-			expect_error_at(2, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('_note token. notes get skipped over', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['_note', 'token', '.'])),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(3)
-			expect_error_at(1, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('(imp) token. notes get skipped over', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['(imp)', 'token', '.'])),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(3)
-			expect_error_at(1, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('Token. _note token.', () => {
-			const test_tokens = [
-				create_sentence(create_tokens(['Token', '.'])),
-				create_sentence(create_tokens(['_note', 'token', '.'])),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(5)
-			expect_error_at(3, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('[token] token. nested clauses get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_clause_token(create_tokens(['[', 'token', ']'])),
-					...create_tokens(['token', '.']),
-				]),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(5)
-			expect_error_at(1, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('[[token]] token. nested clauses get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_clause_token([
-						create_token('[', TOKEN_TYPE.PUNCTUATION),
-						create_clause_token(create_tokens(['[', 'token', ']'])),
-						create_token(']', TOKEN_TYPE.PUNCTUATION),
-					]),
-					...create_tokens(['token', '.']),
-				]),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(7)
-			expect_error_at(2, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('to. function words get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_token('to', TOKEN_TYPE.FUNCTION_WORD),
-					create_token('token', TOKEN_TYPE.LOOKUP_WORD),
-					create_token('.', TOKEN_TYPE.PUNCTUATION),
-				]),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(3)
-			expect_error_at(0, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('followers/disciples. pairings get checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_token('followers', TOKEN_TYPE.LOOKUP_WORD, { pairing: create_token('disciples', TOKEN_TYPE.LOOKUP_WORD) }),
-					create_token('token', TOKEN_TYPE.LOOKUP_WORD),
-					create_token('.', TOKEN_TYPE.PUNCTUATION),
-				]),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(3)
-			expect_error_at(0, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-		test('you go. an existing error doesn\'t get overwritten', () => {
-			const test_tokens = [
-				create_sentence([
-					create_token('you', TOKEN_TYPE.LOOKUP_WORD, { error: 'Some error' }),
-					create_token('go', TOKEN_TYPE.LOOKUP_WORD),
-					create_token('.', TOKEN_TYPE.PUNCTUATION),
-				]),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(3)
-			expect_error_at(0, 'Some error', checked_tokens)
-			expect(checked_tokens[1].error_message).toBe('')
-		})
-		test('Token, ["hello"]. beginning of quote is checked', () => {
-			const test_tokens = [
-				create_sentence([
-					create_token('Token', TOKEN_TYPE.LOOKUP_WORD),
-					create_token(',', TOKEN_TYPE.PUNCTUATION),
-					create_clause_token([
-						create_token('[', TOKEN_TYPE.PUNCTUATION),
-						create_token('"', TOKEN_TYPE.PUNCTUATION),
-						create_token('hello', TOKEN_TYPE.LOOKUP_WORD),
-						create_token('"', TOKEN_TYPE.PUNCTUATION),
-						create_token(']', TOKEN_TYPE.PUNCTUATION),
-					]),
-					create_token('.', TOKEN_TYPE.PUNCTUATION),
-				]),
-			]
-
-			const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-			expect(checked_tokens).length(8)
-			expect_error_at(4, ERRORS.FIRST_WORD_NOT_CAPITALIZED, checked_tokens)
-		})
-	})
-})
-
-describe('sentence syntax: tag setting', () => {
-	test('relative clause tag', () => {
-		const test_tokens = clausify(tokenize_input('People [who] say [who] person ["who].'))
-		test_tokens[0].clause.sub_tokens[0].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
-		test_tokens[0].clause.sub_tokens[2].lookup_results.push(create_lookup_result('say', { part_of_speech: 'Verb' }))
-		test_tokens[0].clause.sub_tokens[4].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
-
-		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-		const clause_tokens = checked_tokens[0].clause.sub_tokens
-		
-		expect(clause_tokens[1].type).toBe(TOKEN_TYPE.CLAUSE)
-		expect(clause_tokens[1].tag).toBe('relative_clause')
-		expect(clause_tokens[3].type).toBe(TOKEN_TYPE.CLAUSE)
-		expect(clause_tokens[3].tag).not.toBe('relative_clause')
-		expect(clause_tokens[5].type).toBe(TOKEN_TYPE.CLAUSE)
-		expect(clause_tokens[5].tag).not.toBe('relative_clause')
-	})
-	test('"that" clause tag', () => {
-		const test_tokens = clausify(tokenize_input('That person [that]. John saw [that].'))
-		test_tokens[0].clause.sub_tokens[1].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
-		test_tokens[1].clause.sub_tokens[1].lookup_results.push(create_lookup_result('see', { part_of_speech: 'Verb' }))
-
-		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-		
-		expect(checked_tokens[0].clause.sub_tokens[2].tag).toBe('relative_clause|patient_clause')
-		expect(checked_tokens[0].clause.sub_tokens[2].sub_tokens[1].tag).toBe('relativizer|complementizer')
-		
-		expect(checked_tokens[1].clause.sub_tokens[2].tag).toBe('patient_clause')
-		expect(checked_tokens[1].clause.sub_tokens[2].sub_tokens[1].tag).toBe('complementizer')
-	})
-	test('Adverbial clause tag', () => {
-		const test_tokens = clausify(tokenize_input('[Because].'))
-		test_tokens[0].clause.sub_tokens[0].sub_tokens[1].lookup_results.push(create_lookup_result('because', { part_of_speech: 'Adposition' }))
-
-		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-		const clause_tokens = checked_tokens[0].clause.sub_tokens
-		
-		expect(clause_tokens[0].tag).toBe('adverbial_clause')
-	})
-})
-
-describe('pairing part_of_speech disambiguation', () => {
-	test('both words fully match part_of_speech', () => {
+	test('valid', () => {
 		const test_tokens = [create_sentence([
-			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
+			create_lookup_token('Token', { tag: 'first_word'}),
 			create_pairing_token(
-				create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
-				create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 2 })] }),
+				create_lookup_token('First', { tag: 'first_word'}),
+				create_lookup_token('second'),
 			),
-			create_token('.', TOKEN_TYPE.PUNCTUATION),
+			create_token('Function', TOKEN_TYPE.FUNCTION_WORD, { tag: 'first_word' }),
+			create_token('name', TOKEN_TYPE.LOOKUP_WORD, { tag: 'first_word', pronoun: create_token('You', TOKEN_TYPE.FUNCTION_WORD) }),
 		])]
 
 		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES)
 
 		expect(checked_tokens).toEqual(test_tokens)
 	})
-	test('overlap with one part_of_speech', () => {
+
+	test('invalid', () => {
 		const test_tokens = [create_sentence([
-			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
+			create_lookup_token('token', { tag: 'first_word'}),
 			create_pairing_token(
-				create_lookup_token('first', { lookup_results: [
-					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
-					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
-				] }),
-				create_lookup_token('second', { lookup_results: [
-					create_lookup_result('second', { part_of_speech: 'Verb', level: 2 }),
-					create_lookup_result('second', { part_of_speech: 'Adjective', level: 2 }),
-				] }),
+				create_lookup_token('first', { tag: 'first_word'}),
+				create_lookup_token('second'),
 			),
-			create_token('.', TOKEN_TYPE.PUNCTUATION),
+			create_token('function', TOKEN_TYPE.FUNCTION_WORD, { tag: 'first_word' }),
+			create_token('name', TOKEN_TYPE.LOOKUP_WORD, { tag: 'first_word', pronoun: create_token('you', TOKEN_TYPE.FUNCTION_WORD) }),
 		])]
 
 		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
 
-		expect(checked_tokens[1].error_message).toBe('')
-		expect(checked_tokens[1].lookup_results.length).toBe(1)
-		expect(checked_tokens[1].lookup_results[0].part_of_speech).toBe('Verb')
-
-		expect(checked_tokens[1].complex_pairing?.error_message).toBe('')
-		expect(checked_tokens[1].complex_pairing?.lookup_results.length).toBe(1)
-		expect(checked_tokens[1].complex_pairing?.lookup_results[0].part_of_speech).toBe('Verb')
-	})
-	test('overlap with two part_of_speech', () => {
-		const test_tokens = [create_sentence([
-			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
-			create_pairing_token(
-				create_lookup_token('first', { lookup_results: [
-					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
-					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
-				] }),
-				create_lookup_token('second', { lookup_results: [
-					create_lookup_result('second', { part_of_speech: 'Verb', level: 2 }),
-					create_lookup_result('second', { part_of_speech: 'Noun', level: 2 }),
-				] }),
-			),
-			create_token('.', TOKEN_TYPE.PUNCTUATION),
-		])]
-
-		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES)
-
-		expect(checked_tokens).toEqual(test_tokens)
-	})
-	test('overlap with no part_of_speech', () => {
-		const test_tokens = [create_sentence([
-			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
-			create_pairing_token(
-				create_lookup_token('first', { lookup_results: [
-					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
-					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
-				] }),
-				create_lookup_token('second', { lookup_results: [
-					create_lookup_result('second', { part_of_speech: 'Adjective', level: 2 }),
-					create_lookup_result('second', { part_of_speech: 'Adverb', level: 2 }),
-				] }),
-			),
-			create_token('.', TOKEN_TYPE.PUNCTUATION),
-		])]
-
-		const checked_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
-
-		expect(checked_tokens[1].error_message).toBe(ERRORS.PAIRING_DIFFERENT_PARTS_OF_SPEECH)
-		expect(checked_tokens[1].lookup_results.length).toBe(2)
-
-		expect(checked_tokens[1].complex_pairing?.error_message).toBe('')
-		expect(checked_tokens[1].complex_pairing?.lookup_results.length).toBe(2)
+		expect(checked_tokens[0].error_message).toBe(ERRORS.FIRST_WORD_NOT_CAPITALIZED)
+		expect(checked_tokens[1].error_message).toBe(ERRORS.FIRST_WORD_NOT_CAPITALIZED)
+		expect(checked_tokens[2].error_message).toBe(ERRORS.FIRST_WORD_NOT_CAPITALIZED)
+		expect(checked_tokens[3].pronoun?.error_message).toBe(ERRORS.FIRST_WORD_NOT_CAPITALIZED)
 	})
 })

--- a/app/src/lib/rules/syntax_rules.test.js
+++ b/app/src/lib/rules/syntax_rules.test.js
@@ -170,9 +170,9 @@ function create_sentence(tokens) {
 describe('sentence syntax: capitalization', () => {
 	test('valid', () => {
 		const test_tokens = [create_sentence([
-			create_lookup_token('Token', { tag: 'first_word'}),
+			create_lookup_token('Token', { tag: 'first_word' }),
 			create_pairing_token(
-				create_lookup_token('First', { tag: 'first_word'}),
+				create_lookup_token('First', { tag: 'first_word' }),
 				create_lookup_token('second'),
 			),
 			create_token('Function', TOKEN_TYPE.FUNCTION_WORD, { tag: 'first_word' }),
@@ -186,9 +186,9 @@ describe('sentence syntax: capitalization', () => {
 
 	test('invalid', () => {
 		const test_tokens = [create_sentence([
-			create_lookup_token('token', { tag: 'first_word'}),
+			create_lookup_token('token', { tag: 'first_word' }),
 			create_pairing_token(
-				create_lookup_token('first', { tag: 'first_word'}),
+				create_lookup_token('first', { tag: 'first_word' }),
 				create_lookup_token('second'),
 			),
 			create_token('function', TOKEN_TYPE.FUNCTION_WORD, { tag: 'first_word' }),

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -261,7 +261,7 @@ const transform_rules_json = [
 			'notfollowedby': {
 				'category': 'Noun',
 				'skip': ['vp_modifiers', 'adjp'],
-			}
+			},
 		},
 		'transform': { 'concept': 'be-D' },
 	},
@@ -276,7 +276,7 @@ const transform_rules_json = [
 			'notfollowedby': {
 				'category': 'Noun',
 				'skip': ['vp_modifiers', 'adjp'],
-			}
+			},
 		},
 		'transform': { 'concept': 'become-A' },
 	},
@@ -358,8 +358,8 @@ const transform_rules_json = [
 		'name': 'tag head nouns',
 		'trigger': { 'category': 'Noun' },
 		'context': {
-			'notprecededby': [{ 'category': 'Noun'}, { 'token': 'of', 'skip': 'np_modifiers'}],
-			'notfollowedby': { 'category': 'Noun', 'skip': 'np_modifiers' }
+			'notprecededby': [{ 'category': 'Noun' }, { 'token': 'of', 'skip': 'np_modifiers' }],
+			'notfollowedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
 		},
 		'transform': { 'tag': 'head_np' },
 	},

--- a/app/src/lib/rules/transform_rules.test.js
+++ b/app/src/lib/rules/transform_rules.test.js
@@ -1,0 +1,68 @@
+import { TOKEN_TYPE } from '../parser/token'
+import { tokenize_input } from '../parser/tokenize'
+import { clausify } from '../parser/clausify'
+import { apply_rules } from './rules_processor'
+import { describe, expect, test } from 'vitest'
+import { TRANSFORM_RULES } from './transform_rules'
+
+/**
+ * 
+ * @param {string} stem
+ * @param {Object} [data={}] 
+ * @param {string} [data.sense='A'] 
+ * @param {string} [data.part_of_speech='Noun'] 
+ * @param {number} [data.level=1] 
+ * @returns {LookupResult}
+ */
+function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+	const concept = {
+		id: '0',
+		stem,
+		sense,
+		part_of_speech,
+		level,
+		gloss: '',
+		categorization: '',
+	}
+	return {
+		stem,
+		part_of_speech,
+		form: 'stem',
+		concept,
+		how_to: [],
+	}
+}
+
+describe('builtin tag setting', () => {
+	const TRANSFORM_RULES_BUILTIN = TRANSFORM_RULES.slice(0, 2)
+
+	test('relative clause tag', () => {
+		const test_tokens = clausify(tokenize_input('People [who] say [who] person ["who].'))
+		test_tokens[0].clause.sub_tokens[0].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
+		test_tokens[0].clause.sub_tokens[2].lookup_results.push(create_lookup_result('say', { part_of_speech: 'Verb' }))
+		test_tokens[0].clause.sub_tokens[4].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
+
+		const checked_tokens = apply_rules(test_tokens, TRANSFORM_RULES_BUILTIN)
+		const clause_tokens = checked_tokens[0].clause.sub_tokens
+		
+		expect(clause_tokens[1].type).toBe(TOKEN_TYPE.CLAUSE)
+		expect(clause_tokens[1].tag).toBe('relative_clause')
+		expect(clause_tokens[3].type).toBe(TOKEN_TYPE.CLAUSE)
+		expect(clause_tokens[3].tag).not.toBe('relative_clause')
+		expect(clause_tokens[5].type).toBe(TOKEN_TYPE.CLAUSE)
+		expect(clause_tokens[5].tag).not.toBe('relative_clause')
+	})
+	test('"that" clause tag', () => {
+		const test_tokens = clausify(tokenize_input('That person [that]. John saw [that].'))
+		test_tokens[0].clause.sub_tokens[1].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
+		test_tokens[1].clause.sub_tokens[1].lookup_results.push(create_lookup_result('see', { part_of_speech: 'Verb' }))
+
+		const checked_tokens = apply_rules(test_tokens, TRANSFORM_RULES_BUILTIN)
+		
+		expect(checked_tokens[0].clause.sub_tokens[2].tag).toBe('relative_clause')
+		expect(checked_tokens[0].clause.sub_tokens[2].sub_tokens[1].tag).toBe('relativizer')
+		
+		expect(checked_tokens[1].clause.sub_tokens[2].tag).toBe('subordinate_clause')
+		expect(checked_tokens[1].clause.sub_tokens[2].sub_tokens[1].tag).toBe('remote_demonstrative')
+	})
+})


### PR DESCRIPTION
### Enhance and refactor rules.
- support searching within subtokens
- support use of shorthand 'skip groups'
- move some `syntax_rules` into more logical places

### Added/updated several rules
- tag patient clauses more accurately (`quote_begin`, `same_subject`, or `stand_alone`)

- support `begin` along with `start`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0df14277-8619-447f-a542-09830a9ea565)

- Fix #83 with use of skip groups
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f95563ad-e5c9-4cba-b821-9c9048e2ceea)

### Support improved how-to lookup.
- Show warning that a word is not yet in the ontology but should be soon (could this be the first use-case of an 'info' message?)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/819d2d75-fa34-4799-af0b-24f9e1f647e7)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/ae978c37-2850-4252-b738-e14759fbd18d)

- support the improved api for the how-to lookup
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b2e99df4-d9a7-4d8f-9080-593edbf79753)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/33e30978-3634-438f-83bf-e634b9605f54)

- don't remove all other senses when selecting a sense via rules
-- Created #84 to handle a user-specified sense
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/5388f2d2-acf6-4826-9868-5a10a7ba136c)

