### PR TITLE
Fix 'named' phrases

### DIFF
--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -208,7 +208,7 @@ const transform_rules_json = [
 		'trigger': { 'token': 'named' },
 		'context': {
 			'precededby': { 'category': 'Verb', 'skip': 'all' },
-			'followedby': { 'category': 'Noun' },
+			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
 		},
 		'transform': { 'function': { 'relation': 'name' } },
 	},
@@ -216,7 +216,10 @@ const transform_rules_json = [
 		'name': '\'named\' before a name and before a Verb becomes a function word',
 		'trigger': { 'token': 'named' },
 		'context': {
-			'followedby': [{ 'category': 'Noun' }, { 'category': 'Verb', 'skip': 'all' }],
+			'followedby': [
+				{ 'category': 'Noun', 'skip': 'np_modifiers' },
+				{ 'category': 'Verb', 'skip': 'all' },
+			],
 		},
 		'transform': { 'function': { 'relation': 'name' } },
 	},


### PR DESCRIPTION
Fixes #116 
`Melchizedek named that man _ExplainName was the king of Salem named a city _ExplainName.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/cdb32e5f-0b6c-4a09-8fb4-f7c0fcc627fc)

The rule that recognized the 'named' relation was expecting a name to follow, ie a non-modified noun (eg. 'a man named Paul'). However, the _explainName structure is written with the nouns flipped, meaning the noun that follows 'named' could be any noun phrase. The 'named' rules have been adjusted to accommodate this.

Note this rule still doesn't trigger when 'named' is being used as the Verb:
`John named that man Saul.`
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/1644470c-fc02-4385-8ea1-80aeef431a22)
