### PR TITLE
Add part of speech disambiguating notes

### DIFF
--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -652,6 +652,22 @@ const builtin_checker_rules = [
 		},
 	},
 	{
+		name: 'Check for words with ambiguous parts of speech',
+		comment: '',
+		rule: {
+			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
+			context: create_context_filter({}),
+			action: message_set_action(function* ({ trigger_token: token }) {
+				if (token.lookup_results.every(result => result.part_of_speech.toLowerCase() === token.lookup_results[0].part_of_speech.toLowerCase())) {
+					return {}
+				}
+				
+				yield { warning: 'The editor cannot determine which part of speech this word is, so some errors and warnings within the same clause may not be accurate.' }
+				yield { suggest: "Add '_noun', '_verb', '_adj', '_adv', or '_adp' after '{token}' if you want the editor to check the syntax more accurately." }
+			}),
+		},
+	},
+	{
 		name: 'Check argument structure/case frame',
 		comment: 'case frame rules can eventually be used for verbs, adjectives, adverbs, adpositions, and even conjunctions',
 		rule: {

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -831,9 +831,13 @@ function* check_lookup_results(token) {
 	} else if (token.lookup_results.some(result => result.how_to.length > 0)) {
 		yield { token_to_flag: token, error: 'The {category} \'{stem}\' is not in the Ontology. Hover over the word for hints from the How-To document.' }
 		
+	} else if (token.lookup_results.length > 0) {
+		// a dummy result for an unknown word
+		yield { token_to_flag: token, warning: 'The {category} \'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
 	} else {
 		yield { token_to_flag: token, warning: '\'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
 		yield { token_to_flag: token, warning: 'WARNING: Because this word is not recognized, errors and warnings within the same clause may not be accurate.' }
+		yield { token_to_flag: token, suggest: "Add '_noun', '_verb', '_adj', '_adv', or '_adp' after the unknown word if you want the editor to check the syntax more accurately." }
 	}
 }
 

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -643,10 +643,10 @@ const builtin_checker_rules = [
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
 			context: create_context_filter({}),
 			action: message_set_action(function* ({ trigger_token: token }) {
-				yield check_lookup_results(token)
+				yield* check_lookup_results(token)
 
 				if (token.complex_pairing) {
-					yield check_lookup_results(token.complex_pairing)
+					yield* check_lookup_results(token.complex_pairing)
 				}
 			}),
 		},
@@ -819,21 +819,21 @@ function check_ambiguous_level(level_check) {
 /**
  * 
  * @param {Token} token 
- * @returns {MessageInfo}
  */
-function check_lookup_results(token) {
+function* check_lookup_results(token) {
 	if (token.lookup_results.some(result => result.concept !== null && result.concept.id !== '0')) {
 		return {}
 	}
 
 	if (token.lookup_results.at(0)?.concept?.id === '0') {
-		return { token_to_flag: token, info: 'The {category} \'{stem}\' is not yet in the Ontology, but should be soon. Consult the How-To document for more info.' }
+		yield { token_to_flag: token, info: 'The {category} \'{stem}\' is not yet in the Ontology, but should be soon. Consult the How-To document for more info.' }
 
 	} else if (token.lookup_results.some(result => result.how_to.length > 0)) {
-		return { token_to_flag: token, error: 'The {category} \'{stem}\' is not in the Ontology. Hover over the word for hints from the How-To document.' }
+		yield { token_to_flag: token, error: 'The {category} \'{stem}\' is not in the Ontology. Hover over the word for hints from the How-To document.' }
 		
 	} else {
-		return { token_to_flag: token, warning: '\'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
+		yield { token_to_flag: token, warning: '\'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
+		yield { token_to_flag: token, warning: 'WARNING: Because this word is not recognized, errors and warnings within the same clause may not be accurate.' }
 	}
 }
 

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -359,7 +359,7 @@ const builtin_part_of_speech_rules = [
 		comment: '',
 		rule: {
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
-			context: create_context_filter({ 'followedby': { 'token': '_noun|_verb|_adj|_adv' } }),
+			context: create_context_filter({ 'followedby': { 'token': '_noun|_verb|_adj|_adv|_adp' } }),
 			action: simple_rule_action(({ trigger_token, tokens, context_indexes }) => {
 				const part_of_speech_note = tokens[context_indexes[0]].token
 				const part_of_speech = new Map([
@@ -367,6 +367,7 @@ const builtin_part_of_speech_rules = [
 					['_verb', 'Verb'],
 					['_adj', 'Adjective'],
 					['_adv', 'Adverb'],
+					['_adp', 'Adposition'],
 				]).get(part_of_speech_note) ?? ''
 
 				keep_parts_of_speech(new Set([part_of_speech]))(trigger_token)

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -1,5 +1,6 @@
 import { ERRORS } from '$lib/parser/error_messages'
 import { create_context_filter, create_token_filter, message_set_action, simple_rule_action } from './rules_parser'
+import { TOKEN_TYPE, create_lookup_result } from '$lib/parser/token'
 
 /**
  * These rules are designed to disambiguate words that could be multiple parts of speech.
@@ -349,6 +350,30 @@ const builtin_part_of_speech_rules = [
 					category_filter(right)
 				} else {
 					return { error: ERRORS.PAIRING_DIFFERENT_PARTS_OF_SPEECH }
+				}
+			}),
+		},
+	},
+	{
+		name: 'Select part-of-speech based on a note',
+		comment: '',
+		rule: {
+			trigger: token => token.type === TOKEN_TYPE.LOOKUP,
+			context: create_context_filter({ 'followedby': { 'token': '_noun|_verb|_adj|_adv' } }),
+			action: simple_rule_action(({ trigger_token, tokens, context_indexes }) => {
+				const part_of_speech_note = tokens[context_indexes[0]].token
+				const part_of_speech = new Map([
+					['_noun', 'Noun'],
+					['_verb', 'Verb'],
+					['_adj', 'Adjective'],
+					['_adv', 'Adverb'],
+				]).get(part_of_speech_note) ?? ''
+
+				keep_parts_of_speech(new Set([part_of_speech]))(trigger_token)
+
+				// if no results remain, add a dummy one so the word acts like that part-of-speech
+				if (trigger_token.lookup_results.length === 0) {
+					trigger_token.lookup_results.push(create_lookup_result({ stem: trigger_token.token, part_of_speech }))
 				}
 			}),
 		},

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -358,7 +358,7 @@ const builtin_part_of_speech_rules = [
 		name: 'Select part-of-speech based on a note',
 		comment: '',
 		rule: {
-			trigger: token => token.type === TOKEN_TYPE.LOOKUP,
+			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
 			context: create_context_filter({ 'followedby': { 'token': '_noun|_verb|_adj|_adv' } }),
 			action: simple_rule_action(({ trigger_token, tokens, context_indexes }) => {
 				const part_of_speech_note = tokens[context_indexes[0]].token

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -208,7 +208,7 @@ const transform_rules_json = [
 		'trigger': { 'token': 'named' },
 		'context': {
 			'precededby': { 'category': 'Verb', 'skip': 'all' },
-			'followedby': { 'level': '4' },
+			'followedby': { 'category': 'Noun' },
 		},
 		'transform': { 'function': { 'relation': 'name' } },
 	},
@@ -216,7 +216,7 @@ const transform_rules_json = [
 		'name': '\'named\' before a name and before a Verb becomes a function word',
 		'trigger': { 'token': 'named' },
 		'context': {
-			'followedby': [{ 'level': '4' }, { 'category': 'Verb', 'skip': 'all' }],
+			'followedby': [{ 'category': 'Noun' }, { 'category': 'Verb', 'skip': 'all' }],
 		},
 		'transform': { 'function': { 'relation': 'name' } },
 	},


### PR DESCRIPTION
Resolves #111 

### Show additional messages on words that are Unknown
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b153e7a9-a7ba-4fed-b2fe-f6917c706143)

### Support _noun/_verb/etc notes for unknown words
- useful for when a word will be added to the Ontology but hasn't been yet.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b734cb1c-8232-45cf-ab6b-f26e8c19d12f)

### Show a warning on words that still have an ambiguous part-of-speech
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/ac54fbbe-463d-4211-923c-c32f93ef6a3f)

### Support _noun/_verb/etc notes for disambiguation
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/d6e80f22-4401-4545-b5be-3c5db6370c00)

### Support _noun/_verb/etc for any words
- `search` is a verb in the ontology, and so creates false warnings in the sentence below, without the note. Adding _noun treats 'search' as a Noun, even though it is only known as a Verb - useful for when a word will be added to the Ontology but hasn't been yet.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/5fcf2761-8610-4d3c-a862-ec721424e707)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/cbfc3157-613b-42e6-a0d2-1bd7a10e84ca)
