### PR TITLE
Minor Editor fixes

### DIFF
--- a/app/src/lib/parser/tokenize.js
+++ b/app/src/lib/parser/tokenize.js
@@ -90,9 +90,10 @@ export function tokenize_input(text = '') {
 
 	function colon() {
 		if (peek_match(/\d/)) {
-			return simple_token(TOKEN_TYPE.PUNCTUATION)
+			// verse reference
+			return create_token(collect_text(), TOKEN_TYPE.LOOKUP_WORD, { lookup_term: '-ReferenceMarker' })
 		}
-		return check_boundary_for_token(word_token)
+		return check_boundary_for_token(() => simple_token(TOKEN_TYPE.PUNCTUATION))
 	}
 
 	function clause_notation() {

--- a/app/src/lib/parser/tokenize.test.js
+++ b/app/src/lib/parser/tokenize.test.js
@@ -320,7 +320,7 @@ describe('tokenize_input', () => {
 			create_word_token('token'),
 			create_token(',', TOKEN_TYPE.PUNCTUATION),
 			create_word_token('5'),
-			create_token(':', TOKEN_TYPE.PUNCTUATION),
+			create_token(':', TOKEN_TYPE.LOOKUP_WORD, { lookup_term: '-ReferenceMarker' }),
 			create_word_token('5'),
 		]
 

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -242,7 +242,9 @@ const verb_case_frames = new Map([
 		}],
 		['become-J', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
 	]],
-	['cause', []],
+	['cause', [
+		['cause-A', { 'other_optional': 'patient' }],
+	]],
 	['come', []],
 	['give', [
 		['give-A', {

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -242,9 +242,7 @@ const verb_case_frames = new Map([
 		}],
 		['become-J', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
 	]],
-	['cause', [
-		['cause-A', { 'other_optional': 'patient' }],
-	]],
+	['cause', []],
 	['come', []],
 	['give', [
 		['give-A', {

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -126,7 +126,7 @@ const verb_case_frames = new Map([
 				'context': {
 					'precededby': [
 						{ 'tag': { 'syntax': 'existential' }, 'skip': 'vp_modifiers' },
-						{ 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] }
+						{ 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] },
 					],
 				},
 				'missing_message': 'be-E requires the format \'there be X\'.',

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -663,7 +663,7 @@ const builtin_checker_rules = [
 				}
 				
 				yield { warning: 'The editor cannot determine which part of speech this word is, so some errors and warnings within the same clause may not be accurate.' }
-				yield { suggest: "Add '_noun', '_verb', '_adj', '_adv', or '_adp' after '{token}' if you want the editor to check the syntax more accurately." }
+				yield { suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after '{token}' if you want the editor to check the syntax more accurately." }
 			}),
 		},
 	},
@@ -853,7 +853,7 @@ function* check_lookup_results(token) {
 	} else {
 		yield { token_to_flag: token, warning: '\'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
 		yield { token_to_flag: token, warning: 'WARNING: Because this word is not recognized, errors and warnings within the same clause may not be accurate.' }
-		yield { token_to_flag: token, suggest: "Add '_noun', '_verb', '_adj', '_adv', or '_adp' after the unknown word if you want the editor to check the syntax more accurately." }
+		yield { token_to_flag: token, suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after the unknown word if you want the editor to check the syntax more accurately." }
 	}
 }
 

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -183,7 +183,7 @@ export function parse_lookup_rule(rule_json) {
 	 * @param {RuleTriggerContext} trigger_context 
 	 * @returns {number}
 	 */
-	function lookup_rule_action({ tokens, trigger_index, context_indexes }) {
+	function lookup_rule_action({ tokens, trigger_index, trigger_token, context_indexes }) {
 		const lookup_terms = lookup_term.split('|')
 
 		// specify the sense if given in the lookup value
@@ -191,10 +191,11 @@ export function parse_lookup_rule(rule_json) {
 		lookup_terms[0] = stem
 		
 		tokens[trigger_index] = {
-			...tokens[trigger_index],
+			...trigger_token,
 			type: TOKEN_TYPE.LOOKUP_WORD,
-			specified_sense: sense || tokens[trigger_index].specified_sense,
+			specified_sense: sense || trigger_token.specified_sense,
 			lookup_terms,
+			lookup_results: trigger_token.lookup_results.filter(result => lookup_terms.includes(result.stem)),
 		}
 
 		if (context_indexes.length === 0) {
@@ -210,7 +211,7 @@ export function parse_lookup_rule(rule_json) {
 		
 		// combine context tokens into one
 		const tokens_to_combine = tokens.splice(trigger_index, combine + 1)
-		const new_token_value = tokens_to_combine.map(token => token.token).join(' ')
+		const new_token_value = tokens_to_combine.map(({ token }) => token).join(' ')
 		tokens.splice(trigger_index, 0, { ...tokens_to_combine[0], token: new_token_value })
 		return trigger_index + combine + 1
 	}

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -70,7 +70,7 @@ const lookup_rules_json = [
 	},
 	{
 		'name': 'because of becomes because-B',
-		'trigger': { 'token': 'because' },
+		'trigger': { 'token': 'Because|because' },
 		'context': { 'followedby': { 'token': 'of' } },
 		'lookup': 'because-B',
 		'combine': 1,

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -46,21 +46,19 @@ const part_of_speech_rules_json = [
 		'name': 'If Noun-Verb preceded by Adjective or Conjunction, delete the Verb',
 		'category': 'Noun|Verb',
 		'context': {
-			'precededby': { 'category': 'Verb|Adjective|Conjunction' },
-			'notprecededby': { 'stem': 'be', 'skip': 'vp_modifiers' },
+			'precededby': { 'category': 'Adjective|Conjunction' },
 		},
 		'remove': 'Verb',
 		'comment': 'Preceded by an Adjective: Daniel 1:7 The official gave new names(N/V) to the men... Preceded by a Conjunction: Because we don\'t allow coordinate VPs in these propositions, if there\'s a Conjunction preceding the Noun/Verb, the word must be a Noun. Daniel 2:37 God has given wealth and honor(N/V) to you.',
 	},
 	{
-		'name': 'If Noun-Verb preceded by Verb other than "be", delete the Verb',
+		'name': 'If Noun-Verb preceded by Verb, delete the Verb',
 		'category': 'Noun|Verb',
 		'context': {
 			'precededby': { 'category': 'Verb' },
-			'notprecededby': { 'stem': 'be' },
 		},
 		'remove': 'Verb',
-		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Preceded by "be": You(people) should be teaching(N/V) other people about those things.',
+		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Sometimes wrongly selects Noun when preceded by "be": You(people) should be teaching(N/V) other people about those things. (not sure how to fix this without breaking other cases)',
 	},
 	{
 		'name': 'If Noun-Verb preceded by certain Adpositions, delete the Verb',

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -104,11 +104,11 @@ const part_of_speech_rules_json = [
 		'comment': 'only for \'so\'. \'for\' might be the \'for each...\' sense',
 	},
 	{
-		'name': 'If "so" appears anywhere else in the sentence, remove Conjunction',
+		'name': 'If "so/for" appears anywhere else in the sentence, remove Conjunction',
 		'category': 'Adposition|Conjunction',
-		'trigger': { 'stem': 'so' },
+		'trigger': { 'token': 'so|for' },
 		'remove': 'Conjunction',
-		'comment': 'This relies on the previous rule to catch all uses of the conjunction',
+		'comment': 'This relies on the fact these conjunctions must be the first word and therefore capitalized',
 	},
 	{
 		'name': 'If Adverb-Adjective followed by Noun, remove Adverb',

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -52,15 +52,6 @@ const part_of_speech_rules_json = [
 		'comment': 'Preceded by an Adjective: Daniel 1:7 The official gave new names(N/V) to the men... Preceded by a Conjunction: Because we don\'t allow coordinate VPs in these propositions, if there\'s a Conjunction preceding the Noun/Verb, the word must be a Noun. Daniel 2:37 God has given wealth and honor(N/V) to you.',
 	},
 	{
-		'name': 'If Noun-Verb preceded by Verb, delete the Verb',
-		'category': 'Noun|Verb',
-		'context': {
-			'precededby': { 'category': 'Verb' },
-		},
-		'remove': 'Verb',
-		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Sometimes wrongly selects Noun when preceded by "be": You(people) should be teaching(N/V) other people about those things. (not sure how to fix this without breaking other cases)',
-	},
-	{
 		'name': 'If Noun-Verb preceded by certain Adpositions, delete the Verb',
 		'category': 'Noun|Verb',
 		'context': {
@@ -95,6 +86,15 @@ const part_of_speech_rules_json = [
 		},
 		'remove': 'Noun',
 		'comment': '"The people [that are in the tribe named Levi] saw(N/V) Mary." This only works because cases like "the judge\'s(N/V) house" are handled earlier.',
+	},
+	{
+		'name': 'If Noun-Verb preceded by Verb, delete the Verb',
+		'category': 'Noun|Verb',
+		'context': {
+			'precededby': { 'category': 'Verb' },
+		},
+		'remove': 'Verb',
+		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Sometimes wrongly selects Noun when preceded by "be": You(people) should be teaching(N/V) other people about those things. (not sure how to fix this without breaking other cases)',
 	},
 	{
 		'name': 'If Adposition-Conjunction is the first word of a sentence, remove Adposition',

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -43,13 +43,24 @@ const part_of_speech_rules_json = [
 		'comment': 'I will judge(N/V). I do not judge(N/V). I should judge(N/V). etc',
 	},
 	{
-		'name': 'If Noun-Verb preceded by Verb, Adjective, Conjunction, delete the Verb',
+		'name': 'If Noun-Verb preceded by Adjective or Conjunction, delete the Verb',
 		'category': 'Noun|Verb',
 		'context': {
 			'precededby': { 'category': 'Verb|Adjective|Conjunction' },
+			'notprecededby': { 'stem': 'be', 'skip': 'vp_modifiers' },
 		},
 		'remove': 'Verb',
-		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Preceded by an Adjective: Daniel 1:7 The official gave new names(N/V) to the men... Preceded by a Conjunction: Because we don\'t allow coordinate VPs in these propositions, if there\'s a Conjunction preceding the Noun/Verb, the word must be a Noun. Daniel 2:37 God has given wealth and honor(N/V) to you.',
+		'comment': 'Preceded by an Adjective: Daniel 1:7 The official gave new names(N/V) to the men... Preceded by a Conjunction: Because we don\'t allow coordinate VPs in these propositions, if there\'s a Conjunction preceding the Noun/Verb, the word must be a Noun. Daniel 2:37 God has given wealth and honor(N/V) to you.',
+	},
+	{
+		'name': 'If Noun-Verb preceded by Verb other than "be", delete the Verb',
+		'category': 'Noun|Verb',
+		'context': {
+			'precededby': { 'category': 'Verb' },
+			'notprecededby': { 'stem': 'be' },
+		},
+		'remove': 'Verb',
+		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Preceded by "be": You(people) should be teaching(N/V) other people about those things.',
 	},
 	{
 		'name': 'If Noun-Verb preceded by certain Adpositions, delete the Verb',
@@ -359,7 +370,7 @@ const builtin_part_of_speech_rules = [
 		comment: '',
 		rule: {
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
-			context: create_context_filter({ 'followedby': { 'token': '_noun|_verb|_adj|_adv|_adp' } }),
+			context: create_context_filter({ 'followedby': { 'token': '_noun|_verb|_adj|_adv|_adp|_conj' } }),
 			action: simple_rule_action(({ trigger_token, tokens, context_indexes }) => {
 				const part_of_speech_note = tokens[context_indexes[0]].token
 				const part_of_speech = new Map([
@@ -368,6 +379,7 @@ const builtin_part_of_speech_rules = [
 					['_adj', 'Adjective'],
 					['_adv', 'Adverb'],
 					['_adp', 'Adposition'],
+					['_conj', 'Conjunction'],
 				]).get(part_of_speech_note) ?? ''
 
 				keep_parts_of_speech(new Set([part_of_speech]))(trigger_token)
@@ -375,6 +387,30 @@ const builtin_part_of_speech_rules = [
 				// if no results remain, add a dummy one so the word acts like that part-of-speech
 				if (trigger_token.lookup_results.length === 0) {
 					trigger_token.lookup_results.push(create_lookup_result({ stem: trigger_token.token, part_of_speech }))
+				}
+			}),
+		},
+	},
+	{
+		name: 'Disambiguate part-of-speech based on the selected sense',
+		comment: '',
+		rule: {
+			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && token.specified_sense.length > 0,
+			context: create_context_filter({}),
+			action: message_set_action(({ trigger_token: token }) => {
+				if (token.lookup_results.every(result => result.part_of_speech.toLowerCase() === token.lookup_results[0].part_of_speech.toLowerCase())) {
+					return {}
+				}
+
+				// get all results that match the specified sense
+				const parts_of_speech_for_sense = new Set(token.lookup_results
+					.filter(result => result.concept?.sense === token.specified_sense)
+					.map(result => result.part_of_speech))
+
+				if (parts_of_speech_for_sense.size > 0) {
+					keep_parts_of_speech(parts_of_speech_for_sense)(token)
+				} else {
+					return { warning: `No sense '${token.specified_sense}' was found for this word in any part-of-speech.` }
 				}
 			}),
 		},

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -429,6 +429,16 @@ const transform_rules_json = [
 		},
 		'transform': { 'tag': { 'syntax': 'predicate_adjective' } },
 	},
+	{
+		'name': 'tag adjectives around verse references',
+		'trigger': { 'token': ':', 'stem': '-ReferenceMarker' },
+		'context': {
+			'precededby': { 'category': 'Adjective' },
+			'followedby': { 'category': 'Adjective' },
+		},
+		'context_transform': [{ 'tag': { 'syntax': '' } }, { 'tag': { 'syntax': '' } }],
+		'comment': 'remove the "predicate_adjective" tag from verse reference numbers',
+	},
 ]
 
 /**


### PR DESCRIPTION
### Handle verse references
`(footnote) You(people) (imp) see Psalms 2:7.`
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/6b912f15-3e13-4732-9cff-6274878df428)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/77d459c2-32c6-4f47-97b9-eaa02843e8f0)

### Select because-B for 'because of X'
`Because of that reason, John must go.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7b42b996-8864-4942-ab39-f5d29fdc6840)

### 'just like' should not lookup 'just'
`The priest must give gifts/sacrifices for-B the priest's bad-B actions [just like the priest gives gifts/sacrifices for-B the bad-B actions of the people].`
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/991ae27e-a8d1-407b-b9ef-4a3f69280488)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b406b048-618d-4a87-b2da-6799e427b7a8)

### Use specified sense to disambiguate parts of speech
- eg. for-B should always result in the Adposition because there is no Conjunction for-B
`The priest must give gifts/sacrifices for-B the priest's bad-B actions.`
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/022b9886-cc9c-4496-9cc3-74a94585d963)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/9b77d577-9dc3-4228-b5b7-b7e3b1168351)

### Improve Noun/Verb part-of-speech rule when after 'be'
- 'teaching' after 'be' should actually be the Verb. By reordering the rules, it now detects the Noun after 'teaching' first before detecting the verb 'be'
`You(people) should be teaching other people about those things.`
**Before:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/4eb34491-fa28-4698-bf0a-fb24478d5419)

**After:**
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/7c32a1e7-d3dd-4a08-9df1-e3be3ccf0b4c)

- An ambiguous word like 'judges' after 'be' is still handled correctly
`You(people) should be judges for your(people's) people.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/c691b5fa-bb0c-45af-940b-a2e64abd87b7)