### PR TITLE
Fine tune and add case frame rules

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -110,6 +110,7 @@ type ArgumentRoleRule = {
 	context: TokenContextFilter
 	action: RoleRuleAction
 	missing_message: string
+	extra_message: string
 }
 
 type ArgumentRulesForSense = {
@@ -129,13 +130,13 @@ type RoleMatchResult = {
 	success: boolean
 	trigger_index: number
 	context_indexes: number[]
+	rule: ArgumentRoleRule
 }
 
 type CaseFrameResult = {
 	is_valid: boolean
 	is_checked: boolean
-	rule: ArgumentRulesForSense
 	valid_arguments: RoleMatchResult[]
 	extra_arguments: RoleMatchResult[]
-	missing_arguments: RoleTag[]
+	missing_arguments: ArgumentRoleRule[]
 }

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -223,17 +223,15 @@ export function create_lookup_result({ stem, part_of_speech }, { form='stem', co
  * @param {Object} [data={}] 
  * @param {boolean} [data.is_valid=false] 
  * @param {boolean} [data.is_checked=false] 
- * @param {ArgumentRulesForSense?} [data.rule={}] 
  * @param {RoleMatchResult[]} [data.valid_arguments=[]] 
  * @param {RoleMatchResult[]} [data.extra_arguments=[]] 
- * @param {RoleTag[]} [data.missing_arguments=[]] 
+ * @param {ArgumentRoleRule[]} [data.missing_arguments=[]] 
  * @returns {CaseFrameResult}
  */
-export function create_case_frame({ is_valid=false, is_checked=false, rule=null, valid_arguments=[], extra_arguments=[], missing_arguments=[] }={}) {
+export function create_case_frame({ is_valid=false, is_checked=false, valid_arguments=[], extra_arguments=[], missing_arguments=[] }={}) {
 	return {
 		is_valid,
 		is_checked,
-		rule: rule ?? { sense: '', rules: [], other_optional: [], other_required: [], patient_clause_type: '' },
 		valid_arguments,
 		extra_arguments,
 		missing_arguments,

--- a/app/src/lib/rules/case_frame/rules.js
+++ b/app/src/lib/rules/case_frame/rules.js
@@ -6,11 +6,11 @@ import { check_verb_case_frames, check_verb_case_frames_passive } from './verbs'
 const case_frame_rules = [
 	{
 		name: 'Verb case frame, active',
-		comment: 'For now, only trigger when not within a relative clause, question, or possible same-subject clause since arguments get moved around',
+		comment: 'For now, only trigger when not within a relative clause, question, or same-subject clause since arguments get moved around or are missing',
 		rule: {
 			trigger: create_token_filter({ 'category': 'Verb' }),
 			context: create_context_filter({
-				'notprecededby': { 'tag': 'relativizer|passive|infinitive', 'skip': 'all' },
+				'notprecededby': { 'tag': 'relativizer|passive|infinitive_same_subject', 'skip': 'all' },
 				'notfollowedby': { 'token': '?', 'skip': 'all' },
 			}),
 			action: (tokens, trigger_index) => {
@@ -21,12 +21,12 @@ const case_frame_rules = [
 	},
 	{
 		name: 'Verb case frame, passive',
-		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around',
+		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around or are missing',
 		rule: {
 			trigger: create_token_filter({ 'category': 'Verb' }),
 			context: create_context_filter({
 				'precededby': { 'tag': 'passive', 'skip': 'all' },
-				'notprecededby': { 'tag': 'relativizer', 'skip': 'all' },
+				'notprecededby': { 'tag': 'relativizer|infinitive_same_subject', 'skip': 'all' },
 				'notfollowedby': { 'token': '?', 'skip': 'all' },
 			}),
 			action: (tokens, trigger_index) => {

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -99,13 +99,13 @@ const verb_case_frames = new Map([
 		['ask-C', {
 			'patient': {
 				'by_clause_tag': 'patient_clause_different_participant',
-				'missing_message': "ask-C should be written in the format 'X asked [Y to Verb]'."
+				'missing_message': "ask-C should be written in the format 'X asked [Y to Verb]'.",
 			},
 			'other_extra': {
 				'extra_patient': {
 					'directly_after_verb': { },
-					'extra_message': "ask-C should not be written with the patient. Use the format 'X asked [Y to Verb]'."
-				}
+					'extra_message': "ask-C should not be written with the patient. Use the format 'X asked [Y to Verb]'.",
+				},
 			},
 			'comment': 'the patient is omitted in the phase 1 and copied from within the subordinate. so treat the clause like the patient',
 		}],
@@ -117,7 +117,7 @@ const verb_case_frames = new Map([
 		['ask-F', {
 			'patient_clause_different_participant': [
 				{
-					'by_clause_tag': 'patient_clause_quote_begin',
+					'by_clause_tag': 'patient_clause_different_participant',
 					'missing_message': "ask-F should be written in the format 'asked X [(if//whether) ...]' (with or without the if/whether)",
 				},
 				{
@@ -128,6 +128,7 @@ const verb_case_frames = new Map([
 					// TODO make if/whether function words using a subtoken context transform
 				},
 			],
+			'comment': "This can be written as 'asked X [(if//whether) ...]' (with or without the if/whether)",
 		}],
 	]],
 	['be', [
@@ -250,12 +251,15 @@ const verb_case_frames = new Map([
 			'instrument': { 'by_adposition': 'with' },
 		}],
 		['make-C', {
-			// TODO find a better way to handle the different situations. examples:
+			// Possible accepted formats:
 			// Gen 22:16 make a promise [in my name](instrument).
 			// Gen 6:18 God made a covenant [with Noah](destination). (specific to 'covenant', usually 'to' indicates destination)
 			// Daniel 12:7 That man made a promise [by God](instrument). (not recognized in Analyzer but valid phase 1)
 			'instrument': [
-				{ 'by_adposition': 'by' },
+				{
+					'by_adposition': 'by',
+					'trigger': { 'tag': 'head_np', 'stem': 'God|Yahweh' },
+				},
 				{
 					'by_adposition': 'in',
 					'trigger': { 'tag': 'head_np', 'stem': 'name' },
@@ -267,8 +271,8 @@ const verb_case_frames = new Map([
 					'trigger': { 'tag': 'head_np' },
 					'context': { 'precededby': [{ 'stem': 'covenant' }, { 'token': 'with', 'skip': 'np_modifiers' }] },
 					'context_transform': [{}, { 'function': '' }],
-				}
-			]
+				},
+			],
 		}],
 		['make-E', { 'instrument': { 'by_adposition': 'with' } }],
 	]],
@@ -298,13 +302,13 @@ const verb_case_frames = new Map([
 		['tell-B', {
 			'patient': {
 				'by_clause_tag': 'patient_clause_different_participant',
-				'missing_message': "tell-B should be written in the format 'X told [Y to Verb]'."
+				'missing_message': "tell-B should be written in the format 'X told [Y to Verb]'.",
 			},
 			'other_extra': {
 				'extra_patient': {
 					'directly_after_verb': { },
-					'extra_message': "tell-B should not be written with the patient. Use the format 'X told [Y to Verb]'."
-				}
+					'extra_message': "tell-B should not be written with the patient. Use the format 'X told [Y to Verb]'.",
+				},
 			},
 			'comment': 'the patient is omitted in the phase 1 and copied from within the subordinate. so treat the clause like the patient',
 		}],
@@ -319,6 +323,9 @@ const verb_case_frames = new Map([
 			'patient': { },		// clear the patient so it doesn't get confused with the destination
 			'patient_clause_type': 'patient_clause_quote_begin',
 		}],
+	]],
+	['want', [
+		['want-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
 ])
 
@@ -418,7 +425,7 @@ export function check_verb_case_frames_passive(tokens, verb_index) {
 	const passive_rules = Object.entries(passive_rules_json).flatMap(parse_case_frame_rule)
 
 	check_verb_case_frames(tokens, verb_index,
-		role_rules => role_rules.filter(rule => !['patient', 'agent'].includes(rule.role_tag)).concat(passive_rules)
+		role_rules => role_rules.filter(rule => !['patient', 'agent'].includes(rule.role_tag)).concat(passive_rules),
 	)
 }
 

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -19,7 +19,7 @@ const checker_rules_json = [
 		'trigger': { 'category': 'Verb' },
 		'context': {
 			'precededby': { 'tag': 'passive', 'skip': 'all' },
-			'notfollowedby': { 'tag': 'agent', 'skip': 'all' },
+			'notfollowedby': { 'tag': 'agent|agent_of_passive', 'skip': 'all' },
 		},
 		'require': {
 			'followedby': 'by X',
@@ -603,7 +603,7 @@ const builtin_checker_rules = [
 				if (case_frames.length === 0 || case_frames[0].is_valid) {
 					return trigger_index + 1
 				}
-				const missing_arguments = new Set(case_frames.flatMap(case_frame => case_frame.missing_arguments))
+				const missing_arguments = new Set(case_frames.flatMap(case_frame => case_frame.missing_arguments.map(rule => rule.role_tag)))
 
 				// Only show the message if all senses are invalid, but some are missing a patient clause
 				if (['agent_clause', 'patient_clause_different_participant'].some(role => missing_arguments.has(role))) {

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -85,21 +85,11 @@ const part_of_speech_rules_json = [
 		'comment': 'only for \'so\'. \'for\' might be the \'for each...\' sense',
 	},
 	{
-		'name': '\'so-that\' will always be the Adposition',
-		'category': 'Adposition|Conjunction',
-		'trigger': { 'token': 'so-that' },
-		'remove': 'Conjunction',
-		'comment': '',
-	},
-	{
-		'name': 'If \'so\' is at the start of a subordinate clause, remove the Conjunction',
+		'name': 'If "so" appears anywhere else in the sentence, remove Conjunction',
 		'category': 'Adposition|Conjunction',
 		'trigger': { 'stem': 'so' },
-		'context': {
-			'precededby': { 'token': '[' },
-		},
 		'remove': 'Conjunction',
-		'comment': '',
+		'comment': 'This relies on the previous rule to catch all uses of the conjunction',
 	},
 	{
 		'name': 'If Adverb-Adjective followed by Noun, remove Adverb',

--- a/app/src/lib/rules/sense_selection_rules.js
+++ b/app/src/lib/rules/sense_selection_rules.js
@@ -15,6 +15,7 @@ const verb_sense_rules = [
 	['ask', [
 		['ask-B', { }],	// prioritize ask-B over ask-A
 		['ask-D', { }],	// prioritize ask-D over ask-A
+		['ask-F', { }],	// prioritize ask-F over ask-A
 	]],
 	['be', [
 		// 'be' is very particular and so each sense is specified to make the priority clear. Not all verbs will need this.
@@ -89,6 +90,9 @@ const verb_sense_rules = [
 	['tell', [
 		// prioritize tell-C over tell-A due to the presence of the 'about'. tell-A may count as valid if there is a relative clause on its patient.
 		['tell-C', { }],
+	]],
+	['want', [
+		['want-D', { 'patient': { 'stem': 'peace|health|life' } }],
 	]],
 ]
 

--- a/app/src/lib/rules/sense_selection_rules.js
+++ b/app/src/lib/rules/sense_selection_rules.js
@@ -12,6 +12,10 @@ import { create_context_filter, create_token_filter } from './rules_parser'
  * @type {[WordStem, SenseRules[]][]}
  */
 const verb_sense_rules = [
+	['ask', [
+		['ask-B', { }],	// prioritize ask-B over ask-A
+		['ask-D', { }],	// prioritize ask-D over ask-A
+	]],
 	['be', [
 		// 'be' is very particular and so each sense is specified to make the priority clear. Not all verbs will need this.
 		// For example, both be-I and be-F would match 'John is with Mary'
@@ -67,6 +71,10 @@ const verb_sense_rules = [
 	]],
 	['know', [
 		['know-C', { 'patient': { 'stem': 'law|meaning|name|secret|thing' } }],
+	]],
+	['make', [
+		['make-C', { 'patient': { 'stem': 'command|fire|god|peace|promise|wave|covenant' } }],
+		['make-E', { 'patient': { 'stem': 'bread|food' } }],
 	]],
 	['say', [
 		['say-D', { 'agent': { 'stem': 'law' } }],
@@ -147,6 +155,10 @@ export const SENSE_RULES = sense_rules.map(({ rule }) => rule)
  */
 function find_matching_sense(tokens, token_index) {
 	const token = tokens[token_index]
+	if (!token.lookup_results.some(result => result.case_frame.is_checked)) {
+		return undefined
+	}
+	
 	const stem = token.lookup_results[0].stem
 	const category = token.lookup_results[0].part_of_speech
 	const sense_filters = SENSE_FILTER_RULES.get(category)?.get(stem) ?? []
@@ -177,39 +189,36 @@ function select_word_sense(tokens, verb_index) {
 	if (tokens[verb_index].lookup_results.length === 0) {
 		return
 	}
-	
-	const verb_token = tokens[verb_index]
-	const stem = verb_token.lookup_results[0].stem
+
+	const token = tokens[verb_index]
+	const stem = token.lookup_results[0].stem
 
 	// Move the valid lookups to the top
-	const valid_lookups = verb_token.lookup_results.filter(result => result.case_frame.is_valid)
-	const invalid_lookups = verb_token.lookup_results.filter(result => !result.case_frame.is_valid)
-	verb_token.lookup_results = [...valid_lookups, ...invalid_lookups]
+	const valid_lookups = token.lookup_results.filter(result => result.case_frame.is_valid)
+	const invalid_lookups = token.lookup_results.filter(result => !result.case_frame.is_valid)
+	token.lookup_results = [...valid_lookups, ...invalid_lookups]
 	
 	// Use the matching valid sense, or else the first valid sense, or else sense A.
 	// The lookups should already be ordered alphabetically so the first valid sense is the lowest letter
 	const default_matching_sense = find_matching_sense(tokens, verb_index)
 		|| `${stem}-${valid_lookups.at(0)?.concept?.sense ?? 'A'}`
 
-	const specified_sense = verb_token.specified_sense ? `${stem}-${verb_token.specified_sense}` : ''
+	const specified_sense = token.specified_sense ? `${stem}-${token.specified_sense}` : ''
 
 	if (specified_sense === default_matching_sense) {
-		verb_token.suggest_message = 'Consider removing the sense, as it would be selected by default.'
+		token.suggest_message = 'Consider removing the sense, as it would be selected by default.'
 	}
 
 	const sense_to_select = specified_sense ? specified_sense : default_matching_sense
-	set_token_concept(verb_token, sense_to_select)
+	set_token_concept(token, sense_to_select)
 
-	const selected_result = verb_token.lookup_results[0]
+	const selected_result = token.lookup_results[0]
 	if (!selected_result.case_frame.is_valid) {
 		return
 	}
 
 	// apply the selected result's argument actions
 	for (const valid_argument of selected_result.case_frame.valid_arguments) {
-		/** @type {ArgumentRoleRule} */
-		// @ts-ignore a valid argument will always have a rule associated with it
-		const argument_rule = selected_result.case_frame.rule.rules.find(rule => rule.role_tag === valid_argument.role_tag)
-		argument_rule.action(tokens, valid_argument)
+		valid_argument.rule.action(tokens, valid_argument)
 	}
 }

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -110,6 +110,16 @@ const transform_rules_json = [
 		'transform': { 'tag': 'patient_clause_different_participant' },
 	},
 	{
+		'name': 'tag \'that\' at the beginning of a main clause as remove_demonstrative when followed by a noun',
+		'trigger': { 'token': 'That|that' },
+		'context': {
+			'notprecededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
+			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
+		},
+		'transform': { 'tag': 'remote_demonstrative' },
+		'comment': 'this clears the relativizer tag',
+	},
+	{
 		'name': '"no" before a noun becomes negative_noun_polarity',
 		'trigger': { 'token': 'no' },
 		'context': { 'followedby': { 'category': 'Noun', 'skip': { 'category': 'Adjective' } } },
@@ -227,7 +237,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'function': 'auxiliary|passive' },
-		'comment': 'skip all because it may be a question (eg. "Are those words written in the book?"). We\'ll have to assume it\'s not an error.'
+		'comment': 'skip all because it may be a question (eg. "Are those words written in the book?"). We\'ll have to assume it\'s not an error.',
 	},
 	{
 		'name': 'be before a participle Verb indicates imperfective',
@@ -240,7 +250,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'function': 'auxiliary|imperfective_aspect' },
-		'comment': 'skip all because it may be a question (eg. "Are those people going?"). We\'ll have to assume it\'s not an error.'
+		'comment': 'skip all because it may be a question (eg. "Are those people going?"). We\'ll have to assume it\'s not an error.',
 	},
 	{
 		'name': 'Any \'be\' verb remaining before another verb becomes a generic auxiliary',
@@ -267,7 +277,7 @@ const transform_rules_json = [
 			'followedby': { 'tag': 'auxiliary', 'skip': 'all' },
 		},
 		'transform': { 'function': 'auxiliary' },
-		'comment': 'skip all because it may be a question (eg. "Is that bread being eaten?"). We\'ll have to assume it\'s not an error.'
+		'comment': 'skip all because it may be a question (eg. "Is that bread being eaten?"). We\'ll have to assume it\'s not an error.',
 	},
 	{
 		'name': 'by preceded by a passive be indicates the agent',
@@ -318,6 +328,7 @@ const transform_rules_json = [
 	},
 ]
 
+// TODO make these not built-in when we support subtokens context transforms. These need to be here in order to set the tag on the relativizers.
 /** @type {BuiltInRule[]} */
 const builtin_transform_rules = [
 	{
@@ -327,7 +338,7 @@ const builtin_transform_rules = [
 			trigger: create_token_filter({ 'tag': 'subordinate_clause' }),
 			context: create_context_filter({
 				'precededby': { 'category': 'Noun' },
-				'subtokens': { 'tag': 'relativizer', 'skip': { 'token': '[' } },
+				'subtokens': { 'tag': 'relativizer', 'skip': [{ 'token': '[' }, { 'category': 'Conjunction' }] },
 			}),
 			action: create_token_modify_action(token => {
 				const relativizer = token.sub_tokens[1]
@@ -343,7 +354,7 @@ const builtin_transform_rules = [
 			trigger: create_token_filter({ 'tag': 'subordinate_clause' }),
 			context: create_context_filter({
 				'notprecededby': { 'category': 'Noun' },
-				'subtokens': { 'token': 'that', 'skip': { 'token': '[' } },
+				'subtokens': { 'token': 'that', 'skip': [{ 'token': '[' }, { 'category': 'Conjunction' }] },
 			}),
 			action: create_token_modify_action(token => {
 				token.sub_tokens[1].tag = 'remote_demonstrative'

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -14,6 +14,14 @@ const transform_rules_json = [
 		'transform': { 'function': 'infinitive' },
 	},
 	{
+		'name': 'infinitive "to" as the first word of a subordinate should be tagged as "same subject"',
+		'trigger': { 'tag': 'infinitive' },
+		'context': {
+			'precededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
+		},
+		'transform': { 'function': 'infinitive|infinitive_same_subject' },
+	},
+	{
 		'name': 'start or begin before a verb becomes a function word',
 		'trigger': { 'stem': 'start|begin' },
 		'context': {
@@ -79,7 +87,7 @@ const transform_rules_json = [
 	{
 		'name': 'tag subordinate clauses starting with the infinitive \'to\' as \'same_participant\'',
 		'trigger': { 'tag': 'subordinate_clause' },
-		'context': { 'subtokens': { 'tag': 'infinitive', 'skip': { 'token': '[' } } },
+		'context': { 'subtokens': { 'tag': 'infinitive_same_subject', 'skip': { 'token': '[' } } },
 		'transform': { 'tag': 'patient_clause_same_participant' },
 	},
 	{
@@ -215,10 +223,11 @@ const transform_rules_json = [
 			'followedby': {
 				'category': 'Verb',
 				'form': 'past participle',
-				'skip': 'vp_modifiers',
+				'skip': 'all',
 			},
 		},
 		'transform': { 'function': 'auxiliary|passive' },
+		'comment': 'skip all because it may be a question (eg. "Are those words written in the book?"). We\'ll have to assume it\'s not an error.'
 	},
 	{
 		'name': 'be before a participle Verb indicates imperfective',
@@ -227,16 +236,17 @@ const transform_rules_json = [
 			'followedby': {
 				'category': 'Verb',
 				'form': 'participle',
-				'skip': 'vp_modifiers',
+				'skip': 'all',
 			},
 		},
 		'transform': { 'function': 'auxiliary|imperfective_aspect' },
+		'comment': 'skip all because it may be a question (eg. "Are those people going?"). We\'ll have to assume it\'s not an error.'
 	},
 	{
 		'name': 'Any \'be\' verb remaining before another verb becomes a generic auxiliary',
 		'trigger': { 'category': 'Verb', 'stem': 'be' },
 		'context': {
-			'followedby': { 'category': 'Verb', 'skip': 'vp_modifiers' },
+			'followedby': { 'category': 'Verb', 'skip': 'all' },
 		},
 		'transform': { 'function': 'auxiliary' },
 		'comment': 'the more precise function may be ambiguous e.g. "was cry-out"',
@@ -245,10 +255,7 @@ const transform_rules_json = [
 		'name': 'have before a Verb indicates flashback/perfect',
 		'trigger': { 'stem': 'have' },
 		'context': {
-			'followedby': {
-				'category': 'Verb',
-				'skip': 'vp_modifiers',
-			},
+			'followedby': { 'category': 'Verb', 'skip': 'all' },
 		},
 		'transform': { 'function': 'auxiliary|flashback' },
 		'comment': 'don\'t check for the past participle form because of cases like "have cry-out"',
@@ -257,9 +264,10 @@ const transform_rules_json = [
 		'name': 'be before an auxiliary becomes an auxiliary',
 		'trigger': { 'stem': 'be' },
 		'context': {
-			'followedby': { 'tag': 'auxiliary', 'skip': 'vp_modifiers' },
+			'followedby': { 'tag': 'auxiliary', 'skip': 'all' },
 		},
 		'transform': { 'function': 'auxiliary' },
+		'comment': 'skip all because it may be a question (eg. "Is that bread being eaten?"). We\'ll have to assume it\'s not an error.'
 	},
 	{
 		'name': 'by preceded by a passive be indicates the agent',
@@ -303,8 +311,8 @@ const transform_rules_json = [
 		'name': 'tag predicate adjectives',
 		'trigger': { 'category': 'Adjective' },
 		'context': {
-			'precededby': { 'category': 'Verb', 'skip': ['vp_modifiers', 'adjp_modifiers_predicative'] },
-			'notfollowedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
+			'precededby': { 'category': 'Verb', 'skip': 'all' },
+			'notfollowedby': { 'category': 'Noun', 'skip': ['np_modifiers', 'adjp_modifiers_predicative'] },
 		},
 		'transform': { 'tag': 'predicate_adjective' },
 	},


### PR DESCRIPTION
**Add extra support needed for make/ask/tell**
- multiple possible structures for the same argument role (eg ask-A)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/096b325c-848d-4ce2-8e8f-1bdc7069b02c)
- show a specific message for an argument that is not written correctly (eg tell-B)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/87fa427e-50e5-4f5b-8518-bb93322cad5e)

**Show a better message when an agent is missing for all senses (whether in a passive, imperative, or due to bracketing issues).**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/fe97da93-f86a-46a0-9394-5f396024b12e)

**Fix issues with questions and passives**
- Passives that have not been checked by the case frame rules now find the agent again.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7eacf0ba-67b0-42c2-b540-98ed01deef69)

- Auxiliary be/have are now recognized when split from the verb (as in a question)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0c7ab106-8a81-4210-8bc6-84a8979fd5d0)

**Recognize 'so' when not at the start of a sentence as the adposition**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/e25924a4-c611-4ee9-98c4-bf36ed391976)
