### PR TITLE
Fix false lookup matches

### DIFF
--- a/app/src/lib/lookups/form.js
+++ b/app/src/lib/lookups/form.js
@@ -35,10 +35,11 @@ export function check_forms(db) {
 		// So add a lookup term for each unique stem (case-insensitive)
 		const unique_stems = new Set(lookup_results.map(({ stem }) => stem.toLowerCase()))
 
-		// Add the original lookup stem in case there is a missing form (eg. Adjectives left, following)
-		unique_stems.add(term.toLowerCase())
+		// Exclude the original lookup stem as it's handled separately
+		unique_stems.delete(term.toLowerCase())
 
-		token.lookup_terms = [...unique_stems]
+		// Keep the original token-based term as the first lookup term
+		token.lookup_terms = [term.toLowerCase(), ...unique_stems]
 		token.lookup_results = lookup_results
 	}
 

--- a/app/src/lib/lookups/how_to.js
+++ b/app/src/lib/lookups/how_to.js
@@ -13,6 +13,11 @@ export async function check_how_to(lookup_token) {
 			// The sense exists in the ontology and the how-to
 			existing_result.how_to.push(how_to_result)
 
+		} else if (how_to_result.stem.toLowerCase() !== lookup_token.lookup_terms[0].toLowerCase()) {
+			// The word exists in the how-to but it doesn't match the token based on the form
+			// eg. the token 'witnessing' should not match with the how-to result for the Noun 'witness'
+			// don't add it to the results
+			
 		} else if (how_to_result.sense) {
 			// The sense exists in the how-to but not in the ontology, but is planned to be added
 			const new_result = create_lookup_result(how_to_result, { how_to: [how_to_result] })
@@ -27,14 +32,10 @@ export async function check_how_to(lookup_token) {
 			}
 			lookup_token.lookup_results.push(new_result)
 
-		} else if (how_to_result.stem.toLowerCase() === lookup_token.lookup_terms[0].toLowerCase()) {
+		} else {
 			// The word exists in the how-to but not in the ontology, and may never be
 			const new_result = create_lookup_result(how_to_result, { how_to: [how_to_result] })
 			lookup_token.lookup_results.push(new_result)
-
-		} else {
-			// The word exists in the how-to but it doesn't match the token based on the form
-			// eg. the token 'witnessing' should not match with the how-to result for the Noun 'witness'
 		}
 	}
 

--- a/app/src/lib/lookups/how_to.js
+++ b/app/src/lib/lookups/how_to.js
@@ -27,10 +27,14 @@ export async function check_how_to(lookup_token) {
 			}
 			lookup_token.lookup_results.push(new_result)
 
-		} else {
+		} else if (how_to_result.stem.toLowerCase() === lookup_token.lookup_terms[0].toLowerCase()) {
 			// The word exists in the how-to but not in the ontology, and may never be
 			const new_result = create_lookup_result(how_to_result, { how_to: [how_to_result] })
 			lookup_token.lookup_results.push(new_result)
+
+		} else {
+			// The word exists in the how-to but it doesn't match the token based on the form
+			// eg. the token 'witnessing' should not match with the how-to result for the Noun 'witness'
 		}
 	}
 

--- a/app/src/lib/lookups/ontology.js
+++ b/app/src/lib/lookups/ontology.js
@@ -18,11 +18,13 @@ export async function check_ontology(lookup_token) {
 	 */
 	function transform_results(transformed_results, ontology_result) {
 		const existing_result = lookup_token.lookup_results.find(lookup => lookups_match(lookup, ontology_result))
-		if (!existing_result && ontology_result.stem.toLowerCase() !== lookup_token.lookup_terms[0]) {
+		
+		if (!existing_result && ontology_result.stem.toLowerCase() !== lookup_token.lookup_terms[0].toLowerCase()) {
 			// Don't include new results that don't match the original token lookup term
 			// eg. 'covering' should not match the noun 'cover', even though it matches the ontology search for the verb stem 'cover'
 			return transformed_results
 		}
+		
 		const form = existing_result?.form ?? 'stem'
 		const result = create_lookup_result(ontology_result, { form, concept: ontology_result })
 		transformed_results.push(result)


### PR DESCRIPTION
Based on the lookup search of the stem, it was finding results that should not match based on the form of the word (eg. 'covering' will never be the noun 'cover'). It usually isn't a problem due to the part-of-speech rules that filter out the wrong ones, but it doesn't always work. This PR fully resolves that issue.

**covering**
Before:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/75499c2b-515c-4e6d-8fe7-f5cc51148a25)

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/98434f10-b812-4082-a8f8-c7de6cb5bb1c)

**judged**
Before:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b93562bd-7120-4dfa-8e24-5d4c05dba1b4)

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/3470e872-b8e0-4ba2-8e51-b4f030ddf82d)

**judges**
- this could still be either the verb or noun
After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f597e0e7-c3e2-4d55-ad3f-fc94cc032f57)

**pleased**
Before:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/47002885-cfdb-4f94-90dc-bcc14547f6c8)

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/ed21438b-6898-4acc-9f67-e62c975dc07c)

**bowed**
Before:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b61bccf3-65ea-4e37-ad6f-0ad2faee695e)

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b840927a-33c2-4d26-9da2-3c704c76f115)