### PR TITLE
Add rules and rule functionality.

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -25,6 +25,16 @@ type Sentence = {
 	clause: Clause
 }
 
+interface Message {
+	error?: string
+	suggest?: string
+}
+
+interface MessageInfo extends Message {
+	token_to_flag?: Token
+	plain?: boolean
+}
+
 type LookupTerm = string
 
 type LookupResponse<T> = {
@@ -81,12 +91,21 @@ type ContextFilterResult = {
 type TokenTransform = (token: Token) => Token
 
 type CheckerAction = {
+	on: string?;
 	precededby: string?;
 	followedby: string?;
 	message: string
 }
 
-type RuleAction = (tokens: Token[], trigger_index: number, context_result: ContextFilterResult) => number
+type RuleTriggerContext = {
+	trigger_token: Token
+	trigger_index: number
+	tokens: Token[]
+	context_indexes: number[]
+	subtoken_indexes: number[]
+}
+
+type RuleAction = (trigger_context: RuleTriggerContext) => number
 
 type TokenRule = {
 	trigger: TokenFilter
@@ -106,9 +125,7 @@ type WordStem = string
 
 type ArgumentRoleRule = {
 	role_tag: RoleTag
-	trigger: TokenFilter
-	context: TokenContextFilter
-	action: RoleRuleAction
+	trigger_rule: TokenRule
 	missing_message: string
 	extra_message: string
 }
@@ -121,15 +138,12 @@ type ArgumentRulesForSense = {
 	patient_clause_type: RoleTag
 }
 
-type RoleRuleAction = (tokens: Token[], role_match: RoleMatchResult) => void
-
-type ArgumentMatchFilter = (tokens: Token[], role_matches: RoleMatchResult[]) => boolean
+type ArgumentMatchFilter = (role_matches: RoleMatchResult[]) => boolean
 
 type RoleMatchResult = {
 	role_tag: RoleTag
 	success: boolean
-	trigger_index: number
-	context_indexes: number[]
+	trigger_context: RuleTriggerContext
 	rule: ArgumentRoleRule
 }
 

--- a/app/src/lib/lookups/index.js
+++ b/app/src/lib/lookups/index.js
@@ -1,6 +1,6 @@
 import { TOKEN_TYPE, token_has_tag } from '../parser/token'
 import { REGEXES } from '../regexes'
-import { create_context_filter, create_token_filter, create_token_modify_action } from '../rules/rules_parser'
+import { create_context_filter, create_token_filter, simple_rule_action } from '../rules/rules_parser'
 import { apply_rule_to_tokens } from '../rules/rules_processor'
 import { check_forms } from './form'
 import { check_how_to } from './how_to'
@@ -77,7 +77,7 @@ const result_filter_rules = [
 		rule: {
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && !token_has_tag(token, { 'position': 'first_word' }),
 			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
+			action: simple_rule_action(({ trigger_token: token }) => {
 				if (token.token !== 'null') {
 					// 'null' is used for some double pairings like 'friends/brothers and null/sisters'.
 					// But the concept in the ontology is NULL, so should not be filtered by capitalization
@@ -96,8 +96,8 @@ const result_filter_rules = [
 		rule: {
 			trigger: create_token_filter({ 'token': 'to|from|down|off|out|up' }),
 			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				token.lookup_results = []
+			action: simple_rule_action(({ trigger_token }) => {
+				trigger_token.lookup_results = []
 			}),
 		},
 	},

--- a/app/src/lib/rules/case_frame/rules.js
+++ b/app/src/lib/rules/case_frame/rules.js
@@ -1,4 +1,4 @@
-import { create_context_filter, create_token_filter } from '../rules_parser'
+import { create_context_filter, create_token_filter, simple_rule_action } from '../rules_parser'
 import { check_verb_case_frames, check_verb_case_frames_passive } from './verbs'
 
 
@@ -13,10 +13,7 @@ const case_frame_rules = [
 				'notprecededby': { 'tag': [{ 'syntax': 'relativizer|infinitive_same_subject' }, { 'auxiliary': 'passive' }], 'skip': 'all' },
 				'notfollowedby': { 'token': '?', 'skip': 'all' },
 			}),
-			action: (tokens, trigger_index) => {
-				check_verb_case_frames(tokens, trigger_index)
-				return trigger_index + 1
-			},
+			action: simple_rule_action(check_verb_case_frames),
 		},
 	},
 	{
@@ -29,10 +26,7 @@ const case_frame_rules = [
 				'notprecededby': { 'tag': { 'syntax': 'relativizer|infinitive_same_subject' }, 'skip': 'all' },
 				'notfollowedby': { 'token': '?', 'skip': 'all' },
 			}),
-			action: (tokens, trigger_index) => {
-				check_verb_case_frames_passive(tokens, trigger_index)
-				return trigger_index + 1
-			},
+			action: simple_rule_action(check_verb_case_frames_passive),
 		},
 	},
 ]

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -91,19 +91,7 @@ const verb_case_frames = new Map([
 			'destination': { 'directly_after_verb': { } },
 			'patient': { 'by_adposition': 'for' },
 		}],
-		['ask-C', {
-			'patient': {
-				'by_clause_tag': 'patient_clause_different_participant',
-				'missing_message': "ask-C should be written in the format 'X asked [Y to Verb]'.",
-			},
-			'other_extra': {
-				'extra_patient': {
-					'directly_after_verb': { },
-					'extra_message': "ask-C should not be written with the patient. Use the format 'X asked [Y to Verb]'.",
-				},
-			},
-			'comment': 'the patient is omitted in the phase 1 and copied from within the subordinate. so treat the clause like the patient',
-		}],
+		['ask-C', 'patient_from_subordinate_clause'],
 		['ask-D', {
 			'destination': { 'directly_after_verb': { } },
 			'patient': { 'by_adposition': 'about' },
@@ -220,6 +208,37 @@ const verb_case_frames = new Map([
 		['be-W', { 'state': { 'directly_after_verb_with_adposition': 'in' } }],
 		['be-X', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
 	]],
+	['become', [
+		['become-A', {
+			'other_required': 'predicate_adjective',
+			'other_optional': 'patient_clause_same_participant|patient_clause_different_participant',
+			'comment': 'some predicate adjectives take a patient clause, so those should be recognized and accepted',
+		}],
+		['become-F', {
+			'agent': {
+				'directly_before_verb': { 'stem': 'weather' },
+				'missing_message': 'become-F requires the format \'The weather be X\' where X can be a noun (eg rain) or adjective (eg hot).',
+			},
+			'other_optional': 'predicate_adjective',
+		}],
+		['become-G', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
+		['become-H', {
+			'state': {
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': { 'precededby': { 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers', { 'token': 'made' }] } },
+			},
+			'comment': 'there may or may not be "made of" before the np',
+		}],
+		['become-I', {
+			'state': {
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': { 'precededby': { 'category': 'Adposition', 'skip': 'np_modifiers' } },
+			},
+		}],
+		['become-J', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
+	]],
+	['cause', []],
+	['come', []],
 	['give', [
 		['give-A', {
 			'patient': {
@@ -228,6 +247,7 @@ const verb_case_frames = new Map([
 			},
 		}],
 	]],
+	['go', []],
 	['have', [
 		['know-J', { 'instrument': { 'by_adposition': 'with' } }],
 	]],
@@ -237,9 +257,52 @@ const verb_case_frames = new Map([
 		['hear-C', { 'other_optional': 'patient_clause_simultaneous' }],
 		['hear-D', { 'patient': { 'by_adposition': 'about' } }],
 	]],
+	['help', [
+		['help-B', 'patient_from_subordinate_clause'],
+	]],
 	['know', [
 		['know-D', { 'patient': { 'directly_after_verb_with_adposition': 'about' } }],
 		['know-B', { 'instrument': { 'by_adposition': 'with' } }],
+	]],
+	['leave', []],
+	['like', [
+		['like-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['live', [
+		['live-A', {
+			'destination': {
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': {
+					'precededby': [
+						{ 'category': 'Verb', 'skip': 'vp_modifiers' },
+						{ 'category': 'Adposition', 'skip': 'np_modifiers' },
+					],
+					'notprecededby' : { 'token': 'with|for', 'skip': 'np_modifiers' },
+				},
+				'comment': 'Could have any adposition except with/for (eg "in Egypt", "along the Nile", "by the river", etc)',
+			},
+		}],
+		['live-B', {
+			'other_rules': {
+				'lifespan_oblique': {
+					'trigger': { 'tag': { 'syntax': 'head_np' } , 'stem': 'year|time' },
+					'context': { 'precededby': { 'token': 'for', 'skip': 'np_modifiers' } },
+					'comment': 'eg Adam lived for 930 years',
+				},
+			},
+			'other_optional': 'lifespan_oblique',
+		}],
+		['live-C', {
+			'other_rules': {
+				'just_like_clause': {
+					'by_clause_tag': 'adverbial_clause',
+					'context': {
+						'subtokens': { 'stem': 'just-like', 'skip': { 'token': '[' } },
+					},
+				},
+			},
+			'other_optional': 'just_like_clause',
+		}],
 	]],
 	['make', [
 		['make-A', {
@@ -279,34 +342,43 @@ const verb_case_frames = new Map([
 	['see', [
 		['see-B', { 'other_optional': 'patient_clause_simultaneous' }],
 	]],
+	['send', [
+		['send-B', {
+			'patient': {
+				'directly_after_verb': { },
+				'missing_message': "'send' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
+			},
+		}],
+		['send-C', {
+			'patient': {
+				'directly_after_verb': { },
+				'missing_message': "'send' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
+			},
+		}],
+	]],
 	['speak', [
 		['speak-A', {
 			'patient': { 'by_adposition': 'about' },
 			'instrument': {
-				'by_adposition': 'in',
+				'by_adposition': 'in',	// in a language
 				'context_transform': { 'concept': 'in-K' },
-			},	// in a language
+			},
+			'other_rules': {
+				'extra_patient': {
+					'directly_after_verb': {},
+					'extra_message': 'speak-A cannot be used with a regular object. The patient is expressed as \'speak about X\'',
+				},
+			},
 		}],
 	]],
+	['take', []],
 	['tell', [
 		['tell-A', {
 			'instrument': { 'by_adposition': 'with' },
 			'patient_clause_different_participant': { 'by_clause_tag': 'patient_clause_different_participant|relative_clause_that' },
 			'comment': 'the patient clause may have been interpreted as a relative clause if \'that\' was present',
 		}],
-		['tell-B', {
-			'patient': {
-				'by_clause_tag': 'patient_clause_different_participant',
-				'missing_message': "tell-B should be written in the format 'X told [Y to Verb]'.",
-			},
-			'other_extra': {
-				'extra_patient': {
-					'directly_after_verb': { },
-					'extra_message': "tell-B should not be written with the patient. Use the format 'X told [Y to Verb]'.",
-				},
-			},
-			'comment': 'the patient is omitted in the phase 1 and copied from within the subordinate. so treat the clause like the patient',
-		}],
+		['tell-B', 'patient_from_subordinate_clause'],
 		['tell-C', {
 			'destination': { 'directly_after_verb': { } },
 			'instrument': { 'by_adposition': 'with' },
@@ -317,6 +389,25 @@ const verb_case_frames = new Map([
 			'destination': { 'directly_after_verb': { } },
 			'patient': { },		// clear the patient so it doesn't get confused with the destination
 			'patient_clause_type': 'patient_clause_quote_begin',
+		}],
+	]],
+	['think', [
+		['think-A', { 'patient': { 'by_adposition': 'about' } }],
+		['think-B', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+		['think-D', {
+			'patient_clause_same_participant': {
+				'by_clause_tag': 'patient_clause_same_participant',
+				'context': {
+					'precededby': { 'token': 'about' },
+				},
+				'context_transform': { 'function': '' },
+				'missing_message': "think-D should be written in the format 'think about [Verb-ing]'",
+			},
+			'patient_clause_different_participant': {
+				'by_clause_tag': 'patient_clause_different_participant',
+				'extra_message': "think-D should be written in the format 'think about [Verb-ing]'",
+			},
+			'patient_clause_type': 'patient_clause_same_participant',
 		}],
 	]],
 	['want', [
@@ -366,7 +457,7 @@ function create_verb_argument_rules() {
  * @returns {ArgumentRoleRule[]}
  */
 function get_default_rules_for_stem(stem) {
-	const role_to_remove = ['be', 'have'].includes(stem) ? 'patient' : 'state'
+	const role_to_remove = ['be', 'become', 'have'].includes(stem) ? 'patient' : 'state'
 	return DEFAULT_CASE_FRAME_RULES.filter(rule => rule.role_tag !== role_to_remove)
 }
 
@@ -375,12 +466,11 @@ const VERB_CASE_FRAME_RULES = create_verb_argument_rules()
 
 /**
  * 
- * @param {Token[]} tokens 
- * @param {number} verb_index 
+ * @param {RuleTriggerContext} trigger_context
  * @param {((rules: ArgumentRoleRule[]) => ArgumentRoleRule[])} rules_modifier
  */
-export function check_verb_case_frames(tokens, verb_index, rules_modifier=rules => rules) {
-	const verb_token = tokens[verb_index]
+export function check_verb_case_frames(trigger_context, rules_modifier=rules => rules) {
+	const verb_token = trigger_context.trigger_token
 
 	const stem = verb_token.lookup_results[0].stem
 	const argument_rules_by_sense = VERB_CASE_FRAME_RULES.get(stem)
@@ -390,7 +480,7 @@ export function check_verb_case_frames(tokens, verb_index, rules_modifier=rules 
 		return
 	}
 
-	check_case_frames(tokens, verb_index, {
+	check_case_frames(trigger_context, {
 		rules_by_sense: argument_rules_by_sense.map(rules_for_sense => ({ ...rules_for_sense, rules: rules_modifier(rules_for_sense.rules) })),
 		default_rules: rules_modifier(get_default_rules_for_stem(stem)),
 		role_letter_map: VERB_LETTER_TO_ROLE,
@@ -399,10 +489,9 @@ export function check_verb_case_frames(tokens, verb_index, rules_modifier=rules 
 
 /**
  * 
- * @param {Token[]} tokens 
- * @param {number} verb_index 
+ * @param {RuleTriggerContext} trigger_context
  */
-export function check_verb_case_frames_passive(tokens, verb_index) {
+export function check_verb_case_frames_passive(trigger_context) {
 	// for a passive, the 'patient' goes right before the verb and the 'agent' is detected by the adposition 'by'
 	const passive_rules_json = {
 		'patient': {
@@ -416,7 +505,8 @@ export function check_verb_case_frames_passive(tokens, verb_index) {
 	}
 	const passive_rules = Object.entries(passive_rules_json).flatMap(parse_case_frame_rule)
 
-	check_verb_case_frames(tokens, verb_index,
+	check_verb_case_frames(
+		trigger_context,
 		role_rules => role_rules.filter(rule => !['patient', 'agent'].includes(rule.role_tag)).concat(passive_rules),
 	)
 }

--- a/app/src/lib/rules/checker_rules.test.js
+++ b/app/src/lib/rules/checker_rules.test.js
@@ -117,7 +117,7 @@ describe('built-in checker rules', () => {
 			expect(checked_tokens[0].error_message).toBe('')
 			expect(checked_tokens[1].error_message).toBe('')
 			expect(checked_tokens[2].error_message).toBe(ERRORS.WORD_LEVEL_TOO_HIGH)
-			expect(checked_tokens[3].error_message).toBe(ERRORS.WORD_LEVEL_TOO_HIGH)
+			// expect(checked_tokens[3].error_message).toBe(ERRORS.WORD_LEVEL_TOO_HIGH)	// TODO renable when the rule is fixed
 			expect(checked_tokens[4].error_message).toBe('')
 		})
 		test('pairing: both words right level', () => {

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -76,6 +76,13 @@ const lookup_rules_json = [
 		'combine': 1,
 	},
 	{
+		'name': 'close to becomes close',
+		'trigger': { 'token': 'close' },
+		'context': { 'followedby': { 'token': 'to' } },
+		'lookup': 'close',
+		'combine': 1,
+	},
+	{
 		'name': 'give birth',
 		'trigger': { 'stem': 'give' },
 		'context': { 'followedby': { 'token': 'birth' } },
@@ -173,12 +180,10 @@ export function parse_lookup_rule(rule_json) {
 
 	/**
 	 * 
-	 * @param {Token[]} tokens 
-	 * @param {number} trigger_index 
-	 * @param {ContextFilterResult} context_result 
+	 * @param {RuleTriggerContext} trigger_context 
 	 * @returns {number}
 	 */
-	function lookup_rule_action(tokens, trigger_index, { context_indexes }) {
+	function lookup_rule_action({ tokens, trigger_index, context_indexes }) {
 		tokens[trigger_index] = { ...tokens[trigger_index], type: TOKEN_TYPE.LOOKUP_WORD, lookup_terms: lookup_term.split('|') }
 
 		if (context_indexes.length === 0) {

--- a/app/src/lib/rules/rules_processor.js
+++ b/app/src/lib/rules/rules_processor.js
@@ -57,7 +57,12 @@ export function apply_rule_to_tokens(tokens, rule) {
 			i++
 			continue
 		}
-		i = rule.action(tokens, i, context_result)
+		i = rule.action({
+			tokens,
+			trigger_index: i,
+			trigger_token: tokens[i],
+			...context_result,
+		})
 	}
 
 	return tokens

--- a/app/src/lib/rules/syntax_rules.js
+++ b/app/src/lib/rules/syntax_rules.js
@@ -1,7 +1,7 @@
 import { TOKEN_TYPE, add_tag_to_token } from '$lib/parser/token'
 import { REGEXES } from '$lib/regexes'
 import { PRONOUN_RULES } from './pronoun_rules'
-import { create_context_filter, create_token_filter, create_token_modify_action } from './rules_parser'
+import { create_context_filter, create_token_filter, simple_rule_action } from './rules_parser'
 
 /**
  * These rules are for tagging tokens based on the syntax. These cannot rely on any lookup data.
@@ -14,8 +14,8 @@ const builtin_syntax_rules = [
 		rule: {
 			trigger: create_token_filter({ 'tag': { 'clause_type': 'subordinate_clause' } }),
 			context: create_context_filter({ 'subtokens': { 'token': '"', 'skip': { 'token': '[' } } }),
-			action: create_token_modify_action(token => {
-				add_tag_to_token(token, { 'clause_type': 'patient_clause_quote_begin' })
+			action: simple_rule_action(({ trigger_token }) => {
+				add_tag_to_token(trigger_token, { 'clause_type': 'patient_clause_quote_begin' })
 			}),
 		},
 	},
@@ -25,9 +25,9 @@ const builtin_syntax_rules = [
 		rule: {
 			trigger: create_token_filter({ 'tag': { 'clause_type': 'main_clause|patient_clause_quote_begin' } }),
 			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
+			action: simple_rule_action(({ trigger_token }) => {
 				// find first word token, even if nested in another clause
-				const word_token = find_first_word(token)
+				const word_token = find_first_word(trigger_token)
 				if (!word_token) {
 					return
 				}
@@ -42,8 +42,8 @@ const builtin_syntax_rules = [
 		rule: {
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && REGEXES.HAS_POSSESSIVE.test(token.token),
 			context: create_context_filter({}),
-			action: create_token_modify_action(token => {
-				add_tag_to_token(token, { 'relation': 'genitive_saxon' })
+			action: simple_rule_action(({ trigger_token }) => {
+				add_tag_to_token(trigger_token, { 'relation': 'genitive_saxon' })
 			}),
 		},
 	},


### PR DESCRIPTION
### Added some checker rules
- Can't use 'when' as a relativizer
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/e09f025d-9e34-4def-959e-f056c661b694)

- Don't allow passives in a same-subject patient clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/ae443cca-0505-4161-842e-65cc3462bfc8)

- Don't allow passives in an in-order-to clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/72be148c-cd84-4fb1-803f-353ef5e69433)

- Suggest avoiding a negative outside a cause/purpose clause
  - make it a suggestion because of the explication for 'to fast' (not eat [so-that X could pray])
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/6aa08052-e0c1-4611-ad88-8d17e82784b9)

- Temporarily disable the level 3 (complex) because the rules can't handle it properly yet (needs to look out from current clause into all parent clauses)

### Added case frames for become, cause, come, go, help, leave, like, live, send, take, and think.
(no screenshots)

### Added handling (some temporary) of certain adjectives
- Improved handling of measurement/unit adjectives
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/9ec65c9b-1610-48a8-b273-0404dfd2d54e)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/87f3b02d-6f6c-4f8d-8686-1af9b5190846)

- Improve handling of surprised/amazed
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0132a973-192f-42cf-8c06-9561686fea4b)

- Improve handling of 'close to'
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/2622cc85-e5af-4353-a260-4323c98d0229)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f30d347c-36b5-46bc-a27a-d852d345151f)

- Add temporary handling of adjectives with certain Noun arguments
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/0f718ac6-70f8-49bb-a356-926ca4e4168e)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/d245226f-2829-4478-ba42-4e7c2f45200c)

- Handle some Nouns with noun arguments
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/1300de91-44fb-4df5-8b30-e6c67ad72268)

### Changed system for setting token messages
- preparing for #100 

### Use a more flexible `RuleTriggerContext` to pass to rule actions