### PR TITLE
Add case frame rules

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -35,6 +35,7 @@ interface LookupResult extends LookupWord {
 	form: string
 	concept: OntologyResult | null
 	how_to: HowToResult[]
+	case_frame: CaseFrameResult
 }
 
 interface OntologyResult extends LookupWord {
@@ -96,4 +97,44 @@ type BuiltInRule = {
 	name: string
 	comment: string
 	rule: TokenRule
+}
+
+type RoleTag = string
+type WordSense = string
+type WordStem = string
+
+type ArgumentRoleRule = {
+	role_tag: RoleTag
+	trigger: TokenFilter
+	context: TokenContextFilter
+	action: RoleRuleAction
+	missing_message: string
+}
+
+type ArgumentRulesForSense = {
+	sense: WordSense
+	rules: ArgumentRoleRule[]
+	other_required: RoleTag[]
+	other_optional: RoleTag[]
+	patient_clause_type: RoleTag
+}
+
+type RoleRuleAction = (tokens: Token[], role_match: RoleMatchResult) => void
+
+type ArgumentMatchFilter = (tokens: Token[], role_matches: RoleMatchResult[]) => boolean
+
+type RoleMatchResult = {
+	role_tag: RoleTag
+	success: boolean
+	trigger_index: number
+	context_indexes: number[]
+}
+
+type CaseFrameResult = {
+	is_valid: boolean
+	is_checked: boolean
+	rule: ArgumentRulesForSense
+	valid_arguments: RoleMatchResult[]
+	extra_arguments: RoleMatchResult[]
+	missing_arguments: RoleTag[]
 }

--- a/app/src/lib/lookups.js
+++ b/app/src/lib/lookups.js
@@ -1,5 +1,6 @@
 import { TOKEN_TYPE, split_stem_and_sense } from './parser/token'
 import { REGEXES } from './regexes'
+import { create_case_frame, create_sense_argument_rule } from './rules/case_frame'
 import { create_context_filter, create_token_filter, create_token_modify_action } from './rules/rules_parser'
 import { apply_rule_to_tokens } from './rules/rules_processor'
 
@@ -201,6 +202,7 @@ async function check_how_to(lookup_token) {
  * @param {string} [other_data.form='stem'] 
  * @param {OntologyResult?} [other_data.concept=null] 
  * @param {HowToResult[]} [other_data.how_to=[]] 
+ * @returns {LookupResult}
  */
 function create_lookup_result({ stem, part_of_speech }, { form='stem', concept=null, how_to=[] }={}) {
 	return {
@@ -209,6 +211,7 @@ function create_lookup_result({ stem, part_of_speech }, { form='stem', concept=n
 		form,
 		concept,
 		how_to,
+		case_frame: create_case_frame({ is_valid: true, rule: create_sense_argument_rule({ sense: concept?.sense }) })
 	}
 }
 

--- a/app/src/lib/lookups.js
+++ b/app/src/lib/lookups.js
@@ -211,7 +211,7 @@ function create_lookup_result({ stem, part_of_speech }, { form='stem', concept=n
 		form,
 		concept,
 		how_to,
-		case_frame: create_case_frame({ is_valid: true, rule: create_sense_argument_rule({ sense: concept?.sense }) })
+		case_frame: create_case_frame({ is_valid: true, rule: create_sense_argument_rule({ sense: concept?.sense }) }),
 	}
 }
 

--- a/app/src/lib/lookups.js
+++ b/app/src/lib/lookups.js
@@ -1,6 +1,5 @@
-import { TOKEN_TYPE, split_stem_and_sense } from './parser/token'
+import { TOKEN_TYPE, split_stem_and_sense, create_lookup_result } from './parser/token'
 import { REGEXES } from './regexes'
-import { create_case_frame, create_sense_argument_rule } from './rules/case_frame'
 import { create_context_filter, create_token_filter, create_token_modify_action } from './rules/rules_parser'
 import { apply_rule_to_tokens } from './rules/rules_processor'
 
@@ -192,26 +191,6 @@ async function check_how_to(lookup_token) {
 		let matches = results.matches
 
 		return matches
-	}
-}
-
-/**
- * 
- * @param {LookupWord} lookup
- * @param {Object} [other_data={}] 
- * @param {string} [other_data.form='stem'] 
- * @param {OntologyResult?} [other_data.concept=null] 
- * @param {HowToResult[]} [other_data.how_to=[]] 
- * @returns {LookupResult}
- */
-function create_lookup_result({ stem, part_of_speech }, { form='stem', concept=null, how_to=[] }={}) {
-	return {
-		stem,
-		part_of_speech,
-		form,
-		concept,
-		how_to,
-		case_frame: create_case_frame({ is_valid: true, rule: create_sense_argument_rule({ sense: concept?.sense }) }),
 	}
 }
 

--- a/app/src/lib/parser/index.js
+++ b/app/src/lib/parser/index.js
@@ -22,6 +22,8 @@ export async function parse(text) {
 	return pipe(
 		rules_applier(RULES.PART_OF_SPEECH),
 		rules_applier(RULES.TRANSFORM),
+		rules_applier(RULES.CASE_FRAME),
+		rules_applier(RULES.SENSE),
 		rules_applier(RULES.CHECKER),
 		flatten_sentences,
 	)(with_lookups)
@@ -41,6 +43,8 @@ export function parse_for_test(text) {
 		rules_applier(RULES.LOOKUP),
 		rules_applier(RULES.PART_OF_SPEECH),
 		rules_applier(RULES.TRANSFORM),
+		rules_applier(RULES.CASE_FRAME),
+		rules_applier(RULES.SENSE),
 		rules_applier(RULES.CHECKER.slice(0,4)),	// TODO remove slice when e2e testing is set up (skips the 'no lookup' check)
 		flatten_sentences,
 	)(text)

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -194,3 +194,46 @@ export function flatten_sentence(sentence) {
 export function concept_with_sense(concept) {
 	return `${concept.stem}-${concept.sense}`
 }
+
+/**
+ * 
+ * @param {LookupWord} lookup
+ * @param {Object} [other_data={}] 
+ * @param {string} [other_data.form='stem'] 
+ * @param {OntologyResult?} [other_data.concept=null] 
+ * @param {HowToResult[]} [other_data.how_to=[]] 
+ * @param {CaseFrameResult?} [other_data.case_frame=null] 
+ * @returns {LookupResult}
+ */
+export function create_lookup_result({ stem, part_of_speech }, { form='stem', concept=null, how_to=[], case_frame=null }={}) {
+	return {
+		stem,
+		part_of_speech,
+		form,
+		concept,
+		how_to,
+		case_frame: case_frame ?? create_case_frame({ is_valid: true, is_checked: false }),
+	}
+}
+
+/**
+ * 
+ * @param {Object} [data={}] 
+ * @param {boolean} [data.is_valid=false] 
+ * @param {boolean} [data.is_checked=false] 
+ * @param {ArgumentRulesForSense?} [data.rule={}] 
+ * @param {RoleMatchResult[]} [data.valid_arguments=[]] 
+ * @param {RoleMatchResult[]} [data.extra_arguments=[]] 
+ * @param {RoleTag[]} [data.missing_arguments=[]] 
+ * @returns {CaseFrameResult}
+ */
+export function create_case_frame({ is_valid=false, is_checked=false, rule=null, valid_arguments=[], extra_arguments=[], missing_arguments=[] }={}) {
+	return {
+		is_valid,
+		is_checked,
+		rule: rule ?? { sense: '', rules: [], other_optional: [], other_required: [], patient_clause_type: '' },
+		valid_arguments,
+		extra_arguments,
+		missing_arguments,
+	}
+}

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -90,7 +90,18 @@ export function create_clause_token(sub_tokens, tag='subordinate_clause') {
 /**
  * 
  * @param {Token} token 
- * @param {string} concept must include the sense
+ * @param {WordSense} concept 
+ * @return {number}
+ */
+export function find_result_index(token, concept) {
+	const { stem, sense } = split_stem_and_sense(concept)
+	return token.lookup_results.findIndex(result => result.stem === stem && result.concept?.sense === sense)
+}
+
+/**
+ * 
+ * @param {Token} token 
+ * @param {WordSense} concept must include the sense
  * @returns {Token}
  */
 export function set_token_concept(token, concept) {
@@ -99,8 +110,7 @@ export function set_token_concept(token, concept) {
 		return token
 	}
 
-	const { stem, sense } = split_stem_and_sense(concept)
-	const concept_index = token.lookup_results.findIndex(result => result.stem === stem && result.concept?.sense === sense)
+	const concept_index = find_result_index(token, concept)
 	const selected_result = token.lookup_results.splice(concept_index, 1)
 
 	// put the selected sense at the top

--- a/app/src/lib/rules/case_frame/common.js
+++ b/app/src/lib/rules/case_frame/common.js
@@ -1,0 +1,412 @@
+import { TOKEN_TYPE, concept_with_sense } from '$lib/parser/token'
+import { pipe } from '$lib/pipeline'
+import { apply_token_transforms, create_context_filter, create_token_filter, create_token_transform, create_token_transforms } from '../rules_parser'
+import { check_verb_case_frames, check_verb_case_frames_passive } from './verbs'
+
+/**
+ * 
+ * @param {RoleTag} role_tag 
+ * @returns {string}
+ */
+function missing_argument_message(role_tag) {
+	const messages = new Map([
+		['agent_clause', 'And agent clause is required (e.g. \'It Verb [X...]\' or \'[X...] Verb...\').'],
+		['patient_clause_quote_begin', 'A direct-speech patient clause is required.'],
+		['patient_clause_different_participant', 'A different-participant patient clause is required (i.e. the clause subject must be explicit).'],
+		['patient_clause_same_participant', 'A same-participant patient clause is required (e.g. \'... [to sing]\').'],
+		['patient_clause_simultaneous', 'A simultaneous perception clause is required (e.g. \'John saw [Mary singing]\').'],
+	])
+	return messages.get(role_tag) ?? `A ${role_tag} is required.`
+}
+
+/**
+ * 
+ * @param {OntologyResult} concept
+ * @param {RoleTag} role_tag 
+ * @returns {string}
+ */
+function extra_argument_message(concept, role_tag) {
+	const sense = concept_with_sense(concept)
+	const category = concept.part_of_speech
+	const consult_message = `Consult the ${category}'s Theta Grid usage.`
+	const messages = new Map([
+		['patient', `Unexpected ${role_tag} for ${sense}. ${consult_message}`],
+		['source', `Unexpected ${role_tag} for ${sense}. ${consult_message}`],
+		['destination', `Unexpected ${role_tag} for ${sense}. ${consult_message}`],
+		['beneficiary', `${sense} does not usually take a ${role_tag}. Check to make sure its usage is acceptable.`],
+		['instrument', `${sense} does not usually take a ${role_tag}. Check to make sure its usage is acceptable.`],
+		['agent_clause', `${sense} cannot be used with an agent clause. ${consult_message}`],
+		['patient_clause_different_participant', `${sense} cannot be used with an different-participant patient clause. ${consult_message}`],
+		['patient_clause_same_participant', `${sense} cannot be used with a same-participant patient clause. ${consult_message}`],
+		['patient_clause_simultaneous', `${sense} cannot be used with a simultaneous perception clause. ${consult_message}`],
+		['patient_clause_quote_begin', `${sense} cannot be used with direct speech. ${consult_message}`],
+		['predicate_adjective', `${sense} cannot be used with a predicate Adjective. ${consult_message}`],
+	])
+
+	return messages.get(role_tag) ?? `Unexpected ${role_tag} for ${sense}. Consult its usage in the Ontology.`
+}
+
+/**
+ * 
+ * @param {[RoleTag, any]} rule_json 
+ * @returns {ArgumentRoleRule}
+ */
+export function parse_case_frame_rule([role_tag, rule_json]) {
+	const by_adposition = rule_json['by_adposition']
+	if (by_adposition) {
+		rule_json = {
+			'trigger': { 'tag': 'head_np' },
+			'context': { 'precededby': { 'token': by_adposition, 'skip': 'np_modifiers' } },
+			'context_transform': { 'function': '' },
+			'missing_message': `A ${role_tag} argument is required, which for this verb must be preceded by '${by_adposition}'.`,
+			...rule_json,		// allow a rule to overwrite or add any part of this
+		}
+	}
+
+	const by_clause_tag = rule_json['by_clause_tag']
+	if (by_clause_tag) {
+		rule_json = {
+			'trigger': { 'type': TOKEN_TYPE.CLAUSE, 'tag': by_clause_tag },
+			...rule_json,		// allow a rule to overwrite or add any part of this
+		}
+	}
+
+	const directly_before_verb = rule_json['directly_before_verb']
+	if (directly_before_verb) {
+		rule_json = {
+			'trigger': { 'tag': 'head_np', ...directly_before_verb },
+			'context': { 'followedby': { 'category': 'Verb', 'skip': 'vp_modifiers' } },
+			...rule_json,		// allow a rule to overwrite or add any part of this
+		}
+	}
+
+	const directly_after_verb = rule_json['directly_after_verb']
+	if (directly_after_verb) {
+		rule_json = {
+			'trigger': { 'tag': 'head_np', ...directly_after_verb },
+			'context': { 'precededby': { 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] } },
+			...rule_json,		// allow a rule to overwrite or add any part of this
+		}
+	}
+
+	const directly_after_verb_with_adposition = rule_json['directly_after_verb_with_adposition']
+	if (directly_after_verb_with_adposition) {
+		rule_json = {
+			'trigger': { 'tag': 'head_np' },
+			'context': {
+				'precededby': [
+					{ 'category': 'Verb', 'skip': 'vp_modifiers' },
+					{ 'token': directly_after_verb_with_adposition, 'skip': 'np_modifiers' }
+				]
+			},
+			'context_transform': [{}, { 'function': '' }],
+			'missing_message': `A ${role_tag} is required, which for this verb must be preceded by '${directly_after_verb_with_adposition}'.`,
+			...rule_json,		// allow a rule to overwrite or add any part of this
+		}
+	}
+
+	const predicate_adjective = rule_json['predicate_adjective']
+	if (predicate_adjective) {
+		rule_json = {
+			'trigger': { 'category': 'Adjective', 'tag': 'predicate_adjective' },
+			...rule_json,		// allow a rule to overwrite or add any part of this
+		}
+	}
+
+	const trigger_json = rule_json['trigger']
+	const trigger = trigger_json ? create_token_filter(trigger_json) : () => false
+
+	const context = create_context_filter(rule_json['context'])
+
+	const transform = create_token_transform({ 'tag': role_tag, ...(rule_json['transform'] ?? {}) })
+	const context_transforms = create_token_transforms(rule_json['context_transform'])
+	const missing_message = rule_json['missing_message'] ?? missing_argument_message(role_tag)
+
+	return {
+		role_tag,
+		trigger,
+		context,
+		action: case_frame_rule_action,
+		missing_message,
+	}
+
+	/**
+	 * 
+	 * @param {Token[]} tokens 
+	 * @param {RoleMatchResult} role_match 
+	 */
+	function case_frame_rule_action(tokens, { trigger_index, context_indexes }) {
+		const transforms = [transform, ...context_transforms]
+		const indexes = [trigger_index, ...context_indexes]
+		apply_token_transforms(tokens, indexes, transforms)
+	}
+}
+
+/**
+ * @param {[WordSense, any][]} rule_json
+ * @param {ArgumentRoleRule[]} defaults
+ * @returns {ArgumentRulesForSense[]}
+ */
+export function parse_sense_rules(rule_json, defaults) {
+	return rule_json.map(parse_sense_rule(defaults))
+
+	/**
+	 * 
+	 * @param {ArgumentRoleRule[]} defaults
+	 * @returns {(rule_json: [WordSense, any]) => ArgumentRulesForSense}
+	 */
+	function parse_sense_rule(defaults) {
+		return ([sense, rules_json]) => ({
+			sense,
+			rules: defaults.map(rule => rule.role_tag in rules_json ? parse_case_frame_rule([rule.role_tag, rules_json[rule.role_tag]]) : rule),
+			other_optional: rules_json['other_optional']?.split('|') ?? [],
+			other_required: rules_json['other_required']?.split('|') ?? [],
+			patient_clause_type: rules_json['patient_clause_type'] ?? '',
+		})
+	}
+}
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @param {number} trigger_index 
+ * @param {Object} rule_info
+ * @param {ArgumentRulesForSense[]} [rule_info.rules_by_sense] 
+ * @param {ArgumentRoleRule[]} [rule_info.default_rules] 
+ * @param {Map<string, RoleTag>} [rule_info.role_letter_map] 
+ */
+export function check_case_frames(tokens, trigger_index, { rules_by_sense=[], default_rules=[], role_letter_map=new Map() }) {
+	const pipeline = pipe(
+		get_rules_for_sense(rules_by_sense, default_rules),
+		match_sense_rules(tokens),
+		check_usage(role_letter_map),
+	)
+
+	for (const lookup of tokens[trigger_index].lookup_results.filter(result => result.concept)) {
+		lookup.case_frame = pipeline(lookup)
+	}
+}
+
+/**
+ * 
+ * @param {ArgumentRulesForSense[]} rules_by_sense 
+ * @param {ArgumentRoleRule[]} default_rules
+ * @returns {(lookup: LookupResult) => [LookupResult, ArgumentRulesForSense]}
+ */
+function get_rules_for_sense(rules_by_sense, default_rules) {
+	const defaults_for_stem = {
+		rules: default_rules,
+		other_optional: [],
+		other_required: [],
+		patient_clause_type: '',
+	}
+	return lookup => {
+		const sense = lookup.concept ? concept_with_sense(lookup.concept) : lookup.stem
+		return [lookup, rules_by_sense.find(rule => rule.sense === sense) ?? { sense, ...defaults_for_stem }]
+	}
+}
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @returns {(param: [LookupResult, ArgumentRulesForSense]) => [LookupResult, ArgumentRulesForSense, RoleMatchResult[]]}
+ */
+function match_sense_rules(tokens) {
+	return ([lookup, sense_rule]) => [lookup, sense_rule, sense_rule.rules.map(rule => match_argument_rule(tokens, rule)).filter(match => match.success)]
+}
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @param {ArgumentRoleRule} rule 
+ * @returns {RoleMatchResult}
+ */
+function match_argument_rule(tokens, rule) {
+	for (let i = 0; i < tokens.length;) {
+		if (!rule.trigger(tokens[i])) {
+			i++
+			continue
+		}
+		const context_result = rule.context(tokens, i)
+		if (!context_result.success) {
+			i++
+			continue
+		}
+		return {
+			role_tag: rule.role_tag,
+			success: true,
+			trigger_index: i,
+			context_indexes: context_result.indexes,
+		}
+	}
+	return {
+		role_tag: rule.role_tag,
+		success: false,
+		trigger_index: -1,
+		context_indexes: [],
+	}
+}
+
+/**
+ * @param {Map<string, RoleTag>} role_letter_map
+ * @returns {(param: [LookupResult, ArgumentRulesForSense, RoleMatchResult[]]) => CaseFrameResult}
+ */
+function check_usage(role_letter_map) {
+	return ([lookup, role_rules, role_matches]) => {
+		if (lookup.concept === null) {
+			return create_case_frame({ is_valid: false, is_checked: false })
+		}
+
+		const role_letters = [...lookup.concept.categorization].filter(c => c !== '_')
+
+		// Replace 'patient_clause' with the appropriate clause type
+		const patient_clause_type = role_rules.patient_clause_type || 'patient_clause_different_participant'
+
+		/** @type {string[]} */
+		// @ts-ignore
+		const possible_roles = role_letters
+			.map(c => role_letter_map.get(c.toUpperCase()))
+			.map(role => role === 'patient_clause' ? patient_clause_type : role)
+			.concat([...role_rules.other_optional, ...role_rules.other_required])
+			.filter(role => role)
+
+		/** @type {string[]} */
+		// @ts-ignore
+		const required_roles = role_letters
+			.map(c => role_letter_map.get(c))
+			.map(role => role === 'patient_clause' ? patient_clause_type : role)
+			.concat(role_rules.other_required)
+			.filter(role => role)
+
+		const valid_arguments = role_matches.filter(({ role_tag }) => possible_roles.includes(role_tag))
+		const extra_arguments = role_matches.filter(({ role_tag }) => !possible_roles.includes(role_tag))
+		const missing_arguments = required_roles.filter(role => !role_matches.some(({ role_tag }) => role_tag === role))
+		const is_valid = extra_arguments.length === 0 && missing_arguments.length === 0
+
+		return create_case_frame({
+			is_valid,
+			is_checked: true,
+			valid_arguments,
+			missing_arguments,
+			extra_arguments,
+			rule: role_rules,
+		})
+	}
+}
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @param {number} trigger_index 
+ */
+export function validate_case_frame(tokens, trigger_index) {
+	const token = tokens[trigger_index]
+
+	if (token.lookup_results.length > 1 && !token.lookup_results.some(result => result.case_frame.is_valid)) {
+		token.error_message = 'No senses match the argument structure found in this sentence. Specify a sense to get more info about its expected structure.'
+		return
+	}
+
+	const selected_result = token.lookup_results[0]
+	const case_frame = selected_result.case_frame
+
+	// Show errors for missing and unexpected arguments
+	if (case_frame.missing_arguments.length) {
+		const missing_messages = case_frame.missing_arguments
+			.map(role_tag => case_frame.rule.rules.find(rule => rule.role_tag === role_tag))
+			.map(rule => rule?.missing_message)
+		
+		// TODO add appropriate error tokens instead of putting all the messages on the verb
+		token.error_message = `${missing_messages.join(' | ')} Consult the Ontology for correct usage.`
+	}
+
+	for (const extra_argument of case_frame.extra_arguments) {
+		const argument_token = tokens[extra_argument.trigger_index]
+		const token_to_flag = argument_token.type === TOKEN_TYPE.CLAUSE ? argument_token.sub_tokens[0] : argument_token
+
+		// @ts-ignore there will always be a concept
+		const message = extra_argument_message(selected_result.concept, extra_argument.role_tag)
+
+		if (['beneficiary', 'instrument'].includes(extra_argument.role_tag)) {
+			// These arguments are not necessarily an error, as many verbs could technically take them.
+			// Sometimes they just haven't occurred yet for a sense and so don't appear in the Verb categorization.
+			// So show a suggest message (or info message??) instead of an error.
+			token_to_flag.suggest_message = message
+		} else {
+			token_to_flag.error_message = message
+		}
+	}
+}
+
+/**
+ * 
+ * @param {Object} [data={}] 
+ * @param {boolean} [data.is_valid=false] 
+ * @param {boolean} [data.is_checked=false] 
+ * @param {ArgumentRulesForSense?} [data.rule={}] 
+ * @param {RoleMatchResult[]} [data.valid_arguments=[]] 
+ * @param {RoleMatchResult[]} [data.extra_arguments=[]] 
+ * @param {RoleTag[]} [data.missing_arguments=[]] 
+ * @returns {CaseFrameResult}
+ */
+export function create_case_frame({ is_valid=false, is_checked=false, rule=null, valid_arguments=[], extra_arguments=[], missing_arguments=[] }={}) {
+	return {
+		is_valid,
+		is_checked,
+		rule: rule ?? create_sense_argument_rule(),
+		valid_arguments,
+		extra_arguments,
+		missing_arguments,
+	}
+}
+
+/**
+ * 
+ * @param {Object} [data={}] 
+ * @param {string} [data.sense=''] 
+ * @param {ArgumentRoleRule[]} [data.rules=[]] 
+ * @param {RoleTag[]} [data.other_optional=[]] 
+ * @param {RoleTag[]} [data.other_required=[]] 
+ * @param {RoleTag} [data.patient_clause_type=''] 
+ * @returns {ArgumentRulesForSense}
+ */
+export function create_sense_argument_rule({ sense='', rules=[], other_optional=[], other_required=[], patient_clause_type='' }={}) {
+	return { sense, rules, other_optional, other_required, patient_clause_type }
+}
+
+/** @type {BuiltInRule[]} */
+const case_frame_rules = [
+	{
+		name: 'Verb case frame, active',
+		comment: 'For now, only trigger when not within a relative clause, or a question since arguments get moved around',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({
+				'notprecededby': { 'tag': 'relativizer|passive', 'skip': 'all' },
+				'notfollowedby': { 'token': '?', 'skip': 'all' },
+			}),
+			action: (tokens, trigger_index) => {
+				check_verb_case_frames(tokens, trigger_index)
+				return trigger_index + 1
+			},
+		},
+	},
+	{
+		name: 'Verb case frame, passive',
+		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({
+				'precededby': { 'tag': 'passive', 'skip': 'all' },
+				'notprecededby': { 'tag': 'relativizer', 'skip': 'all' },
+				'notfollowedby': { 'token': '?', 'skip': 'all' },
+			}),
+			action: (tokens, trigger_index) => {
+				check_verb_case_frames_passive(tokens, trigger_index)
+				return trigger_index + 1
+			},
+		},
+	},
+]
+
+export const CASE_FRAME_RULES = case_frame_rules.map(({ rule }) => rule)

--- a/app/src/lib/rules/case_frame/common.js
+++ b/app/src/lib/rules/case_frame/common.js
@@ -96,8 +96,8 @@ export function parse_case_frame_rule([role_tag, rule_json]) {
 			'context': {
 				'precededby': [
 					{ 'category': 'Verb', 'skip': 'vp_modifiers' },
-					{ 'token': directly_after_verb_with_adposition, 'skip': 'np_modifiers' }
-				]
+					{ 'token': directly_after_verb_with_adposition, 'skip': 'np_modifiers' },
+				],
 			},
 			'context_transform': [{}, { 'function': '' }],
 			'missing_message': `A ${role_tag} is required, which for this verb must be preceded by '${directly_after_verb_with_adposition}'.`,
@@ -118,7 +118,7 @@ export function parse_case_frame_rule([role_tag, rule_json]) {
 
 	const context = create_context_filter(rule_json['context'])
 
-	const transform = create_token_transform({ 'tag': role_tag, ...(rule_json['transform'] ?? {}) })
+	const transform = create_token_transform({ 'tag': role_tag, ...rule_json['transform'] ?? {} })
 	const context_transforms = create_token_transforms(rule_json['context_transform'])
 	const missing_message = rule_json['missing_message'] ?? missing_argument_message(role_tag)
 

--- a/app/src/lib/rules/case_frame/common.js
+++ b/app/src/lib/rules/case_frame/common.js
@@ -378,11 +378,11 @@ export function create_sense_argument_rule({ sense='', rules=[], other_optional=
 const case_frame_rules = [
 	{
 		name: 'Verb case frame, active',
-		comment: 'For now, only trigger when not within a relative clause, or a question since arguments get moved around',
+		comment: 'For now, only trigger when not within a relative clause, question, or possible same-subject clause since arguments get moved around',
 		rule: {
 			trigger: create_token_filter({ 'category': 'Verb' }),
 			context: create_context_filter({
-				'notprecededby': { 'tag': 'relativizer|passive', 'skip': 'all' },
+				'notprecededby': { 'tag': 'relativizer|passive|infinitive', 'skip': 'all' },
 				'notfollowedby': { 'token': '?', 'skip': 'all' },
 			}),
 			action: (tokens, trigger_index) => {

--- a/app/src/lib/rules/case_frame/index.js
+++ b/app/src/lib/rules/case_frame/index.js
@@ -1,7 +1,7 @@
-import { CASE_FRAME_RULES, create_case_frame, create_sense_argument_rule } from './common'
+import { validate_case_frame } from './common'
+import { CASE_FRAME_RULES } from './rules'
 
 export {
 	CASE_FRAME_RULES,
-	create_case_frame,
-	create_sense_argument_rule,
+	validate_case_frame,
 }

--- a/app/src/lib/rules/case_frame/index.js
+++ b/app/src/lib/rules/case_frame/index.js
@@ -1,0 +1,7 @@
+import { CASE_FRAME_RULES, create_case_frame, create_sense_argument_rule } from './common'
+
+export {
+	CASE_FRAME_RULES,
+	create_case_frame,
+	create_sense_argument_rule,
+}

--- a/app/src/lib/rules/case_frame/rules.js
+++ b/app/src/lib/rules/case_frame/rules.js
@@ -1,0 +1,40 @@
+import { create_context_filter, create_token_filter } from '../rules_parser'
+import { check_verb_case_frames, check_verb_case_frames_passive } from './verbs'
+
+
+/** @type {BuiltInRule[]} */
+const case_frame_rules = [
+	{
+		name: 'Verb case frame, active',
+		comment: 'For now, only trigger when not within a relative clause, question, or possible same-subject clause since arguments get moved around',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({
+				'notprecededby': { 'tag': 'relativizer|passive|infinitive', 'skip': 'all' },
+				'notfollowedby': { 'token': '?', 'skip': 'all' },
+			}),
+			action: (tokens, trigger_index) => {
+				check_verb_case_frames(tokens, trigger_index)
+				return trigger_index + 1
+			},
+		},
+	},
+	{
+		name: 'Verb case frame, passive',
+		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({
+				'precededby': { 'tag': 'passive', 'skip': 'all' },
+				'notprecededby': { 'tag': 'relativizer', 'skip': 'all' },
+				'notfollowedby': { 'token': '?', 'skip': 'all' },
+			}),
+			action: (tokens, trigger_index) => {
+				check_verb_case_frames_passive(tokens, trigger_index)
+				return trigger_index + 1
+			},
+		},
+	},
+]
+
+export const CASE_FRAME_RULES = case_frame_rules.map(({ rule }) => rule)

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -1,0 +1,326 @@
+import { token_has_concept } from '$lib/parser/token'
+import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from './common'
+
+const default_verb_case_frame_json = {
+	'agent': {
+		'directly_before_verb': { },
+	},
+	'patient': {
+		'directly_after_verb': { },
+		'comment': 'one of state or patient will be removed from the defaults depending on the stem (be/have use state instead of patient)',
+	},
+	'state': {
+		'directly_after_verb': { },
+		'comment': 'one of state or patient will be removed from the defaults depending on the stem (be/have use state instead of patient)',
+	},
+	'source': {
+		'by_adposition': 'from',
+	},
+	'destination': {
+		'by_adposition': 'to',
+	},
+	'instrument': {
+		// TODO check feature on lexicon word like the Analyzer does. instruments have to be a thing, not a person
+		'comment': 'An instrument is not present by default ("with" could mean other things as well)',
+	},
+	'addressee': {
+		'trigger': { 'tag': 'head_np' },
+		'context': { 'followedby': [{'token': ','}, { 'category': 'Verb', 'skip': 'all' }] },
+	},
+	'beneficiary': {
+		// TODO check feature on lexicon word like the Analyzer does. beneficiaries have to be animate, not things.
+		// For now only accept proper names. Not a big deal because the beneficiary is rarely required (only provide-A requires it)
+		'trigger': { 'tag': 'head_np', 'level': '4' },	
+		'context': { 'precededby': { 'token': 'for', 'skip': 'np_modifiers' } },
+		'context_transform': { 'function': '' },
+		'comment': '"for" could mean other things as well. TODO These should be set in the transform rules',
+	},
+	'agent_clause': {
+		'by_clause_tag': 'agent_clause',
+	},
+	// These are extra argument types that are not directly detected by the 'categorization' value but
+	// a sense may need a specific type of.
+	'patient_clause_different_participant': {
+		'by_clause_tag': 'patient_clause_different_participant',
+	},
+	'patient_clause_same_participant': {
+		'by_clause_tag': 'patient_clause_same_participant',
+	},
+	'patient_clause_simultaneous': {
+		'by_clause_tag': 'patient_clause_simultaneous',
+	},
+	'patient_clause_quote_begin': {
+		'by_clause_tag': 'patient_clause_quote_begin',
+	},
+	'predicate_adjective': {
+		'predicate_adjective': {},
+		'comment': 'a predicate adjective is not present by default',
+	},
+}
+
+/**
+ * These rules allow each verb sense to specify rules for each argument that is different from the default.
+ * Only senses that differ from the default structure need to be included here.
+ * 
+ * @type {Map<WordStem, [WordSense, any][]>}
+ */
+const verb_case_frames = new Map([
+	['allow', [
+		['allow-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['be', [
+		['be-D', {
+			'other_required': 'predicate_adjective',
+			'other_optional': 'patient_clause_same_participant|patient_clause_different_participant',
+			'comment': 'some predicate adjectives take a patient clause, so those should be recognized and accepted',
+		}],
+		['be-E', {
+			'agent': {
+				'trigger': { 'tag': 'head_np' },
+				'context': { 'precededby': [{'tag': 'existential'}, { 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] }] },
+				'missing_message': 'be-E requires the format \'there be X\'.',
+			},
+			'state': { },
+		}],
+		['be-F', {
+			'state': {
+				'trigger': { 'tag': 'head_np' },
+				'context': { 'precededby': { 'category': 'Adposition', 'skip': 'np_modifiers' } },
+			},
+		}],
+		['be-G', {
+			'state': { 'directly_after_verb_with_adposition': 'for' },
+			'beneficiary': { },
+		}],
+		['be-H', {
+			'state': {
+				'trigger': { 'tag': 'head_np' },
+				'context': { 'precededby': { 'category': 'Adposition', 'skip': 'np_modifiers' } },
+			},
+		}],
+		['be-I', {
+			'state': { 'directly_after_verb_with_adposition': 'with' },
+		}],
+		['be-J', {
+			'agent': {
+				'directly_before_verb': { 'stem': 'date' },
+				'missing_message': 'be-J requires the format \'The date be X\'.',
+			},
+		}],
+		['be-K', {
+			'agent': {
+				'directly_before_verb': { 'stem': 'name' },
+				'missing_message': 'be-K requires the format "X\'s name be Y" or "The name of X be Y".',
+			},
+		}],
+		['be-N', {
+			'agent': {
+				'directly_before_verb': { 'stem': 'time' },
+				'missing_message': 'be-N requires the format \'The time be X\' where X is a temporal noun (eg 4PM//morning).',
+			},
+		}],
+		['be-O', {
+			'agent': {
+				'directly_before_verb': { 'stem': 'weather' },
+				'missing_message': 'be-O requires the format \'The weather be X\' where X can be a noun (eg rain) or adjective (eg hot).',
+			},
+			'other_optional': 'predicate_adjective',
+		}],
+		['be-P', {
+			'state': { 'directly_after_verb_with_adposition': 'about' },
+		}],
+		['be-Q', {
+			'state': {
+				'trigger': { 'tag': 'head_np' },
+				'context': { 'precededby': { 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers', { 'token': 'made' }] } },
+			},
+			'comment': 'there may or may not be "made of" before the np',
+		}],
+		['be-R', {
+			'state': {
+				'directly_after_verb_with_adposition': 'part',
+				'missing_message': 'be-R requires the format \'X be part of Y\''
+			},
+		}],
+		['be-S', {
+			'predicate_adjective': {
+				'trigger': { 'token': 'old', },
+				'context': { 'precededby': [{ 'category': 'Adjective' }, { 'stem': 'year|month|day' }] },
+				'transform': { 'concept': 'old-B' },
+				'missing_message': 'be-S requires the format \'be X years//months//etc old(-B)\'.'
+			},
+			'state': { },
+			'other_required': 'predicate_adjective',
+			'comment': 'clear the \'state\' argument so it doesn\'t get triggered by \'year/month/day\' etc. \'old\' is the predicate adjective.',
+		}],
+		['be-T', {
+			'state': { 'directly_after_verb_with_adposition': 'from' },
+			'source': { },
+		}],
+		['be-U', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
+		['be-V', { 'other_required': 'predicate_adjective' }],
+		['be-W', { 'state': { 'directly_after_verb_with_adposition': 'in' } }],
+		['be-X', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
+	]],
+	['give', [
+		['give-A', {
+			'patient': {
+				'directly_after_verb': { },
+				'missing_message': "\'give\' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
+			}
+		}]
+	]],
+	['have', [
+		['know-J', { 'instrument': { 'by_adposition': 'with' } }],
+	]],
+	['hear', [
+		['hear-A', { 'instrument': { 'by_adposition': 'with' } }],
+		['hear-B', { 'instrument': { 'by_adposition': 'with' } }],
+		['hear-C', { 'other_optional': 'patient_clause_simultaneous' }],
+		['hear-D', { 'patient': { 'by_adposition': 'about' } }],
+	]],
+	['know', [
+		['know-D', { 'patient': { 'directly_after_verb_with_adposition': 'about' } }],
+		['know-B', { 'instrument': { 'by_adposition': 'with' } }],
+	]],
+	['say', [
+		['say-A', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+		['say-E', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+		['say-F', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['see', [
+		['see-B', { 'other_optional': 'patient_clause_simultaneous' }],
+	]],
+	['speak', [
+		['speak-A', {
+			'patient': { 'by_adposition': 'about' },
+			'instrument': {
+				'by_adposition': 'in',
+				'context_transform': { 'concept': 'in-K' },
+			},	// in a language
+		}],
+	]],
+	['tell', [
+		['tell-A', {
+			'instrument': { 'by_adposition': 'with' },
+			'patient_clause_different_participant': { 'by_clause_tag': 'patient_clause_different_participant|relative_clause_that' },
+			'comment': 'the patient clause may have been interpreted as a relative clause if \'that\' was present',
+		}],
+		['tell-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+		['tell-C', {
+			'destination': { 'directly_after_verb': { } },
+			'instrument': { 'by_adposition': 'with' },
+			'patient': { 'by_adposition': 'about' },
+		}],
+		['tell-D', { 'instrument': { 'by_adposition': 'with' } }],
+		['tell-E', {
+			'destination': { 'directly_after_verb': { } },
+			'patient': { },		// clear the patient so it doesn't get confused with the destination
+			'patient_clause_type': 'patient_clause_quote_begin',
+		}],
+	]],
+])
+
+const VERB_LETTER_TO_ROLE = new Map([
+	['A', 'agent'],
+	['B', 'patient'],
+	['C', 'state'],
+	['D', 'source'],
+	['E', 'destination'],
+	['F', 'instrument'],
+	['G', 'beneficiary'],
+	['H', 'patient_clause'],
+	['I', 'agent_clause'],
+])
+
+/**
+ * @returns {ArgumentRoleRule[]}
+ */
+function create_default_argument_rules() {
+	return Object.entries(default_verb_case_frame_json).map(parse_case_frame_rule)
+}
+
+/**
+ * @returns {Map<WordStem, ArgumentRulesForSense[]>}
+ */
+function create_verb_argument_rules() {
+	return new Map([...verb_case_frames.entries()].map(create_rules_for_stem))
+
+	/**
+	 * 
+	 * @param {[WordStem, [WordSense, any][]]} stem_rules 
+	 * @returns {[WordStem, ArgumentRulesForSense[]]}
+	 */
+	function create_rules_for_stem([stem, sense_rules_json]) {
+		const defaults = get_default_rules_for_stem(stem)
+		return [stem, parse_sense_rules(sense_rules_json, defaults)]
+	}
+}
+
+/**
+ * 
+ * @param {WordStem} stem 
+ * @returns {ArgumentRoleRule[]}
+ */
+function get_default_rules_for_stem(stem) {
+	const role_to_remove = ['be', 'have'].includes(stem) ? 'patient' : 'state'
+	return DEFAULT_CASE_FRAME_RULES.filter(rule => rule.role_tag !== role_to_remove)
+}
+
+const DEFAULT_CASE_FRAME_RULES = create_default_argument_rules()
+const VERB_CASE_FRAME_RULES = create_verb_argument_rules()
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @param {number} verb_index 
+ * @param {((rules: ArgumentRulesForSense[]) => ArgumentRulesForSense[])} rules_modifier
+ */
+export function check_verb_case_frames(tokens, verb_index, rules_modifier=(rules => rules)) {
+	const verb_token = tokens[verb_index]
+	if (!token_has_concept(verb_token)) {
+		return
+	}
+
+	const stem = verb_token.lookup_results[0].stem
+	const argument_rules_by_sense = VERB_CASE_FRAME_RULES.get(stem)
+
+	// TODO remove this at some point and default to empty map instead
+	if (!argument_rules_by_sense) {
+		return
+	}
+
+	check_case_frames(tokens, verb_index, {
+		rules_by_sense: rules_modifier(argument_rules_by_sense),
+		default_rules: get_default_rules_for_stem(stem),
+		role_letter_map: VERB_LETTER_TO_ROLE,
+	})
+}
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @param {number} verb_index 
+ */
+export function check_verb_case_frames_passive(tokens, verb_index) {
+	// for a passive, the 'patient' goes right before the verb and the 'agent' is detected by the adposition 'by'
+	const passive_rules = [
+		parse_case_frame_rule(['patient', {
+			'directly_before_verb': { },
+			'missing_message': 'A patient is required, which goes before the Verb in the passive.'
+		}]),
+		parse_case_frame_rule(['agent', {
+			'by_adposition': 'by',
+			'missing_message': 'An agent is required, which for a passive is preceded by \'by\'.'
+		}]),
+	]
+
+	check_verb_case_frames(tokens, verb_index, sense_rules => 
+		sense_rules.map(rules_for_sense => ({
+			...rules_for_sense,
+			rules: rules_for_sense.rules.filter(rule => !['patient', 'agent'].includes(rule.role_tag)).concat(passive_rules)
+		}))
+	)
+}
+
+// TODO add check for questions and relative clauses

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -25,7 +25,7 @@ const default_verb_case_frame_json = {
 	},
 	'addressee': {
 		'trigger': { 'tag': 'head_np' },
-		'context': { 'followedby': [{'token': ','}, { 'category': 'Verb', 'skip': 'all' }] },
+		'context': { 'followedby': [{ 'token': ',' }, { 'category': 'Verb', 'skip': 'all' }] },
 	},
 	'beneficiary': {
 		// TODO check feature on lexicon word like the Analyzer does. beneficiaries have to be animate, not things.
@@ -77,7 +77,7 @@ const verb_case_frames = new Map([
 		['be-E', {
 			'agent': {
 				'trigger': { 'tag': 'head_np' },
-				'context': { 'precededby': [{'tag': 'existential'}, { 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] }] },
+				'context': { 'precededby': [{ 'tag': 'existential' }, { 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] }] },
 				'missing_message': 'be-E requires the format \'there be X\'.',
 			},
 			'state': { },
@@ -139,19 +139,19 @@ const verb_case_frames = new Map([
 		['be-R', {
 			'state': {
 				'directly_after_verb_with_adposition': 'part',
-				'missing_message': 'be-R requires the format \'X be part of Y\''
+				'missing_message': 'be-R requires the format \'X be part of Y\'',
 			},
 		}],
 		['be-S', {
 			'predicate_adjective': {
-				'trigger': { 'token': 'old', },
+				'trigger': { 'token': 'old' },
 				'context': { 'precededby': [{ 'category': 'Adjective' }, { 'stem': 'year|month|day' }] },
 				'transform': { 'concept': 'old-B' },
-				'missing_message': 'be-S requires the format \'be X years//months//etc old(-B)\'.'
+				'missing_message': 'be-S requires the format \'be X years//months//etc old(-B)\'.',
 			},
 			'state': { },
 			'other_required': 'predicate_adjective',
-			'comment': 'clear the \'state\' argument so it doesn\'t get triggered by \'year/month/day\' etc. \'old\' is the predicate adjective.',
+			'comment': "clear the 'state' argument so it doesn't get triggered by 'year/month/day' etc. 'old' is the predicate adjective.",
 		}],
 		['be-T', {
 			'state': { 'directly_after_verb_with_adposition': 'from' },
@@ -166,9 +166,9 @@ const verb_case_frames = new Map([
 		['give-A', {
 			'patient': {
 				'directly_after_verb': { },
-				'missing_message': "\'give\' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
-			}
-		}]
+				'missing_message': "'give' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
+			},
+		}],
 	]],
 	['have', [
 		['know-J', { 'instrument': { 'by_adposition': 'with' } }],
@@ -276,7 +276,7 @@ const VERB_CASE_FRAME_RULES = create_verb_argument_rules()
  * @param {number} verb_index 
  * @param {((rules: ArgumentRulesForSense[]) => ArgumentRulesForSense[])} rules_modifier
  */
-export function check_verb_case_frames(tokens, verb_index, rules_modifier=(rules => rules)) {
+export function check_verb_case_frames(tokens, verb_index, rules_modifier=rules => rules) {
 	const verb_token = tokens[verb_index]
 	if (!token_has_concept(verb_token)) {
 		return
@@ -307,19 +307,19 @@ export function check_verb_case_frames_passive(tokens, verb_index) {
 	const passive_rules = [
 		parse_case_frame_rule(['patient', {
 			'directly_before_verb': { },
-			'missing_message': 'A patient is required, which goes before the Verb in the passive.'
+			'missing_message': 'A patient is required, which goes before the Verb in the passive.',
 		}]),
 		parse_case_frame_rule(['agent', {
 			'by_adposition': 'by',
-			'missing_message': 'An agent is required, which for a passive is preceded by \'by\'.'
+			'missing_message': 'An agent is required, which for a passive is preceded by \'by\'.',
 		}]),
 	]
 
 	check_verb_case_frames(tokens, verb_index, sense_rules => 
 		sense_rules.map(rules_for_sense => ({
 			...rules_for_sense,
-			rules: rules_for_sense.rules.filter(rule => !['patient', 'agent'].includes(rule.role_tag)).concat(passive_rules)
-		}))
+			rules: rules_for_sense.rules.filter(rule => !['patient', 'agent'].includes(rule.role_tag)).concat(passive_rules),
+		})),
 	)
 }
 

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -1,6 +1,6 @@
 import { ERRORS } from '$lib/parser/error_messages'
 import { TOKEN_TYPE, convert_to_error_token, create_added_token } from '$lib/parser/token'
-import { validate_case_frame } from './case_frame/common'
+import { validate_case_frame } from './case_frame'
 import { create_context_filter, create_token_filter, create_token_modify_action } from './rules_parser'
 
 const checker_rules_json = [

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -1,16 +1,17 @@
 import { ERRORS } from '$lib/parser/error_messages'
 import { TOKEN_TYPE, convert_to_error_token, create_added_token } from '$lib/parser/token'
+import { validate_case_frame } from './case_frame/common'
 import { create_context_filter, create_token_filter, create_token_modify_action } from './rules_parser'
 
 const checker_rules_json = [
 	{
-		'name': 'Speak does not use quotes',
-		'trigger': { 'stem': 'speak' },
+		'name': 'Check for "it" apart from an agent clause',
+		'trigger': { 'tag': 'agent_proposition_subject' },
 		'context': {
-			'followedby': { 'tag': 'quote_begin', 'skip': 'all' },
+			'notfollowedby': { 'tag': 'agent_clause', 'skip': 'all' },
 		},
 		'require': {
-			'message': '\'Speak\' cannot be used with a direct quote. Consider using \'say\' instead.',
+			'message': 'Third person pronouns should be replaced with the Noun they represent, e.g., Paul (instead of him).',
 		},
 	},
 	{
@@ -18,7 +19,7 @@ const checker_rules_json = [
 		'trigger': { 'category': 'Verb' },
 		'context': {
 			'precededby': { 'tag': 'passive', 'skip': 'all' },
-			'notfollowedby': { 'tag': 'agent_of_passive', 'skip': 'all' },
+			'notfollowedby': { 'tag': 'agent', 'skip': 'all' },
 		},
 		'require': {
 			'followedby': 'by X',
@@ -88,21 +89,24 @@ const checker_rules_json = [
 			'message': 'An imperative clause must have an explicit subject.',
 		},
 	},
-	{
-		'name': 'Check for an imperative note that does not follow the \'you\'',
-		'trigger': { 'token': '(imp)' },
-		'context': {
-			'notprecededby': { 'tag': 'second_person' },
-		},
-		'suggest': {
-			'message': 'Consider putting the imperative (imp) notation after the \'you\' subject of the clause.',
-		},
-	},
+	// TODO uncomment when tags are expanded. currently tags keep getting overwritten, so
+	// at this point, the tag is not necessarily 'second_person' anymore.
+	// {
+	// 	'name': 'Check for an imperative note that does not follow the \'you\'',
+	// 	'trigger': { 'token': '(imp)' },
+	// 	'context': {
+	// 		'notprecededby': { 'tag': 'second_person' },
+	// 	},
+	// 	'suggest': {
+	// 		'message': 'Consider putting the imperative (imp) notation after the \'you\' subject of the clause.',
+	// 	},
+	// },
 	{
 		'name': 'Check for an imperative note in a complement clause',
 		'trigger': { 'token': '(imp)' },
 		'context': {
-			'precededby': { 'tag': 'complementizer', 'skip': 'all' },
+			'precededby': { 'token': '[', 'skip': 'all' },
+			'notprecededby': { 'token': '"', 'skip': 'all' },
 		},
 		'require': {
 			'message': 'Cannot mark complement clauses as imperative.',
@@ -214,10 +218,11 @@ const checker_rules_json = [
 		},
 	},
 	{
+		// TODO check this via case frame/usage rules
 		'name': 'Expect a [ before an adverbial clause',
 		'trigger': { 'category': 'Adposition', 'usage': 'C' },
 		'context': {
-			'notprecededby': { 'token': '[' },
+			'notprecededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
 		},
 		'require': {
 			'precededby': '[',
@@ -233,6 +238,17 @@ const checker_rules_json = [
 		'require': {
 			'followedby': '[',
 			'message': 'Missing bracket before an opening quote',
+		},
+	},
+	{
+		'name': 'Expect a , before a quote_begin clause',
+		'trigger': { 'tag': 'patient_clause_quote_begin' },
+		'context': {
+			'notprecededby': { 'token': ',' },
+		},
+		'require': {
+			'precededby': ',',
+			'message': 'Missing comma before an opening quote',
 		},
 	},
 	{
@@ -379,23 +395,18 @@ const checker_rules_json = [
 	},
 	{
 		'name': 'Use \'all of\' rather than \'all\' for non-generic Nouns',
-		'trigger': { 'token': 'all' },
+		'trigger': { 'stem': 'all' },
 		'context': {
-			'notfollowedby': [
-				{
-					'token': 'of|_generic',
-					'skip': [
-						{ 'token': 'the|those|these' },
-						{ 'category': 'Noun' },
-					],
-				},
-			],
+			'notfollowedby': {
+				'token': 'of|_generic',
+				'skip': 'np',
+			},
 		},
-		'suggest': {
+		'require': {
 			'followedby': 'of',
 			'message': 'Use \'all of\' unless the modified Noun should be generic, in which case add \'_generic\' after the Noun. See P1 Checklist 0.17.',
 		},
-		'comment': 'See section 0.17 of the Phase 1 checklist',
+		'comment': 'This may still miss cases because it doesn\'t check if the \'of\' immediately follows the \'all\', but this is the best I could do.',
 	},
 	{
 		'name': 'Cannot use aspect auxilliaries (eg start) without another Verb',
@@ -563,6 +574,56 @@ const builtin_checker_rules = [
 					}
 				}
 			}),
+		},
+	},
+	{
+		name: 'Check argument structure/case frame',
+		comment: 'case frame rules can eventually be used for verbs, adjectives, adverbs, adpositions, and even conjunctions',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({ }),
+			action: (tokens, trigger_index) => {
+				validate_case_frame(tokens, trigger_index)
+				return trigger_index + 1
+			},
+		},
+	},
+	{
+		name: 'Check for an errant \'that\' in a complement clause',
+		comment: 'While TBTA sometimes accepts it, using "that" as a complementizer is too inconsistent and so is not allowed in P1',
+		rule: {
+			trigger: create_token_filter({ 'tag': 'patient_clause_different_participant|agent_clause' }),
+			context: create_context_filter({
+				'subtokens': { 'token': 'that', 'skip': { 'token': '[' } },
+			}),
+			action: create_token_modify_action(token => {
+				token.sub_tokens[1].suggest_message = 'If this \'that\' is not supposed to be a demonstrative, consider removing it. Avoid using \'that\' as a complementizer in general.'
+			}),
+		},
+	},
+	{
+		name: 'Check for a relative clause that might supposed to be a complement clause',
+		comment: 'While TBTA sometimes accepts it, using "that" as a complementizer is too inconsistent and so is not allowed in P1',
+		rule: {
+			trigger: create_token_filter({ 'tag': 'relative_clause_that' }),
+			context: create_context_filter({
+				'precededby': { 'category': 'Verb', 'skip': 'all' },
+			}),
+			action: (tokens, trigger_index, context_indexes) => {
+				const verb_token = tokens[context_indexes[0]]
+				const case_frames = verb_token.lookup_results.map(result => result.case_frame)
+				if (case_frames.length === 0 || case_frames[0].is_valid) {
+					return trigger_index + 1
+				}
+				const missing_arguments = new Set(case_frames.flatMap(case_frame => case_frame.missing_arguments))
+
+				// Only show the message if all senses are invalid, but some are missing a patient clause
+				if (['agent_clause', 'patient_clause_different_participant'].some(role => missing_arguments.has(role))) {
+					const that_token = tokens[trigger_index].sub_tokens[1]
+					that_token.suggest_message = 'This is being interpreted as a relative clause. If it\'s supposed to be a complement clause, remove the \'that\'.'
+				}
+				return trigger_index + 1
+			},
 		},
 	},
 ]

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -89,20 +89,8 @@ const checker_rules_json = [
 			'message': 'An imperative clause must have an explicit subject.',
 		},
 	},
-	// TODO uncomment when tags are expanded. currently tags keep getting overwritten, so
-	// at this point, the tag is not necessarily 'second_person' anymore.
-	// {
-	// 	'name': 'Check for an imperative note that does not follow the \'you\'',
-	// 	'trigger': { 'token': '(imp)' },
-	// 	'context': {
-	// 		'notprecededby': { 'tag': 'second_person' },
-	// 	},
-	// 	'suggest': {
-	// 		'message': 'Consider putting the imperative (imp) notation after the \'you\' subject of the clause.',
-	// 	},
-	// },
 	{
-		'name': 'Check for an imperative note in a complement clause',
+		'name': 'Check for an imperative note in a non-quote subordinate clause',
 		'trigger': { 'token': '(imp)' },
 		'context': {
 			'precededby': { 'token': '[', 'skip': 'all' },

--- a/app/src/lib/rules/checker_rules.test.js
+++ b/app/src/lib/rules/checker_rules.test.js
@@ -3,6 +3,7 @@ import { ERRORS } from '../parser/error_messages'
 import { apply_rules } from './rules_processor'
 import { describe, expect, test } from 'vitest'
 import { CHECKER_RULES } from './checker_rules'
+import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -62,6 +63,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		form: 'stem',
 		concept,
 		how_to: [],
+		case_frame: create_case_frame(),
 	}
 }
 

--- a/app/src/lib/rules/checker_rules.test.js
+++ b/app/src/lib/rules/checker_rules.test.js
@@ -1,9 +1,8 @@
-import { TOKEN_TYPE, create_clause_token, create_token, flatten_sentence } from '../parser/token'
+import { TOKEN_TYPE, create_clause_token, create_lookup_result, create_token, flatten_sentence } from '../parser/token'
 import { ERRORS } from '../parser/error_messages'
 import { apply_rules } from './rules_processor'
 import { describe, expect, test } from 'vitest'
 import { CHECKER_RULES } from './checker_rules'
-import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -47,7 +46,7 @@ function create_sentence(tokens) {
  * @param {number} [data.level=1] 
  * @returns {LookupResult}
  */
-function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+function lookup_w_concept(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
 	const concept = {
 		id: '0',
 		stem,
@@ -57,14 +56,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		gloss: '',
 		categorization: '',
 	}
-	return {
-		stem,
-		part_of_speech,
-		form: 'stem',
-		concept,
-		how_to: [],
-		case_frame: create_case_frame(),
-	}
+	return create_lookup_result({ stem, part_of_speech }, { concept })
 }
 
 describe('built-in checker rules', () => {
@@ -73,11 +65,11 @@ describe('built-in checker rules', () => {
 
 		test('different levels', () => {
 			const test_tokens = [create_sentence([
-				create_lookup_token('token0', { lookup_results: [create_lookup_result('token0', { level: 0 })] }),
-				create_lookup_token('token1', { lookup_results: [create_lookup_result('token1', { level: 1 })] }),
-				create_lookup_token('token2', { lookup_results: [create_lookup_result('token2', { level: 2 })] }),
-				create_lookup_token('token3', { lookup_results: [create_lookup_result('token3', { level: 3 })] }),
-				create_lookup_token('token4', { lookup_results: [create_lookup_result('token4', { level: 4 })] }),
+				create_lookup_token('token0', { lookup_results: [lookup_w_concept('token0', { level: 0 })] }),
+				create_lookup_token('token1', { lookup_results: [lookup_w_concept('token1', { level: 1 })] }),
+				create_lookup_token('token2', { lookup_results: [lookup_w_concept('token2', { level: 2 })] }),
+				create_lookup_token('token3', { lookup_results: [lookup_w_concept('token3', { level: 3 })] }),
+				create_lookup_token('token4', { lookup_results: [lookup_w_concept('token4', { level: 4 })] }),
 			])]
 	
 			const checked_tokens = apply_rules(test_tokens, LEVEL_CHECK_RULES).flatMap(flatten_sentence)
@@ -91,12 +83,12 @@ describe('built-in checker rules', () => {
 		test('pairing: both words right level', () => {
 			const test_tokens = [create_sentence([
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 0 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 2 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 0 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 2 })] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 3 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 3 })] }),
 				),
 			])]
 	
@@ -107,8 +99,8 @@ describe('built-in checker rules', () => {
 		test('pairing: level 4 words are valid for both', () => {
 			const test_tokens = [create_sentence([
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 4 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 4 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 4 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 4 })] }),
 				),
 			])]
 	
@@ -119,12 +111,12 @@ describe('built-in checker rules', () => {
 		test('pairing: first word wrong level', () => {
 			const test_tokens = [create_sentence([
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 2 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 2 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 2 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 2 })] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 3 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 3 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 3 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 3 })] }),
 				),
 			])]
 	
@@ -138,12 +130,12 @@ describe('built-in checker rules', () => {
 		test('pairing: second word wrong level', () => {
 			const test_tokens = [create_sentence([
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 0 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 0 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 0 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 0 })] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 1 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 1 })] }),
 				),
 			])]
 	
@@ -157,12 +149,12 @@ describe('built-in checker rules', () => {
 		test('pairing: both words wrong level', () => {
 			const test_tokens = [create_sentence([
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 2 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 0 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 2 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 0 })] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 3 })] }),
-					create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 1 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 3 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 1 })] }),
 				),
 			])]
 	
@@ -182,16 +174,16 @@ describe('built-in checker rules', () => {
 			const test_tokens = [create_sentence([
 				create_lookup_token('token', { lookup_results: [] }),
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token', { level: 1 }),
-					create_lookup_result('token2', { level: 2 }),
+					lookup_w_concept('token', { level: 1 }),
+					lookup_w_concept('token2', { level: 2 }),
 				] }),
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token', { level: 1 }),
-					create_lookup_result('token4', { level: 4 }),
+					lookup_w_concept('token', { level: 1 }),
+					lookup_w_concept('token4', { level: 4 }),
 				] }),
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token', { level: 2 }),
-					create_lookup_result('token1', { level: 1 }),
+					lookup_w_concept('token', { level: 2 }),
+					lookup_w_concept('token1', { level: 1 }),
 				] }),
 			])]
 	
@@ -205,28 +197,28 @@ describe('built-in checker rules', () => {
 		test('complex pairing level check', () => {
 			const test_tokens = [create_sentence([
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
 					create_lookup_token('second', { lookup_results: [] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
 					create_lookup_token('second', { lookup_results: [
-						create_lookup_result('second', { level: 2 }),
-						create_lookup_result('second1', { level: 1 }),
+						lookup_w_concept('second', { level: 2 }),
+						lookup_w_concept('second1', { level: 1 }),
 					] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
 					create_lookup_token('second', { lookup_results: [
-						create_lookup_result('second', { level: 2 }),
-						create_lookup_result('second1', { level: 4 }),
+						lookup_w_concept('second', { level: 2 }),
+						lookup_w_concept('second1', { level: 4 }),
 					] }),
 				),
 				create_pairing_token(
-					create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
+					create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
 					create_lookup_token('second', { lookup_results: [
-						create_lookup_result('second', { level: 1 }),
-						create_lookup_result('second2', { level: 2 }),
+						lookup_w_concept('second', { level: 1 }),
+						lookup_w_concept('second2', { level: 2 }),
 					] }),
 				),
 			])]

--- a/app/src/lib/rules/index.js
+++ b/app/src/lib/rules/index.js
@@ -5,6 +5,8 @@ import { PART_OF_SPEECH_RULES } from './part_of_speech_rules'
 import { rules_applier } from './rules_processor'
 import { TRANSFORM_RULES } from './transform_rules'
 import { PRONOUN_RULES } from './pronoun_rules'
+import { CASE_FRAME_RULES } from './case_frame'
+import { SENSE_RULES } from './sense_selection_rules'
 
 const RULES = {
 	PRONOUN: PRONOUN_RULES,
@@ -12,6 +14,8 @@ const RULES = {
 	SYNTAX: SYNTAX_RULES,
 	PART_OF_SPEECH: PART_OF_SPEECH_RULES,
 	TRANSFORM: TRANSFORM_RULES,
+	CASE_FRAME: CASE_FRAME_RULES,
+	SENSE: SENSE_RULES,	// TODO maybe these can be lumped in with the case-frame rules?
 	CHECKER: CHECKER_RULES,
 }
 

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -128,7 +128,7 @@ const lookup_rules_json = [
 		'name': 'like -> just-like (the adposition)',
 		'trigger': { 'token': 'like' },
 		'lookup': 'like|just-like',
-		'comment': 'this is needed so the adposition is found as well, which is handled by words like be/seem/sound/etc'
+		'comment': 'this is needed so the adposition is found as well, which is handled by words like be/seem/sound/etc',
 	},
 	{
 		'name': 'worry about',

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -125,6 +125,12 @@ const lookup_rules_json = [
 		'combine': 1,
 	},
 	{
+		'name': 'like -> just-like (the adposition)',
+		'trigger': { 'token': 'like' },
+		'lookup': 'like|just-like',
+		'comment': 'this is needed so the adposition is found as well, which is handled by words like be/seem/sound/etc'
+	},
+	{
 		'name': 'worry about',
 		'trigger': { 'stem': 'worry' },
 		'context': { 'followedby': { 'token': 'about' } },
@@ -173,7 +179,7 @@ export function parse_lookup_rule(rule_json) {
 	 * @returns {number}
 	 */
 	function lookup_rule_action(tokens, trigger_index, context_indexes) {
-		tokens[trigger_index] = { ...tokens[trigger_index], type: TOKEN_TYPE.LOOKUP_WORD, lookup_terms: [lookup_term] }
+		tokens[trigger_index] = { ...tokens[trigger_index], type: TOKEN_TYPE.LOOKUP_WORD, lookup_terms: lookup_term.split('|') }
 
 		if (context_indexes.length === 0) {
 			return trigger_index + 1

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -157,7 +157,7 @@ const part_of_speech_rules_json = [
 			'precededby': { 'category': 'Verb', 'stem': 'be|feel', 'skip': ['vp_modifiers', 'adjp_modifiers_predicative'] },
 		},
 		'remove': 'Noun',
-		'comment': 'Infected Eye 1:1 Melissa\'s eye is sore(N/Adj).  Infected Eye 1:15 Janet\'s eyes were still sore(N/Adj).',
+		'comment': "Infected Eye 1:1 Melissa's eye is sore(N/Adj).  Infected Eye 1:15 Janet's eyes were still sore(N/Adj).",
 	},
 	{
 		'name': 'If Verb-Adjective preceded by an article or possessive, remove Verb',

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -142,6 +142,24 @@ const part_of_speech_rules_json = [
 		'comment': 'Daniel 7:4 I saw the second(N/Adj) animal.',
 	},
 	{
+		'name': 'If Noun-Adjective followed by Verb, remove Adjective',
+		'category': 'Noun|Adjective',
+		'context': {
+			'followedby': { 'category': 'Verb' },
+		},
+		'remove': 'Noun',
+		'comment': 'Daniel 7:4 I saw the second(N/Adj) animal.',
+	},
+	{
+		'name': 'If Noun-Adjective preceded by \'be\' or \'feel\', remove Noun',
+		'category': 'Noun|Adjective',
+		'context': {
+			'precededby': { 'category': 'Verb', 'stem': 'be|feel', 'skip': ['vp_modifiers', 'adjp_modifiers'] },
+		},
+		'remove': 'Noun',
+		'comment': 'Infected Eye 1:1 Melissa\'s eye is sore(N/Adj).  Infected Eye 1:15 Janet\'s eyes were still sore(N/Adj).',
+	},
+	{
 		'name': 'If Verb-Adjective preceded by an article or possessive, remove Verb',
 		'category': 'Verb|Adjective',
 		'context': {
@@ -180,6 +198,15 @@ const part_of_speech_rules_json = [
 		'comment': 'Luke 3:22 I am pleased(V/Adj) with you.',
 	},
 	{
+		'name': 'If Adjective-Adverb followed by Noun, remove the Adverb',
+		'category': 'Adverb|Adjective',
+		'context': {
+			'followedby': { 'category': 'Noun' },
+		},
+		'remove': 'Adverb',
+		'comment': 'Dan. 1:12 Please give only(Adj/Adv) vegetables ...',
+	},
+	{
 		'name': 'If Adverb-Adjective followed by Verb, remove Adjective',
 		'category': 'Adverb|Adjective',
 		'context': {
@@ -187,6 +214,33 @@ const part_of_speech_rules_json = [
 		},
 		'remove': 'Adjective',
 		'comment': 'Infected Eye 1:5  You must first(Adj/Adv) wash ...',
+	},
+	{
+		'name': 'If Adverb-Adposition followed by a Noun, delete the Adverb',
+		'category': 'Adverb|Adposition',
+		'context': {
+			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
+		},
+		'remove': 'Adverb',
+		'comment': 'Daniel 1:1 when(Adv/Adp) Jehoiakim ... 3:5 when(Adv/Adp) the people hear ...',
+	},
+	{
+		'name': 'If Verb-Adposition precededby by a modal or \'not\', delete the Adposition',
+		'category': 'Verb|Adposition',
+		'context': {
+			'precededby': { 'tag': 'modal|negative_verb_polarity', 'skip': 'vp_modifiers' },
+		},
+		'remove': 'Adposition',
+		'comment': 'John should like(V/Adp) that book.',
+	},
+	{
+		'name': 'If Verb-Adposition at the beginning of a clause, delete the Verb',
+		'category': 'Verb|Adposition',
+		'context': {
+			'precededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
+		},
+		'remove': 'Verb',
+		'comment': 'Daniel 2:40  The fourth kingom will be strong [like(V/Adp) iron is strong].',
 	},
 ]
 

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -63,7 +63,7 @@ const part_of_speech_rules_json = [
 		'name': 'If Noun-Verb preceded by an \'s, delete the Verb',
 		'category': 'Noun|Verb',
 		'context': {
-			'precededby': { 'tag': 'genitive_saxon', 'skip': { 'category': 'Adjective' } },
+			'precededby': { 'tag': 'genitive_saxon', 'skip': 'adjp_attributive' },
 		},
 		'remove': 'Verb',
 		'comment': 'Gideon returned to the Israelite\'s camp.',
@@ -120,26 +120,26 @@ const part_of_speech_rules_json = [
 		'comment': 'John only(Adv/Adj) saw a book.',
 	},
 	{
+		'name': 'If Noun-Adjective followed by Noun, remove Noun',
+		'category': 'Noun|Adjective',
+		'context': {
+			'followedby': { 'category': 'Noun', 'skip': 'adjp_attributive' },
+		},
+		'remove': 'Noun',
+		'comment': 'Daniel 7:4 I saw the second(N/Adj) animal. The chief(N/Adj) evil spirit.',
+	},
+	{
 		'name': 'If Noun-Adjective is preceded by an article but not followed by Noun, remove Adjective',
 		'category': 'Noun|Adjective',
 		'context': {
 			'precededby': {
-				'tag': 'indefinite_article|definite_article|near_demonstrative|remote_demonstrative',
-				'skip': { 'category': 'Adjective' },
+				'tag': 'indefinite_article|definite_article|near_demonstrative|remote_demonstrative|negative_noun_polarity',
+				'skip': 'adjp_attributive',
 			},
-			'notfollowedby': { 'category': 'Noun' },
+			'notfollowedby': { 'category': 'Noun', 'skip': 'adjp_attributive' },
 		},
 		'remove': 'Adjective',
 		'comment': 'John knew about the secret(N/Adj).',
-	},
-	{
-		'name': 'If Noun-Adjective followed by Noun, remove Noun',
-		'category': 'Noun|Adjective',
-		'context': {
-			'followedby': { 'category': 'Noun' },
-		},
-		'remove': 'Noun',
-		'comment': 'Daniel 7:4 I saw the second(N/Adj) animal.',
 	},
 	{
 		'name': 'If Noun-Adjective followed by Verb, remove Adjective',
@@ -148,13 +148,13 @@ const part_of_speech_rules_json = [
 			'followedby': { 'category': 'Verb' },
 		},
 		'remove': 'Noun',
-		'comment': 'Daniel 7:4 I saw the second(N/Adj) animal.',
+		'comment': 'Daniel 3:4 The one official(N/Adj) shouted ...',
 	},
 	{
 		'name': 'If Noun-Adjective preceded by \'be\' or \'feel\', remove Noun',
 		'category': 'Noun|Adjective',
 		'context': {
-			'precededby': { 'category': 'Verb', 'stem': 'be|feel', 'skip': ['vp_modifiers', 'adjp_modifiers'] },
+			'precededby': { 'category': 'Verb', 'stem': 'be|feel', 'skip': ['vp_modifiers', 'adjp_modifiers_predicative'] },
 		},
 		'remove': 'Noun',
 		'comment': 'Infected Eye 1:1 Melissa\'s eye is sore(N/Adj).  Infected Eye 1:15 Janet\'s eyes were still sore(N/Adj).',

--- a/app/src/lib/rules/part_of_speech_rules.test.js
+++ b/app/src/lib/rules/part_of_speech_rules.test.js
@@ -3,6 +3,7 @@ import { ERRORS } from '../parser/error_messages'
 import { apply_rules } from './rules_processor'
 import { describe, expect, test } from 'vitest'
 import { PART_OF_SPEECH_RULES } from './part_of_speech_rules'
+import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -62,6 +63,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		form: 'stem',
 		concept,
 		how_to: [],
+		case_frame: create_case_frame(),
 	}
 }
 

--- a/app/src/lib/rules/part_of_speech_rules.test.js
+++ b/app/src/lib/rules/part_of_speech_rules.test.js
@@ -1,9 +1,8 @@
-import { TOKEN_TYPE, create_clause_token, create_token, flatten_sentence } from '../parser/token'
+import { TOKEN_TYPE, create_clause_token, create_lookup_result, create_token, flatten_sentence } from '../parser/token'
 import { ERRORS } from '../parser/error_messages'
 import { apply_rules } from './rules_processor'
 import { describe, expect, test } from 'vitest'
 import { PART_OF_SPEECH_RULES } from './part_of_speech_rules'
-import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -47,7 +46,7 @@ function create_sentence(tokens) {
  * @param {number} [data.level=1] 
  * @returns {LookupResult}
  */
-function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+function lookup_w_concept(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
 	const concept = {
 		id: '0',
 		stem,
@@ -57,14 +56,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		gloss: '',
 		categorization: '',
 	}
-	return {
-		stem,
-		part_of_speech,
-		form: 'stem',
-		concept,
-		how_to: [],
-		case_frame: create_case_frame(),
-	}
+	return create_lookup_result({ stem, part_of_speech }, { concept })
 }
 
 describe('pairing part_of_speech disambiguation', () => {
@@ -72,8 +64,8 @@ describe('pairing part_of_speech disambiguation', () => {
 		const test_tokens = [create_sentence([
 			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
 			create_pairing_token(
-				create_lookup_token('first', { lookup_results: [create_lookup_result('first', { level: 1 })] }),
-				create_lookup_token('second', { lookup_results: [create_lookup_result('second', { level: 2 })] }),
+				create_lookup_token('first', { lookup_results: [lookup_w_concept('first', { level: 1 })] }),
+				create_lookup_token('second', { lookup_results: [lookup_w_concept('second', { level: 2 })] }),
 			),
 			create_token('.', TOKEN_TYPE.PUNCTUATION),
 		])]
@@ -87,12 +79,12 @@ describe('pairing part_of_speech disambiguation', () => {
 			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
 			create_pairing_token(
 				create_lookup_token('first', { lookup_results: [
-					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
-					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
+					lookup_w_concept('first', { part_of_speech: 'Noun', level: 1 }),
+					lookup_w_concept('first', { part_of_speech: 'Verb', level: 1 }),
 				] }),
 				create_lookup_token('second', { lookup_results: [
-					create_lookup_result('second', { part_of_speech: 'Verb', level: 2 }),
-					create_lookup_result('second', { part_of_speech: 'Adjective', level: 2 }),
+					lookup_w_concept('second', { part_of_speech: 'Verb', level: 2 }),
+					lookup_w_concept('second', { part_of_speech: 'Adjective', level: 2 }),
 				] }),
 			),
 			create_token('.', TOKEN_TYPE.PUNCTUATION),
@@ -113,12 +105,12 @@ describe('pairing part_of_speech disambiguation', () => {
 			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
 			create_pairing_token(
 				create_lookup_token('first', { lookup_results: [
-					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
-					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
+					lookup_w_concept('first', { part_of_speech: 'Noun', level: 1 }),
+					lookup_w_concept('first', { part_of_speech: 'Verb', level: 1 }),
 				] }),
 				create_lookup_token('second', { lookup_results: [
-					create_lookup_result('second', { part_of_speech: 'Verb', level: 2 }),
-					create_lookup_result('second', { part_of_speech: 'Noun', level: 2 }),
+					lookup_w_concept('second', { part_of_speech: 'Verb', level: 2 }),
+					lookup_w_concept('second', { part_of_speech: 'Noun', level: 2 }),
 				] }),
 			),
 			create_token('.', TOKEN_TYPE.PUNCTUATION),
@@ -133,12 +125,12 @@ describe('pairing part_of_speech disambiguation', () => {
 			create_token('A', TOKEN_TYPE.FUNCTION_WORD),
 			create_pairing_token(
 				create_lookup_token('first', { lookup_results: [
-					create_lookup_result('first', { part_of_speech: 'Noun', level: 1 }),
-					create_lookup_result('first', { part_of_speech: 'Verb', level: 1 }),
+					lookup_w_concept('first', { part_of_speech: 'Noun', level: 1 }),
+					lookup_w_concept('first', { part_of_speech: 'Verb', level: 1 }),
 				] }),
 				create_lookup_token('second', { lookup_results: [
-					create_lookup_result('second', { part_of_speech: 'Adjective', level: 2 }),
-					create_lookup_result('second', { part_of_speech: 'Adverb', level: 2 }),
+					lookup_w_concept('second', { part_of_speech: 'Adjective', level: 2 }),
+					lookup_w_concept('second', { part_of_speech: 'Adverb', level: 2 }),
 				] }),
 			),
 			create_token('.', TOKEN_TYPE.PUNCTUATION),

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -428,13 +428,20 @@ export function create_token_modify_action(action) {
 const SKIP_GROUPS = new Map([
 	['determiners', { 'tag': 'indefinite_article|definite_article|near_demonstrative|remote_demonstrative|negative_noun_polarity' }],
 	['degree_indicators', { 'tag': 'intensified_degree|extremely_intensified_degree|least_degree|comparative_degree|too_degree' }],
-	['adjp_modifiers', [
+	['adjp_modifiers_predicative', [
 		'degree_indicators',
 		{ 'tag': 'patient_clause_same_participant|patient_clause_different_participant' },	// some adjectives can take a patient argument
 		{ 'category': 'Adverb' },
 	]],
-	['adjp', [
-		'adjp_modifiers',
+	['adjp_predicative', [
+		'adjp_modifiers_predicative',
+		{ 'category': 'Adjective' },
+	]],
+	['adjp_modifiers_attributive', [
+		'degree_indicators',
+	]],
+	['adjp_attributive', [
+		'adjp_modifiers_attributive',
 		{ 'category': 'Adjective' },
 	]],
 	['advp_modifiers', [
@@ -447,7 +454,7 @@ const SKIP_GROUPS = new Map([
 	['np_modifiers', [
 		{ 'tag': 'genitive_saxon|genitive_norman|relative_clause' },
 		'determiners',
-		'adjp',
+		'adjp_attributive',
 	]],
 	['np', [
 		'np_modifiers',

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -42,11 +42,14 @@ export function create_token_filter(filter_json) {
 	// only support single character usages right now
 	add_lookup_filter('usage', filter_value => has_usage(filter_value))
 
-	add_lookup_filter('form', filter_value => lookup => get_value_checker(lookup.form)(filter_value))
+	add_lookup_filter('form', filter_value => {
+		const filter_forms = filter_value.split('|')
+		return lookup => {
+			const lookup_forms = lookup.form.split('|')
+			return lookup_forms.some(form => filter_forms.includes(form))
+		}
+	})
 
-	if (filters.length === 0) {
-		return () => false
-	}
 	return token => filters.every(filter => filter(token))
 
 	/**
@@ -427,6 +430,7 @@ const SKIP_GROUPS = new Map([
 	['degree_indicators', { 'tag': 'intensified_degree|extremely_intensified_degree|least_degree|comparative_degree|too_degree' }],
 	['adjp_modifiers', [
 		'degree_indicators',
+		{ 'tag': 'patient_clause_same_participant|patient_clause_different_participant' },	// some adjectives can take a patient argument
 		{ 'category': 'Adverb' },
 	]],
 	['adjp', [
@@ -450,7 +454,7 @@ const SKIP_GROUPS = new Map([
 		{ 'category': 'Noun' },
 	]],
 	['vp_modifiers', [
-		{ 'tag': 'negative_verb_polarity|modal|infinitive|auxilliary' },
+		{ 'tag': 'negative_verb_polarity|modal|infinitive|auxiliary' },
 		{ 'category': 'Adverb' },
 	]],
 	['vp', [

--- a/app/src/lib/rules/rules_parser.test.js
+++ b/app/src/lib/rules/rules_parser.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { TOKEN_TYPE, create_token } from '../parser/token'
+import { TOKEN_TYPE, create_token, create_lookup_result } from '../parser/token'
 import { create_context_filter, create_token_filter, create_token_transform } from './rules_parser'
-import { create_case_frame } from './case_frame'
 
 describe('token filters', () => {
 	test('all', () => {
@@ -391,7 +390,7 @@ describe('context filters', () => {
  * @param {number} [data.level=1] 
  * @returns {LookupResult}
  */
-function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+function lookup_w_concept(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
 	const concept = {
 		id: '0',
 		stem,
@@ -401,14 +400,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		gloss: '',
 		categorization: '',
 	}
-	return {
-		stem,
-		part_of_speech,
-		form: 'stem',
-		concept,
-		how_to: [],
-		case_frame: create_case_frame(),
-	}
+	return create_lookup_result({ stem, part_of_speech }, { concept })
 }
 
 describe('token transforms', () => {
@@ -441,8 +433,8 @@ describe('token transforms', () => {
 
 		const token = create_token('token', TOKEN_TYPE.LOOKUP_WORD, { lookup_term: 'token' })
 		token.lookup_results = [
-			create_lookup_result('concept', { 'sense': 'A', 'part_of_speech': 'Noun' }),
-			create_lookup_result('concept', { 'sense': 'B', 'part_of_speech': 'Noun' }),
+			lookup_w_concept('concept', { 'sense': 'A', 'part_of_speech': 'Noun' }),
+			lookup_w_concept('concept', { 'sense': 'B', 'part_of_speech': 'Noun' }),
 		]
 
 		const result = transform(token)

--- a/app/src/lib/rules/rules_parser.test.js
+++ b/app/src/lib/rules/rules_parser.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { TOKEN_TYPE, create_token } from '../parser/token'
 import { create_context_filter, create_token_filter, create_token_transform } from './rules_parser'
+import { create_case_frame } from './case_frame'
 
 describe('token filters', () => {
 	test('all', () => {
@@ -84,7 +85,7 @@ describe('context filters', () => {
 
 		expect(results.every(result => result.success)).toBe(true)
 	})
-	test('invalid filter results in false', () => {
+	test('invalid filter results in true', () => {
 		const context_json = { 'followedby': 'invalid' }
 		const filter = create_context_filter(context_json)
 
@@ -95,7 +96,20 @@ describe('context filters', () => {
 		]
 		const results = tokens.map((_, i) => filter(tokens, i))
 
-		expect(results.some(result => result.success)).toBe(false)
+		expect(results.some(result => result.success)).toBe(true)
+	})
+	test('empty filter results in true', () => {
+		const context_json = { 'followedby': { } }
+		const filter = create_context_filter(context_json)
+
+		const tokens = [
+			create_token('text', TOKEN_TYPE.LOOKUP_WORD, { lookup_term: 'text' }),
+			create_token('token', TOKEN_TYPE.LOOKUP_WORD, { lookup_term: 'token' }),
+			create_token('other', TOKEN_TYPE.LOOKUP_WORD, { lookup_term: 'other' }),
+		]
+		const results = tokens.map((_, i) => filter(tokens, i))
+
+		expect(results.some(result => result.success)).toBe(true)
 	})
 	test('followed by', () => {
 		const context_json = { 'followedby': { 'token': 'other' } }
@@ -393,6 +407,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		form: 'stem',
 		concept,
 		how_to: [],
+		case_frame: create_case_frame(),
 	}
 }
 

--- a/app/src/lib/rules/rules_processor.test.js
+++ b/app/src/lib/rules/rules_processor.test.js
@@ -5,6 +5,7 @@ import { LOOKUP_RULES } from './lookup_rules'
 import { parse_transform_rule } from './transform_rules'
 import { parse_checker_rule } from './checker_rules'
 import { parse_part_of_speech_rule } from './part_of_speech_rules'
+import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -53,6 +54,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		form: 'stem',
 		concept,
 		how_to: [],
+		case_frame: create_case_frame(),
 	}
 }
 

--- a/app/src/lib/rules/rules_processor.test.js
+++ b/app/src/lib/rules/rules_processor.test.js
@@ -1,11 +1,10 @@
-import { TOKEN_TYPE, create_clause_token, create_token, flatten_sentence } from '$lib/parser/token'
+import { TOKEN_TYPE, create_clause_token, create_lookup_result, create_token, flatten_sentence } from '$lib/parser/token'
 import { describe, expect, test } from 'vitest'
 import { apply_rules } from './rules_processor'
 import { LOOKUP_RULES } from './lookup_rules'
 import { parse_transform_rule } from './transform_rules'
 import { parse_checker_rule } from './checker_rules'
 import { parse_part_of_speech_rule } from './part_of_speech_rules'
-import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -38,7 +37,7 @@ function create_lookup_token(token, { lookup_results=[] }={}) {
  * @param {number} [data.level=1] 
  * @returns {LookupResult}
  */
-function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+function lookup_w_concept(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
 	const concept = {
 		id: '0',
 		stem,
@@ -48,14 +47,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		gloss: '',
 		categorization: '',
 	}
-	return {
-		stem,
-		part_of_speech,
-		form: 'stem',
-		concept,
-		how_to: [],
-		case_frame: create_case_frame(),
-	}
+	return create_lookup_result({ stem, part_of_speech }, { concept })
 }
 
 describe('transform rules', () => {
@@ -170,9 +162,9 @@ describe('transform rules', () => {
 			]),
 		]
 		tokens[0].clause.sub_tokens[1].lookup_results = [
-			create_lookup_result('see', { sense: 'A' }),
-			create_lookup_result('see', { sense: 'B' }),
-			create_lookup_result('see', { sense: 'C' }),
+			lookup_w_concept('see', { sense: 'A' }),
+			lookup_w_concept('see', { sense: 'B' }),
+			lookup_w_concept('see', { sense: 'C' }),
 		]
 
 		const results = apply_rules(tokens, transform_rules).flatMap(flatten_sentence)
@@ -529,7 +521,7 @@ describe('part-of-speech rules', () => {
 		const input_tokens = [
 			create_sentence([
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token', { part_of_speech: 'Adjective' }),
+					lookup_w_concept('token', { part_of_speech: 'Adjective' }),
 				] }),
 			]),
 		]
@@ -550,8 +542,8 @@ describe('part-of-speech rules', () => {
 		const input_tokens = [
 			create_sentence([
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token1', { part_of_speech: 'Noun' }),
-					create_lookup_result('token2', { part_of_speech: 'Noun' }),
+					lookup_w_concept('token1', { part_of_speech: 'Noun' }),
+					lookup_w_concept('token2', { part_of_speech: 'Noun' }),
 				] }),
 			]),
 		]
@@ -572,10 +564,10 @@ describe('part-of-speech rules', () => {
 		const input_tokens = [
 			create_sentence([
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token1', { part_of_speech: 'Noun' }),
-					create_lookup_result('token2', { part_of_speech: 'Noun' }),
-					create_lookup_result('token1', { part_of_speech: 'Verb' }),
-					create_lookup_result('token2', { part_of_speech: 'Verb' }),
+					lookup_w_concept('token1', { part_of_speech: 'Noun' }),
+					lookup_w_concept('token2', { part_of_speech: 'Noun' }),
+					lookup_w_concept('token1', { part_of_speech: 'Verb' }),
+					lookup_w_concept('token2', { part_of_speech: 'Verb' }),
 				] }),
 			]),
 		]
@@ -598,11 +590,11 @@ describe('part-of-speech rules', () => {
 		const input_tokens = [
 			create_sentence([
 				create_lookup_token('token', { lookup_results: [
-					create_lookup_result('token1', { part_of_speech: 'Noun' }),
-					create_lookup_result('token2', { part_of_speech: 'Noun' }),
-					create_lookup_result('token1', { part_of_speech: 'Verb' }),
-					create_lookup_result('token2', { part_of_speech: 'Verb' }),
-					create_lookup_result('token1', { part_of_speech: 'Adjective' }),
+					lookup_w_concept('token1', { part_of_speech: 'Noun' }),
+					lookup_w_concept('token2', { part_of_speech: 'Noun' }),
+					lookup_w_concept('token1', { part_of_speech: 'Verb' }),
+					lookup_w_concept('token2', { part_of_speech: 'Verb' }),
+					lookup_w_concept('token1', { part_of_speech: 'Adjective' }),
 				] }),
 			]),
 		]

--- a/app/src/lib/rules/sense_selection_rules.js
+++ b/app/src/lib/rules/sense_selection_rules.js
@@ -128,7 +128,7 @@ const sense_rules = [
 			action: (tokens, trigger_index) => {
 				select_verb_sense(tokens, trigger_index)
 				return trigger_index + 1
-			}
+			},
 		},
 	},
 ]

--- a/app/src/lib/rules/sense_selection_rules.js
+++ b/app/src/lib/rules/sense_selection_rules.js
@@ -1,0 +1,195 @@
+import { find_result_index, set_token_concept } from '$lib/parser/token'
+import { create_context_filter, create_token_filter } from './rules_parser'
+
+/**
+ * These rules help decide which sense to select from the ones that match the argument structure.
+ * They are ordered by priority, and can provide additional filtering of the verb or arguments to
+ * narrow down the match.
+ * A sense can also have multiple rows in case there are multiple incompatible filters to check.
+ * TODO store these in the db
+ * 
+ * @typedef {[string, any]} SenseRules
+ * @type {[WordStem, SenseRules[]][]}
+ */
+const verb_sense_rules = [
+	['be', [
+		// 'be' is very particular and so each sense is specified to make the priority clear. Not all verbs will need this.
+		// For example, both be-I and be-F would match 'John is with Mary'
+		// but be-I is more specific and should be selected over be-F.
+		// senses with unique structures
+		['be-A', { }],	// patient proposition
+		['be-V', { }],	// agent proposition
+		['be-E', { }],	// existential
+		// senses with adpositions in 'state'
+		['be-I', { }],	// accompaniment (with)
+		['be-G', { }],	// benefactive
+		['be-P', { }],	// depiction (about)
+		['be-R', { }],	// partitive (part)
+		['be-T', { }],	// place of origin (from)
+		['be-U', { }],	// be like
+		['be-X', { }],	// metaphorical
+		['be-H', { 'state': { 'stem': 'day|morning|afternoon|evening|Sabbath' } }],	// temporal TODO check features of word from lexicon
+		['be-W', { 'state': { 'stem': 'family|tribe' } }],
+		// senses with unique agents
+		['be-J', { 'agent': { 'stem': 'date' } }],	// date
+		['be-K', { 'agent': { 'stem': 'name' } }],	// name
+		['be-N', { 'agent': { 'stem': 'time' } }],	// time
+		['be-O', { 'agent': { 'stem': 'weather' } }],	// weather
+		// senses with unique states
+		['be-C', { 'state': {
+			'stem': 'man|woman',
+			'context': { 'precededby': [{ 'tag': 'indefinite_article', 'skip': 'adjp_modifiers' }, { 'category': 'Adjective' }] },
+		} }],	// class membership (eg. John is a wicked man)
+		['be-Q', { 'state': { 'stem': 'bronze|clay|cloth|gold|iron|metal|sackcloth|silver|wood' } } ],	// substance (made of)
+		['be-M', { 'state': { 'stem': 'ancestor|brother|child|daughter|descendant|father|husband|mother|sister|son|wife' } }],	// kinship
+		['be-L', { 'state': { 'stem': 'apostle|captain|emperor|governor|judge|king|leader|officer|official|priest|prince|prophet|queen|ruler|servant|slave' } }],	// social role
+		['be-S', { }],	// age
+		['be-B', { }],	// equative
+		// senses with adjectives
+		['be-D', { }],	// predicative
+		['be-F', { }],	// general locative
+	]],
+	['give', [
+		['give-B', { 'patient': { 'stem': 'ring|vaccine' } }],
+		// TODO add another give-B entry to use a lexicon feature to check for any person.
+		['give-C', { 'patient': { 'stem': 'authority|law|name|peace|power|promise|skill|wisdom' } }],
+	]],
+	['have', [
+		['have-H', { 'state': { 'stem': 'eunuch|man|servant|slave' } }],
+		['have-G', { 'state': { 'stem': 'feast|party' } }],
+		['have-F', { 'state': { 'stem': 'leaf|branch|wheel' } }],
+		['have-D', { 'state': { 'stem': 'authority|custom|faith|hope|life|peace|power|problem|spirit|trouble' } }],
+		['have-C', { 'state': { 'stem': 'wing|head|tooth|horn|eye|mouth|testicle' } }],
+		['have-B', { 'state': { 'stem': 'ancestor|brother|child|cousin|daughter|descendant|family|father|father-in-law|husband|mother|mother-in-law|parent|relative|sister|son|wife' } }],
+		['have-E', { 'state': { 'stem': 'AIDS|Avian-Influenza|cold|disease|fever|HIV|pain|sore|leprosy' } }],
+		['have-A', { }],
+		['have-I', { }],	// TODO use a lexicon feature to check for the agent being a place
+	]],
+	['know', [
+		['know-C', { 'patient': { 'stem': 'law|meaning|name|secret|thing' } }],
+	]],
+	['say', [
+		['say-D', { 'agent': { 'stem': 'law' } }],
+	]],
+	['see', [
+		['see-D', { 'patient': { 'stem': 'dream|vision' } }],
+		['see-C', { }],	// prioritize see-C over see-B gets selected
+	]],
+	['speak', [
+		['speak-B', { }],	// prioritize speak-B over speak-A
+	]],
+]
+
+/**
+ * @typedef {(tokens: Token[], role_matches: RoleMatchResult[]) => boolean} ArgumentMatchFilter
+ * @param {SenseRules} sense_rules 
+ * @returns {[WordSense, ArgumentMatchFilter]}
+ */
+function parse_verb_sense_rule([sense, sense_rule_json]) {
+	const role_filters = Object.entries(sense_rule_json).map(parse_sense_rule)
+	return [sense, (tokens, role_match) => role_filters.every(filter => filter(tokens, role_match))]
+
+	/**
+	 * 
+	 * @param {[RoleTag, any]} role_filter_json 
+	 * @returns {ArgumentMatchFilter}
+	 */
+	function parse_sense_rule([role_tag, role_filter_json]) {
+		const trigger = create_token_filter(role_filter_json)
+		const context = create_context_filter(role_filter_json['context'])
+
+		return (tokens, role_matches) => {
+			const match_result = role_matches.find(match => match.role_tag === role_tag)
+			if (!match_result) {
+				return false
+			}
+
+			const index = match_result.trigger_index
+			return trigger(tokens[index]) && context(tokens, index).success
+		}
+	}
+}
+
+/** @type {Map<WordStem, [WordSense, ArgumentMatchFilter][]>} */
+const VERB_SENSE_FILTER_RULES = new Map(verb_sense_rules.map(([stem, sense_rules]) => [stem, sense_rules.map(parse_verb_sense_rule)]))
+
+/** @type {BuiltInRule[]} */
+const sense_rules = [
+	{
+		name: 'Verb sense selection',
+		comment:'',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({ }),
+			action: (tokens, trigger_index) => {
+				select_verb_sense(tokens, trigger_index)
+				return trigger_index + 1
+			}
+		},
+	},
+]
+
+export const SENSE_RULES = sense_rules.map(({ rule }) => rule)
+
+/**
+ * 
+ * @param {Token[]} tokens 
+ * @param {number} token_index 
+ * @returns {WordSense | undefined}
+ */
+function find_matching_sense(tokens, token_index) {
+	const token = tokens[token_index]
+	const stem = token.lookup_results[0].stem
+	const verb_sense_filters = VERB_SENSE_FILTER_RULES.get(stem) ?? []
+	return verb_sense_filters.find(sense_matches)?.[0]
+
+	/**
+	 * 
+	 * @param {[WordSense, ArgumentMatchFilter]} sense_match_filters 
+	 * @returns 
+	 */
+	function sense_matches([sense, match_filter]) {
+		const result_index = find_result_index(token, sense)
+		if (result_index === -1) {
+			return false
+		}
+
+		const result = token.lookup_results[result_index]
+		return result.case_frame.is_valid && match_filter(tokens, result.case_frame.valid_arguments)
+	}
+}
+
+/**
+ * 
+ * @param {Token[]} tokens
+ * @param {number} verb_index
+ */
+function select_verb_sense(tokens, verb_index) {
+	const verb_token = tokens[verb_index]
+	// At this point, a token with a specified sense only has one lookup result, so can be treated normally
+	// TODO after #84 check if token has specified sense (https://github.com/presciencelabs/tabitha-editor/issues/84)
+
+	// Move the valid lookups to the top
+	const valid_lookups = verb_token.lookup_results.filter(result => result.case_frame.is_valid)
+	const invalid_lookups = verb_token.lookup_results.filter(result => !result.case_frame.is_valid)
+	verb_token.lookup_results = [...valid_lookups, ...invalid_lookups]
+	
+	// Use the matching valid sense, or else the first valid sense, or else sense A.
+	// The lookups should already be ordered alphabetically so the first valid sense is the lowest letter
+	const sense_to_select = find_matching_sense(tokens, verb_index)
+		|| `${verb_token.lookup_results[0].stem}-${valid_lookups.at(0)?.concept?.sense ?? 'A'}`
+	set_token_concept(verb_token, sense_to_select)
+
+	const selected_result = verb_token.lookup_results[0]
+	if (!selected_result.case_frame.is_valid) {
+		return
+	}
+
+	// apply the selected result's argument actions
+	for (const valid_argument of selected_result.case_frame.valid_arguments) {
+		/** @type {ArgumentRoleRule} */
+		// @ts-ignore a valid argument will always have a rule associated with it
+		const argument_rule = selected_result.case_frame.rule.rules.find(rule => rule.role_tag === valid_argument.role_tag)
+		argument_rule.action(tokens, valid_argument)
+	}
+}

--- a/app/src/lib/rules/sense_selection_rules.js
+++ b/app/src/lib/rules/sense_selection_rules.js
@@ -78,6 +78,10 @@ const verb_sense_rules = [
 	['speak', [
 		['speak-B', { }],	// prioritize speak-B over speak-A
 	]],
+	['tell', [
+		// prioritize tell-C over tell-A due to the presence of the 'about'. tell-A may count as valid if there is a relative clause on its patient.
+		['tell-C', { }],
+	]],
 ]
 
 /**

--- a/app/src/lib/rules/sense_selection_rules.js
+++ b/app/src/lib/rules/sense_selection_rules.js
@@ -38,7 +38,7 @@ const verb_sense_rules = [
 		// senses with unique states
 		['be-C', { 'state': {
 			'stem': 'man|woman',
-			'context': { 'precededby': [{ 'tag': 'indefinite_article', 'skip': 'adjp_modifiers' }, { 'category': 'Adjective' }] },
+			'context': { 'precededby': [{ 'tag': 'indefinite_article', 'skip': 'adjp_modifiers_attributive' }, { 'category': 'Adjective' }] },
 		} }],	// class membership (eg. John is a wicked man)
 		['be-Q', { 'state': { 'stem': 'bronze|clay|cloth|gold|iron|metal|sackcloth|silver|wood' } } ],	// substance (made of)
 		['be-M', { 'state': { 'stem': 'ancestor|brother|child|daughter|descendant|father|husband|mother|sister|son|wife' } }],	// kinship

--- a/app/src/lib/rules/syntax_rules.js
+++ b/app/src/lib/rules/syntax_rules.js
@@ -16,7 +16,7 @@ const builtin_syntax_rules = [
 			trigger: create_token_filter({ 'tag': 'subordinate_clause' }),
 			context: create_context_filter({ 'subtokens': { 'token': '"', 'skip': { 'token': '[' } } }),
 			action: create_token_modify_action(token => {
-				token.tag = 'patient_clause|quote_begin'
+				token.tag = 'patient_clause_quote_begin'
 			}),
 		},
 	},
@@ -24,7 +24,7 @@ const builtin_syntax_rules = [
 		name: 'Set tag for first words of sentences',
 		comment: '',
 		rule: {
-			trigger: create_token_filter({ 'tag': 'main_clause|quote_begin' }),
+			trigger: create_token_filter({ 'tag': 'main_clause|patient_clause_quote_begin' }),
 			context: create_context_filter({}),
 			action: create_token_modify_action(token => {
 				// find first word token, even if nested in another clause

--- a/app/src/lib/rules/syntax_rules.test.js
+++ b/app/src/lib/rules/syntax_rules.test.js
@@ -19,7 +19,7 @@ describe('sentence syntax: tag setting', () => {
 		expect(clause_tokens[3].type).toBe(TOKEN_TYPE.CLAUSE)
 		expect(clause_tokens[3].tag).toBe('subordinate_clause')
 		expect(clause_tokens[5].type).toBe(TOKEN_TYPE.CLAUSE)
-		expect(clause_tokens[5].tag).toBe('patient_clause|quote_begin')
+		expect(clause_tokens[5].tag).toBe('patient_clause_quote_begin')
 	})
 })
 

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -290,7 +290,7 @@ const transform_rules_json = [
 			'notfollowedby': { 'category': 'Noun', 'skip': [
 				{ 'tag': 'genitive_saxon|relative_clause' },	// can't use 'np_modifiers' since we don't skip the genitive_norman 'of'
 				'determiners',
-				'adjp',
+				'adjp_attributive',
 			]},
 		},
 		'transform': { 'tag': 'head_np' },
@@ -300,7 +300,7 @@ const transform_rules_json = [
 		'name': 'tag predicate adjectives',
 		'trigger': { 'category': 'Adjective' },
 		'context': {
-			'precededby': { 'category': 'Verb', 'skip': ['vp_modifiers', 'adjp_modifiers'] },
+			'precededby': { 'category': 'Verb', 'skip': ['vp_modifiers', 'adjp_modifiers_predicative'] },
 			'notfollowedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
 		},
 		'transform': { 'tag': 'predicate_adjective' },

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -58,14 +58,14 @@ const transform_rules_json = [
 		'trigger': { 'tag': 'subordinate_clause' },
 		'context': { 'precededby': { 'tag': 'agent_proposition_subject', 'skip': 'all' } },
 		'transform': { 'tag': 'agent_clause' },
-		'comment': 'Ruth 2:22 It is good that you continue working...'
+		'comment': 'Ruth 2:22 It is good that you continue working...',
 	},
 	{
 		'name': 'tag subordinate clauses that directly precede the verb as agent clauses',
 		'trigger': { 'tag': 'subordinate_clause' },
 		'context': { 'followedby': { 'category': 'Verb' } },
 		'transform': { 'tag': 'agent_clause' },
-		'comment': 'It is true that John read that book'
+		'comment': 'It is true that John read that book',
 	},
 	{
 		'name': 'tag \'that\' relative clauses that occur with \'it\' as agent clauses',
@@ -287,11 +287,14 @@ const transform_rules_json = [
 		'trigger': { 'category': 'Noun' },
 		'context': {
 			'notprecededby': [{ 'category': 'Noun' }, { 'token': 'of', 'skip': 'np_modifiers' }],
-			'notfollowedby': { 'category': 'Noun', 'skip': [
-				{ 'tag': 'genitive_saxon|relative_clause' },	// can't use 'np_modifiers' since we don't skip the genitive_norman 'of'
-				'determiners',
-				'adjp_attributive',
-			]},
+			'notfollowedby': {
+				'category': 'Noun',
+				'skip': [
+					{ 'tag': 'genitive_saxon|relative_clause' },	// can't use 'np_modifiers' since we don't skip the genitive_norman 'of'
+					'determiners',
+					'adjp_attributive',
+				]
+			},
 		},
 		'transform': { 'tag': 'head_np' },
 	},

--- a/app/src/lib/rules/transform_rules.test.js
+++ b/app/src/lib/rules/transform_rules.test.js
@@ -1,10 +1,9 @@
-import { TOKEN_TYPE } from '../parser/token'
+import { TOKEN_TYPE, create_lookup_result } from '../parser/token'
 import { tokenize_input } from '../parser/tokenize'
 import { clausify } from '../parser/clausify'
 import { apply_rules } from './rules_processor'
 import { describe, expect, test } from 'vitest'
 import { TRANSFORM_RULES } from './transform_rules'
-import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -15,7 +14,7 @@ import { create_case_frame } from './case_frame'
  * @param {number} [data.level=1] 
  * @returns {LookupResult}
  */
-function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
+function lookup_w_concept(stem, { sense='A', part_of_speech='Noun', level=1 }={}) {
 	const concept = {
 		id: '0',
 		stem,
@@ -25,14 +24,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		gloss: '',
 		categorization: '',
 	}
-	return {
-		stem,
-		part_of_speech,
-		form: 'stem',
-		concept,
-		how_to: [],
-		case_frame: create_case_frame(),
-	}
+	return create_lookup_result({ stem, part_of_speech }, { concept })
 }
 
 describe('builtin tag setting', () => {
@@ -40,9 +32,9 @@ describe('builtin tag setting', () => {
 
 	test('relative clause tag', () => {
 		const test_tokens = clausify(tokenize_input('People [who] say [who] person ["who].'))
-		test_tokens[0].clause.sub_tokens[0].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
-		test_tokens[0].clause.sub_tokens[2].lookup_results.push(create_lookup_result('say', { part_of_speech: 'Verb' }))
-		test_tokens[0].clause.sub_tokens[4].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
+		test_tokens[0].clause.sub_tokens[0].lookup_results.push(lookup_w_concept('person', { part_of_speech: 'Noun' }))
+		test_tokens[0].clause.sub_tokens[2].lookup_results.push(lookup_w_concept('say', { part_of_speech: 'Verb' }))
+		test_tokens[0].clause.sub_tokens[4].lookup_results.push(lookup_w_concept('person', { part_of_speech: 'Noun' }))
 
 		const checked_tokens = apply_rules(test_tokens, TRANSFORM_RULES_BUILTIN)
 		const clause_tokens = checked_tokens[0].clause.sub_tokens
@@ -56,8 +48,8 @@ describe('builtin tag setting', () => {
 	})
 	test('"that" clause tag', () => {
 		const test_tokens = clausify(tokenize_input('That person [that]. John saw [that].'))
-		test_tokens[0].clause.sub_tokens[1].lookup_results.push(create_lookup_result('person', { part_of_speech: 'Noun' }))
-		test_tokens[1].clause.sub_tokens[1].lookup_results.push(create_lookup_result('see', { part_of_speech: 'Verb' }))
+		test_tokens[0].clause.sub_tokens[1].lookup_results.push(lookup_w_concept('person', { part_of_speech: 'Noun' }))
+		test_tokens[1].clause.sub_tokens[1].lookup_results.push(lookup_w_concept('see', { part_of_speech: 'Verb' }))
 
 		const checked_tokens = apply_rules(test_tokens, TRANSFORM_RULES_BUILTIN)
 		

--- a/app/src/lib/rules/transform_rules.test.js
+++ b/app/src/lib/rules/transform_rules.test.js
@@ -4,6 +4,7 @@ import { clausify } from '../parser/clausify'
 import { apply_rules } from './rules_processor'
 import { describe, expect, test } from 'vitest'
 import { TRANSFORM_RULES } from './transform_rules'
+import { create_case_frame } from './case_frame'
 
 /**
  * 
@@ -30,6 +31,7 @@ function create_lookup_result(stem, { sense='A', part_of_speech='Noun', level=1 
 		form: 'stem',
 		concept,
 		how_to: [],
+		case_frame: create_case_frame(),
 	}
 }
 
@@ -59,7 +61,7 @@ describe('builtin tag setting', () => {
 
 		const checked_tokens = apply_rules(test_tokens, TRANSFORM_RULES_BUILTIN)
 		
-		expect(checked_tokens[0].clause.sub_tokens[2].tag).toBe('relative_clause')
+		expect(checked_tokens[0].clause.sub_tokens[2].tag).toBe('relative_clause|relative_clause_that')
 		expect(checked_tokens[0].clause.sub_tokens[2].sub_tokens[1].tag).toBe('relativizer')
 		
 		expect(checked_tokens[1].clause.sub_tokens[2].tag).toBe('subordinate_clause')

--- a/app/src/lib/tokens/Result.svelte
+++ b/app/src/lib/tokens/Result.svelte
@@ -4,6 +4,7 @@
 	import TokenDisplay from './TokenDisplay.svelte'
 	import PopupMenu from './PopupMenu.svelte'
 	import Table from './Table.svelte'
+	import Icon from '@iconify/svelte'
 
 	/** @type {Token} */
 	export let token
@@ -24,9 +25,16 @@
 				{@const term = concept_with_sense(concept)}
 				<tr>
 					<td class="whitespace-nowrap">
-						<a class="link not-prose {classes}" href={`${PUBLIC_ONTOLOGY_API_HOST}/?q=${term}`} target="_blank">
-							{term}
-						</a>
+						<span>
+							<a class="link not-prose {classes}" href={`${PUBLIC_ONTOLOGY_API_HOST}/?q=${term}`} target="_blank">
+								{term}
+							</a>
+							{#if entry.case_frame.is_checked && entry.case_frame.is_valid}
+								<Icon icon="mdi:check-bold" class="h-4 w-4 text-success" />
+							{:else if entry.case_frame.is_checked}
+								<Icon icon="mdi:close-thick" class="h-4 w-4 text-error" />
+							{/if}
+						</span>
 					</td>
 					<td class="whitespace-nowrap">{concept.part_of_speech}</td>
 					<td class="whitespace-nowrap">


### PR DESCRIPTION
Add case frame and sense-selection rules, and other supporting rules such as part-of-speech.
Added rules for allow/be/give/have/hear/know/say/see/speak/tell. These check the arguments present for each sense, store the missing and extra arguments, and shows appropriate messages to the user to help them find the right sense or argument structure. Support for more verbs will follow but this is a good start.

**Automatic sense selection based on case frame**
- The checkmark and x indicate which senses match the argument structure/case frame in the clause. (open to change in the UI for this)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/2afd7663-606c-4588-baab-ef984e857424)

**Automatic sense selected based on case frame and semantic keywords**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/e57c8b4d-a158-424d-8342-283f838dfcfa)

**Guide user to specify a sense if no sense matches**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/962df552-95ad-4500-83e7-46114b80287a)

**Notification of missing arguments**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/337a515e-6d02-4e56-ba46-7f3824962bce)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/8204ef77-23f1-4e7b-b19e-7cd8adf31dbe)

**Notification of unexpected/extra arguments**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/bcd887fc-65ec-4158-b0fc-02f0c1261477)

**Warn about wrong clause type**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/9c4e5bfa-1a91-48ad-aece-3b59c27477ab)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/e4bc1424-2777-4c36-b648-acdcb8bcaa52)

**Support for passive clauses**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/977eb39d-60d0-42b4-a358-2bfb3f02642c)

**Warn about extraneous or misinterpreted 'that's**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0bf964ef-fd27-4714-9bfd-4b18dd268906)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b681ea62-cc8a-4950-99d9-7093abb906a5)

**Handle agent clauses (and show error for misused 'it')**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/55e48dfe-e23c-4136-a2c4-3bcfb8ef7790)

**Fixed a couple of issues that Richard/Jeremiah found**
- 'chief' in 'chief evil spirit' was not considered an adjective
- Now it remains ambiguous, just like it is in the Analyzer
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/dde7e85d-4099-4346-9cba-c8c47a3d11e1)

- 'like' is now also recognized as the 'just-like' adposition, so it's not always considered a verb and falsely triggering rules. Adding case frames for become/seem/sound/etc will fully address this like it did for 'be'
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f7466ccf-20a1-4dc6-bf22-0b265c91b8ea)

- Made not using 'all of' as an error instead of suggestion, and fixed capitalization issue
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/11f142f2-39eb-40c5-a9fe-3d31fa5f4481)

- Adverbial clauses with a conjunction no longer trigger an error
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/438630d6-bd07-45a8-a868-6fa8572f86ef)


Note: For some reason the test suites don't like the use of `Object.entries()`. I couldn't figure it out, so those tests don't work for me. But running the app works perfectly fine so not sure what the problem is.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f7601127-e5c5-4ac0-a591-b3fed3d68ecc)
