### PR TITLE
Fix coordinate relative clauses

### DIFF
--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -72,10 +72,10 @@ const part_of_speech_rules_json = [
 		'name': 'If Noun-Verb preceded by a Noun, delete the Noun',
 		'category': 'Noun|Verb',
 		'context': {
-			'precededby': { 'category': 'Noun' },
+			'precededby': { 'category': 'Noun', 'skip': { 'tag': { 'clause_type': 'relative_clause' } } },
 		},
 		'remove': 'Noun',
-		'comment': 'Daniel 3:9  I(astrologer) hope(N/V) that...',
+		'comment': 'Daniel 3:9  I(astrologer) hope(N/V) that... "The people [that are in the tribe named Levi] saw(N/V) Mary."',
 	},
 	{
 		'name': 'If Adposition-Conjunction is the first word of a sentence, remove Adposition',

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -72,10 +72,19 @@ const part_of_speech_rules_json = [
 		'name': 'If Noun-Verb preceded by a Noun, delete the Noun',
 		'category': 'Noun|Verb',
 		'context': {
-			'precededby': { 'category': 'Noun', 'skip': { 'tag': { 'clause_type': 'relative_clause' } } },
+			'precededby': { 'category': 'Noun' },
 		},
 		'remove': 'Noun',
-		'comment': 'Daniel 3:9  I(astrologer) hope(N/V) that... "The people [that are in the tribe named Levi] saw(N/V) Mary."',
+		'comment': 'Daniel 3:9  I(astrologer) hope(N/V) that...',
+	},
+	{
+		'name': 'If Noun-Verb followed by a Noun, delete the Noun',
+		'category': 'Noun|Verb',
+		'context': {
+			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
+		},
+		'remove': 'Noun',
+		'comment': '"The people [that are in the tribe named Levi] saw(N/V) Mary." This only works because cases like "the judge\'s(N/V) house" are handled earlier.',
 	},
 	{
 		'name': 'If Adposition-Conjunction is the first word of a sentence, remove Adposition',

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -67,12 +67,12 @@ const transform_rules_json = [
 		'name': 'Set tag for relative clauses and relativizers',
 		'trigger': { 'tag': { 'clause_type': 'subordinate_clause' } },
 		'context': {
-			'precededby': { 'category': 'Noun' },
+			'precededby': { 'category': 'Noun', 'skip': { 'tag': { 'clause_type': 'relative_clause' } } },
 			'subtokens': { 'tag': { 'syntax': 'relativizer' }, 'skip': [{ 'token': '[' }, { 'category': 'Conjunction' }] },
 		},
 		'transform': { 'tag': { 'clause_type': 'relative_clause' } },
 		'subtoken_transform': { 'tag': { 'determiner': '' } },
-		'comment': 'removes extra tags for words like "who" and "which". clear the determiner tag but keep the syntax one',
+		'comment': 'removes extra tags for words like "who" and "which". clear the determiner tag but keep the syntax one. This also handles coordinate relative clauses.',
 	},
 	{
 		'name': 'Set extra tag for relative clauses that use "that"',
@@ -126,7 +126,7 @@ const transform_rules_json = [
 		'name': 'tag subordinate clauses starting with the infinitive \'to\' as \'same_participant\'',
 		'trigger': { 'tag': { 'clause_type': 'subordinate_clause' } },
 		'context': { 
-			'subtokens': { 'token': 'to', 'tag': { 'syntax': 'infinitive_same_subject' }, 'skip': { 'token': '[' } },
+			'subtokens': { 'token': 'to', 'tag': { 'syntax': 'infinitive_same_subject' }, 'skip': 'all' },
 		},
 		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant' } },
 		'comment': 'eg John wanted [to sing]',


### PR DESCRIPTION
Before:
- The coordinate relative clause wasn't being recognized as a relative clause. We don't (yet) want to check the case frame for relative clauses because there is always a missing argument, in this case the agent.
- Due to the relative clause blocking the subject Noun, 'saw' was not being disambiguated between Noun/Verb.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7173925d-0975-41a6-a03b-6e8c7800dc95)

After:
- The coordinate relative clause is recognized and therefore its case frame is not checked.
- A new rule disambiguates 'saw' based on it being followed directly by a Noun
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/15740457-9dd9-42e5-8c2b-90ea9f74608a)
