### PR TITLE
Add adjective case frames

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -134,8 +134,12 @@ type RoleTag = string
 type WordSense = string
 type WordStem = string
 
+type RoleRulePreset = [string, (preset_value: any, role_tag: RoleTag) => any]
+
 type ArgumentRoleRule = {
 	role_tag: RoleTag
+	// if the trigger rule is relative to the trigger word, this index tells the rule which context index the argument is at
+	relative_context_index: number
 	trigger_rule: TokenRule
 	missing_message: string
 	extra_message: string
@@ -147,6 +151,11 @@ type ArgumentRulesForSense = {
 	other_required: RoleTag[]
 	other_optional: RoleTag[]
 	patient_clause_type: RoleTag
+}
+
+type RoleUsageInfo = {
+	possible_roles: string[]
+	required_roles: string[]
 }
 
 type ArgumentMatchFilter = (role_matches: RoleMatchResult[]) => boolean

--- a/app/src/lib/parser/index.js
+++ b/app/src/lib/parser/index.js
@@ -19,8 +19,7 @@ export async function parse(text, db) {
 		perform_ontology_lookups,
 		rules_applier(RULES.PART_OF_SPEECH),
 		rules_applier(RULES.TRANSFORM),
-		rules_applier(RULES.CASE_FRAME),
-		rules_applier(RULES.SENSE),
+		rules_applier(RULES.ARGUMENT_AND_SENSE),
 		rules_applier(RULES.CHECKER),
 	)(text)
 }
@@ -39,8 +38,7 @@ export function parse_for_test(text) {
 		rules_applier(RULES.LOOKUP),
 		rules_applier(RULES.PART_OF_SPEECH),
 		rules_applier(RULES.TRANSFORM),
-		rules_applier(RULES.CASE_FRAME),
-		rules_applier(RULES.SENSE),
+		rules_applier(RULES.ARGUMENT_AND_SENSE),
 		rules_applier(RULES.CHECKER.slice(0,4)),	// TODO remove slice when e2e testing is set up (skips the 'no lookup' check)
 		flatten_sentences,
 	)(text)

--- a/app/src/lib/parser/token.js
+++ b/app/src/lib/parser/token.js
@@ -200,6 +200,15 @@ export function set_token_concept(token, concept) {
 
 /**
  * 
+ * @param {Token} token 
+ * @returns {boolean}
+ */
+export function is_one_part_of_speech(token) {
+	return token.lookup_results.every(result => result.part_of_speech.toLowerCase() === token.lookup_results[0].part_of_speech.toLowerCase())
+}
+
+/**
+ * 
  * @param {string} term 
  * @returns {{stem: string, sense: string}}
  */

--- a/app/src/lib/rules/case_frame/adjectives.js
+++ b/app/src/lib/rules/case_frame/adjectives.js
@@ -1,0 +1,276 @@
+import { TOKEN_TYPE } from '$lib/parser/token'
+import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from './common'
+
+const default_adjective_case_frame_json = {
+	'modified_noun': {
+		'modified_noun_of_adjective': { },
+	},
+	'nominal_argument': {
+		'trigger': 'none',
+	},
+	'patient_clause_different_participant': {
+		'by_clause_tag': 'patient_clause_different_participant',
+	},
+	'patient_clause_same_participant': {
+		'by_clause_tag': 'patient_clause_same_participant',
+	},
+}
+
+/** @type {RoleRulePreset[]} */
+// @ts-ignore the map initializer array doesn't like the different object structures
+const ROLE_RULE_PRESETS = [
+	['by_adposition', preset_value => ({
+		'by_relative_context': {
+			'followedby': [
+				{ 'token': preset_value },
+				{ 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' },
+			],
+			'argument_context_index': 1,
+		},
+		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
+		'context_transform': { 'function': { 'syntax': '', 'relation': '' } },	// make the adposition a function word and clear other tag values
+		'missing_message': `Couldn't find the nominal argument, which in this case should have '${preset_value}' before it.`,
+	})],
+	['by_clause_tag', preset_value => ({
+		'by_relative_context': {
+			'followedby': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': preset_value, 'role': 'none' } },
+			'comment': 'the clause should immediately follow the adjective',
+		},
+	})],
+	['modified_noun_of_adjective', () => ({ 
+		'by_relative_context': {
+			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
+			'notfollowedby': { 'token': 'of' },
+		},
+		'tag_role': false,
+		'comment': '"of" is a relation that can be part of an NP, but is also used for some nominal arguments and should not be skipped if it immediately follows the Adj (eg. John was afraid of Mary)',
+	})],
+	['subgroup_with_of', () => ({
+		'by_relative_context': {
+			'followedby': [
+				{ 'token': 'of' },
+				{ 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' },
+			],
+			'argument_context_index': 1,
+		},
+		'context_transform': { 'function': { 'relation': 'subgroup' } },
+		'tag_role': false,
+	})],
+	['unit_with_measure', preset_value => ({
+		'by_relative_context': {
+			'precededby': { 'category': 'Noun' },
+		},
+		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
+		// 'context_transform': { 'function': { 'syntax': '', 'relation': '' } },	// make the adposition a function word and clear other tag values
+		'missing_message': `{sense} must be in the format 'N X {stem}' where N is a number/quantity and X is a unit of ${preset_value}.`,
+	})],
+	['by_relative_context', preset_value => ({
+		'trigger': 'all',
+		'context': preset_value,
+		'argument_context_index': preset_value['argument_context_index'] ?? 0,
+	})],
+]
+
+/**
+ * These rules allow each adjective sense to specify rules for each argument that is different from the default.
+ * Only senses that differ from the default structure need to be included here.
+ * 
+ * @type {Map<WordStem, [WordSense, any][]>}
+ */
+const adjective_case_frames = new Map([
+	['afraid', [
+		['afraid-B', { 'nominal_argument': { 'by_adposition': 'of' } }],
+	]],
+	['all', [
+		['all-A', {
+			'modified_noun': [
+				{ 'modified_noun_of_adjective': { } },
+				{ 'subgroup_with_of': { } },
+			],
+			'comment': "'all X' and 'all of X' are both supported",
+		}],
+		['all-B', {
+			'modified_noun': [
+				{ 'modified_noun_of_adjective': { } },
+				{ 'subgroup_with_of': { } },
+			],
+			'comment': "'all X' and 'all of X' are both supported",
+		}],
+	]],
+	['amazed', [
+		['amazed-B', { 'nominal_argument': { 'by_adposition': 'of|by' } }],
+	]],
+	['angry', [
+		['angry-B', { 'nominal_argument': { 'by_adposition': 'at|with' } }],
+	]],
+	['ashamed', [
+		['ashamed-B', { 'nominal_argument': { 'by_adposition': 'of|by' } }],
+	]],
+	['attracted', [
+		['attracted-A', { 'nominal_argument': { 'by_adposition': 'to' } }],
+	]],
+	['close', [
+		['close-B', { 'nominal_argument': { 'by_adposition': 'to' } }],
+	]],
+	['content', [
+		['content-A', { 'nominal_argument': { 'by_adposition': 'with' } }],
+	]],
+	['cruel', [
+		['cruel-B', { 'nominal_argument': { 'by_adposition': 'to' } }],
+	]],
+	['deep', [
+		['deep-A', { 'nominal_argument': { 'unit_with_measure': 'length' } }],
+	]],
+	['different', [
+		['different-B', { 'nominal_argument': { 'by_adposition': 'from' } }],
+	]],
+	['faithful', [
+		['faithful-B', { 'nominal_argument': { 'by_adposition': 'to' } }],
+		['faithful-C', { 'nominal_argument': { 'by_adposition': 'with' } }],
+	]],
+	['far', [
+		['far-A', { 'nominal_argument': { 'by_adposition': 'from' } }],
+	]],
+	['gentle', [
+		['gentle-B', { 'nominal_argument': { 'by_adposition': 'with|to' } }],
+	]],
+	['happy', [
+		['happy-A', { 'nominal_argument': { 'by_adposition': 'with' } }],
+	]],
+	['honest', [
+		['honest-A', { 'nominal_argument': { 'by_adposition': 'with' } }],
+	]],
+	['important', [
+		['important-A', { 'nominal_argument': { 'by_adposition': 'to' } }],
+	]],
+	['jealous', [
+		['jealous-A', { 'nominal_argument': { 'by_adposition': 'of|by' } }],
+	]],
+	['kind', [
+		['kind-B', { 'nominal_argument': { 'by_adposition': 'with|to' } }],
+	]],
+	['long', [
+		['long-C', { 'nominal_argument': { 'unit_with_measure': 'length' } }],
+	]],
+	['merciful', [
+		['merciful-B', { 'nominal_argument': { 'by_adposition': 'to' } }],
+	]],
+	['old', [
+		['old-B', { 'nominal_argument': { 'unit_with_measure': 'time' } }],
+	]],
+	['patient', [
+		['patient-B', { 'nominal_argument': { 'by_adposition': 'with' } }],
+	]],
+	['pleased', [
+		['pleased-A', { 'nominal_argument': { 'by_adposition': 'with' } }],
+	]],
+	['proud', [
+		['proud-B', { 'nominal_argument': { 'by_adposition': 'of' } }],
+	]],
+	['responsible', [
+		['responsible-A', { 'nominal_argument': { 'by_adposition': 'for' } }],
+	]],
+	['sad', [
+		['sad-A', { 'nominal_argument': { 'by_adposition': 'about' } }],
+		['sad-B', { 'nominal_argument': { 'by_adposition': 'for' } }],
+	]],
+	['tall', [
+		['tall-A', { 'nominal_argument': { 'unit_with_measure': 'length' } }],
+	]],
+	['upset', [
+		['upset-B', { 'nominal_argument': { 'by_adposition': 'with' } }],
+		['upset-C', { 'nominal_argument': { 'by_adposition': 'about' } }],
+	]],
+	['wide', [
+		['wide-C', { 'nominal_argument': { 'unit_with_measure': 'length' } }],
+	]],
+])
+
+/**
+ * @returns {ArgumentRoleRule[]}
+ */
+function create_default_argument_rules() {
+	return Object.entries(default_adjective_case_frame_json)
+		.flatMap(rule_json => parse_case_frame_rule(rule_json, ROLE_RULE_PRESETS))
+}
+
+/**
+ * @returns {Map<WordStem, ArgumentRulesForSense[]>}
+ */
+function create_adjective_argument_rules() {
+	return new Map([...adjective_case_frames.entries()].map(create_rules_for_stem))
+
+	/**
+	 * 
+	 * @param {[WordStem, [WordSense, any][]]} stem_rules 
+	 * @returns {[WordStem, ArgumentRulesForSense[]]}
+	 */
+	function create_rules_for_stem([stem, sense_rules_json]) {
+		const presets = { role_presets: ROLE_RULE_PRESETS }
+		return [stem, parse_sense_rules(sense_rules_json, DEFAULT_CASE_FRAME_RULES, presets)]
+	}
+}
+
+const DEFAULT_CASE_FRAME_RULES = create_default_argument_rules()
+const ADJECTIVE_CASE_FRAME_RULES = create_adjective_argument_rules()
+
+/**
+ * 
+ * @param {RuleTriggerContext} trigger_context
+ */
+export function check_adjective_case_frames(trigger_context) {
+	const adjective_token = trigger_context.trigger_token
+
+	const stem = adjective_token.lookup_results[0].stem
+	const argument_rules_by_sense = ADJECTIVE_CASE_FRAME_RULES.get(stem) ?? []
+
+	check_case_frames(trigger_context, {
+		rules_by_sense: argument_rules_by_sense,
+		default_rules: DEFAULT_CASE_FRAME_RULES,
+		role_info_getter: get_adjective_usage_info,
+	})
+}
+
+const ADJECTIVE_LETTER_TO_ROLE = new Map([
+	['A', 'modified_noun'],
+	['B', 'modified_noun'],	// 'A' and 'B' are usually compatible - 'A' is attributive (the happy dog) and 'B' is a simple predicate (the dog is happy)
+	['C', 'nominal_argument'],
+	['D', 'patient_clause_same_participant'],
+	['E', 'patient_clause_different_participant'],
+])
+
+/**
+ * 
+ * @param {string} categorization 
+ * @param {ArgumentRulesForSense} role_rules
+ * @returns {RoleUsageInfo}
+ */
+function get_adjective_usage_info(categorization, role_rules) {
+	// some categorizations are blank - treat all arguments as possible and not required
+	if (categorization.length === 0) {
+		return {
+			possible_roles: [...ADJECTIVE_LETTER_TO_ROLE.values()],
+			required_roles: [],
+		}
+	}
+
+	// The first character of the categorization is the category (Generic, Quantity, Cardinal Number, etc) and not used for usage
+	const role_letters = [...categorization.slice(1)].filter(c => c !== '_')
+
+	/** @type {string[]} */
+	// @ts-ignore
+	const possible_roles = role_letters
+		.map(c => ADJECTIVE_LETTER_TO_ROLE.get(c.toUpperCase()))
+		.concat([...role_rules.other_optional, ...role_rules.other_required])
+		.filter(role => role)
+
+	/** @type {string[]} */
+	// @ts-ignore
+	const required_roles = role_letters
+		.map(c => ADJECTIVE_LETTER_TO_ROLE.get(c))
+		.concat(role_rules.other_required)
+		.filter(role => role && role !== 'modified_noun')
+		// a modified noun should never be required, as usually it's possible for it to also be used predicatively
+
+	return { possible_roles, required_roles }
+}

--- a/app/src/lib/rules/case_frame/adjectives.js
+++ b/app/src/lib/rules/case_frame/adjectives.js
@@ -61,7 +61,6 @@ const ROLE_RULE_PRESETS = [
 			'precededby': { 'category': 'Noun' },
 		},
 		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
-		// 'context_transform': { 'function': { 'syntax': '', 'relation': '' } },	// make the adposition a function word and clear other tag values
 		'missing_message': `{sense} must be in the format 'N X {stem}' where N is a number/quantity and X is a unit of ${preset_value}.`,
 	})],
 	['by_relative_context', preset_value => ({

--- a/app/src/lib/rules/case_frame/common.js
+++ b/app/src/lib/rules/case_frame/common.js
@@ -118,8 +118,7 @@ export function parse_sense_rules(rule_json, defaults, { sense_presets=null, rol
 
 			const role_rules = defaults.flatMap(rule => rule.role_tag in rules_json
 				? parse_case_frame_rule([rule.role_tag, rules_json[rule.role_tag]], role_presets)
-				: [rule]
-			)
+				: [rule])
 
 			const other_rules = 'other_rules' in rules_json
 				? Object.entries(rules_json['other_rules']).flatMap(rule => parse_case_frame_rule(rule, role_presets))

--- a/app/src/lib/rules/case_frame/index.js
+++ b/app/src/lib/rules/case_frame/index.js
@@ -1,7 +1,7 @@
 import { validate_case_frame } from './common'
-import { CASE_FRAME_RULES } from './rules'
+import { ARGUMENT_AND_SENSE_RULES } from './rules'
 
 export {
-	CASE_FRAME_RULES,
+	ARGUMENT_AND_SENSE_RULES,
 	validate_case_frame,
 }

--- a/app/src/lib/rules/case_frame/rules.js
+++ b/app/src/lib/rules/case_frame/rules.js
@@ -1,9 +1,30 @@
+import { TOKEN_TYPE, is_one_part_of_speech } from '$lib/parser/token'
 import { create_context_filter, create_token_filter, simple_rule_action } from '../rules_parser'
+import { select_sense } from './sense_selection'
+import { check_adjective_case_frames } from './adjectives'
 import { check_verb_case_frames, check_verb_case_frames_passive } from './verbs'
 
 
 /** @type {BuiltInRule[]} */
-const case_frame_rules = [
+const argument_and_sense_rules = [
+	{
+		name: 'Adjective case frames',
+		comment: '',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Adjective' }),
+			context: create_context_filter({}),
+			action: simple_rule_action(check_adjective_case_frames),
+		},
+	},
+	{
+		name: 'Adjective sense selection',
+		comment: 'Need to select the sense so that it transforms the adjective arguments before checking the Verb case frames',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Adjective' }),
+			context: create_context_filter({}),
+			action: simple_rule_action(select_sense),
+		},
+	},
 	{
 		name: 'Verb case frame, active',
 		comment: 'For now, only trigger when not within a relative clause, question, or same-subject clause since arguments get moved around or are missing',
@@ -29,6 +50,17 @@ const case_frame_rules = [
 			action: simple_rule_action(check_verb_case_frames_passive),
 		},
 	},
+	{
+		name: 'Other word sense selection',
+		comment: 'Adjective senses have already been selected',
+		rule: {
+			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD
+					&& is_one_part_of_speech(token)
+					&& !create_token_filter({ 'category': 'Adjective' })(token),
+			context: create_context_filter({}),
+			action: simple_rule_action(select_sense),
+		},
+	},
 ]
 
-export const CASE_FRAME_RULES = case_frame_rules.map(({ rule }) => rule)
+export const ARGUMENT_AND_SENSE_RULES = argument_and_sense_rules.map(({ rule }) => rule)

--- a/app/src/lib/rules/case_frame/sense_selection.js
+++ b/app/src/lib/rules/case_frame/sense_selection.js
@@ -1,5 +1,7 @@
-import { TOKEN_TYPE, find_result_index, set_message, set_token_concept } from '$lib/parser/token'
-import { create_context_filter, simple_rule_action, create_token_filter } from './rules_parser'
+import { add_tag_to_token, find_result_index, set_message, set_token_concept } from '$lib/parser/token'
+import { create_context_filter, create_token_filter } from '../rules_parser'
+
+/** @typedef {[string, any]} SenseRules */
 
 /**
  * These rules help decide which sense to select from the ones that match the argument structure.
@@ -8,7 +10,6 @@ import { create_context_filter, simple_rule_action, create_token_filter } from '
  * A sense can also have multiple rows in case there are multiple incompatible filters to check.
  * TODO store these in the db
  * 
- * @typedef {[string, any]} SenseRules
  * @type {[WordStem, SenseRules[]][]}
  */
 const verb_sense_rules = [
@@ -130,10 +131,50 @@ const verb_sense_rules = [
 ]
 
 /**
+ * These rules help decide which sense to select from the ones that match the argument structure.
+ * They are ordered by priority, and can provide additional filtering of the verb or arguments to
+ * narrow down the match.
+ * A sense can also have multiple rows in case there are multiple incompatible filters to check.
+ * Many adjective sense B's have a nominal argument where sense A does not, so if sense B has a
+ * valid argument, it needs to be entered here in order to prioritize it over sense A.
+ * 
+ * @type {[WordStem, SenseRules[]][]}
+ */
+const adjective_sense_rules = [
+	['afraid', [['afraid-B', { }]]],
+	['amazed', [['amazed-B', { }]]],
+	['angry', [['angry-B', { }]]],
+	['ashamed', [['ashamed-B', { }]]],
+	['close', [['close-B', { }]]],
+	['cruel', [['cruel-B', { }]]],
+	['faithful', [
+		['faithful-B', { }],
+		['faithful-C', { 'nominal_argument': { } }],
+	]],
+	['gentle', [['gentle-B', { }]]],
+	['kind', [['kind-B', { }]]],
+	['long', [
+		['long-C', { }],
+		['long-B', { 'nominal_argument': { 'stem': 'time' } }],
+	]],
+	['merciful', [['merciful-B', { }]]],
+	['old', [['old-B', { }]]],
+	['patient', [['patient-B', { }]]],
+	['sad', [
+		['sad-B', { 'nominal_argument': { } }],
+	]],
+	['upset', [
+		['upset-B', { }],
+		['upset-C', { }],
+	]],
+	['wide', [['wide-B', { }]]],
+]
+
+/**
  * @param {SenseRules} sense_rules 
  * @returns {[WordSense, ArgumentMatchFilter]}
  */
-function parse_verb_sense_rule([sense, sense_rule_json]) {
+function parse_sense_rule([sense, sense_rule_json]) {
 	const role_filters = Object.entries(sense_rule_json).map(parse_sense_rule)
 	return [sense, role_match => role_filters.every(filter => filter(role_match))]
 
@@ -159,33 +200,26 @@ function parse_verb_sense_rule([sense, sense_rule_json]) {
 }
 
 /** @type {Map<WordStem, [WordSense, ArgumentMatchFilter][]>} */
-const VERB_SENSE_FILTER_RULES = new Map(verb_sense_rules.map(([stem, sense_rules]) => [stem, sense_rules.map(parse_verb_sense_rule)]))
+const VERB_SENSE_FILTER_RULES = new Map(verb_sense_rules.map(([stem, sense_rules]) => [stem, sense_rules.map(parse_sense_rule)]))
+const ADJECTIVE_SENSE_FILTER_RULES = new Map(adjective_sense_rules.map(([stem, sense_rules]) => [stem, sense_rules.map(parse_sense_rule)]))
 
 const SENSE_FILTER_RULES = new Map([
 	['Verb', VERB_SENSE_FILTER_RULES],
+	['Adjective', ADJECTIVE_SENSE_FILTER_RULES],
 ])
 
-/** @type {BuiltInRule[]} */
-const sense_rules = [
-	{
-		name: 'Word sense selection',
-		comment: '',
-		rule: {
-			trigger: create_token_filter({ 'type': TOKEN_TYPE.LOOKUP_WORD }),
-			context: create_context_filter({ }),
-			action: simple_rule_action(trigger_context => {
-				const token = trigger_context.trigger_token
-				select_word_sense(token, trigger_context)
+/**
+ * 
+ * @param {RuleTriggerContext} trigger_context 
+ */
+export function select_sense(trigger_context) {
+	const token = trigger_context.trigger_token
+	select_word_sense(token, trigger_context)
 
-				if (token.complex_pairing) {
-					select_word_sense(token.complex_pairing, trigger_context)
-				}
-			}),
-		},
-	},
-]
-
-export const SENSE_RULES = sense_rules.map(({ rule }) => rule)
+	if (token.complex_pairing) {
+		select_word_sense(token.complex_pairing, trigger_context)
+	}
+}
 
 /**
  * 
@@ -238,7 +272,7 @@ function select_word_sense(token, trigger_context) {
 	// Use the matching valid sense, or else the first valid sense, or else sense A.
 	// The lookups should already be ordered alphabetically so the first valid sense is the lowest letter
 	const default_matching_sense = find_matching_sense(token)
-		|| `${stem}-${valid_lookups.at(0)?.concept?.sense ?? 'A'}`
+		|| `${stem}-${valid_lookups.at(0)?.concept?.sense || 'A'}`
 
 	const specified_sense = token.specified_sense ? `${stem}-${token.specified_sense}` : ''
 
@@ -250,8 +284,13 @@ function select_word_sense(token, trigger_context) {
 	set_token_concept(token, sense_to_select)
 
 	const selected_result = token.lookup_results[0]
-	if (!selected_result.case_frame.is_valid) {
-		return
+
+	// TODO find a better way?
+	// An adjective being used predicatively should be tagged as such so the verb case frame rules can check it
+	if (selected_result.part_of_speech === 'Adjective') {
+		if (!selected_result.case_frame.valid_arguments.map(arg => arg.role_tag).includes('modified_noun')) {
+			add_tag_to_token(token, { 'syntax': 'predicate_adjective' })
+		}
 	}
 
 	// apply the selected result's argument actions

--- a/app/src/lib/rules/case_frame/sense_selection.js
+++ b/app/src/lib/rules/case_frame/sense_selection.js
@@ -283,18 +283,8 @@ function select_word_sense(token, trigger_context) {
 	const sense_to_select = specified_sense ? specified_sense : default_matching_sense
 	set_token_concept(token, sense_to_select)
 
-	const selected_result = token.lookup_results[0]
-
-	// TODO find a better way?
-	// An adjective being used predicatively should be tagged as such so the verb case frame rules can check it
-	if (selected_result.part_of_speech === 'Adjective') {
-		if (!selected_result.case_frame.valid_arguments.map(arg => arg.role_tag).includes('modified_noun')) {
-			add_tag_to_token(token, { 'syntax': 'predicate_adjective' })
-		}
-	}
-
 	// apply the selected result's argument actions
-	for (const valid_argument of selected_result.case_frame.valid_arguments) {
+	for (const valid_argument of token.lookup_results[0].case_frame.valid_arguments) {
 		valid_argument.rule.trigger_rule.action(valid_argument.trigger_context)
 	}
 }

--- a/app/src/lib/rules/case_frame/sense_selection.js
+++ b/app/src/lib/rules/case_frame/sense_selection.js
@@ -1,4 +1,4 @@
-import { add_tag_to_token, find_result_index, set_message, set_token_concept } from '$lib/parser/token'
+import { find_result_index, set_message, set_token_concept } from '$lib/parser/token'
 import { create_context_filter, create_token_filter } from '../rules_parser'
 
 /** @typedef {[string, any]} SenseRules */
@@ -149,6 +149,7 @@ const adjective_sense_rules = [
 	['cruel', [['cruel-B', { }]]],
 	['faithful', [
 		['faithful-B', { }],
+		// When faithful-C has a nominal argument, it should be prioritized over -A
 		['faithful-C', { 'nominal_argument': { } }],
 	]],
 	['gentle', [['gentle-B', { }]]],
@@ -161,6 +162,7 @@ const adjective_sense_rules = [
 	['old', [['old-B', { }]]],
 	['patient', [['patient-B', { }]]],
 	['sad', [
+		// Only when sad-B has a nominal argument should it be prioritized over sad-A
 		['sad-B', { 'nominal_argument': { } }],
 	]],
 	['upset', [
@@ -272,7 +274,7 @@ function select_word_sense(token, trigger_context) {
 	// Use the matching valid sense, or else the first valid sense, or else sense A.
 	// The lookups should already be ordered alphabetically so the first valid sense is the lowest letter
 	const default_matching_sense = find_matching_sense(token)
-		|| `${stem}-${valid_lookups.at(0)?.concept?.sense || 'A'}`
+		|| `${stem}-${valid_lookups.at(0)?.concept?.sense ?? 'A'}`
 
 	const specified_sense = token.specified_sense ? `${stem}-${token.specified_sense}` : ''
 

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -265,7 +265,7 @@ const verb_case_frames = new Map([
 		}],
 		['be-S', {
 			'predicate_adjective': {
-				'trigger': { 'stem': 'old', },
+				'trigger': { 'stem': 'old' },
 				'context': { 'precededby': [{ 'category': 'Adjective' }, { 'stem': 'year|month|day' }] },
 				'missing_message': 'be-S requires the format \'be X years//months//etc old(-B)\'.',
 			},

--- a/app/src/lib/rules/checker_rules.js
+++ b/app/src/lib/rules/checker_rules.js
@@ -1,5 +1,5 @@
 import { ERRORS } from '$lib/parser/error_messages'
-import { TOKEN_TYPE, create_added_token, format_token_message, get_message_type, set_message_plain } from '$lib/parser/token'
+import { TOKEN_TYPE, create_added_token, format_token_message, get_message_type, is_one_part_of_speech, set_message_plain } from '$lib/parser/token'
 import { REGEXES } from '$lib/regexes'
 import { validate_case_frame } from './case_frame'
 import { create_context_filter, create_token_filter, message_set_action } from './rules_parser'
@@ -655,13 +655,9 @@ const builtin_checker_rules = [
 		name: 'Check for words with ambiguous parts of speech',
 		comment: '',
 		rule: {
-			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD,
+			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && !is_one_part_of_speech(token),
 			context: create_context_filter({}),
-			action: message_set_action(function* ({ trigger_token: token }) {
-				if (token.lookup_results.every(result => result.part_of_speech.toLowerCase() === token.lookup_results[0].part_of_speech.toLowerCase())) {
-					return {}
-				}
-				
+			action: message_set_action(function* () {
 				yield { warning: 'The editor cannot determine which part of speech this word is, so some errors and warnings within the same clause may not be accurate.' }
 				yield { suggest: "Add '_noun', '_verb', '_adj', '_adv', or '_adp' after '{token}' if you want the editor to check the syntax more accurately." }
 			}),
@@ -671,7 +667,7 @@ const builtin_checker_rules = [
 		name: 'Check argument structure/case frame',
 		comment: 'case frame rules can eventually be used for verbs, adjectives, adverbs, adpositions, and even conjunctions',
 		rule: {
-			trigger: create_token_filter({ 'category': 'Verb' }),
+			trigger: create_token_filter({ 'type': TOKEN_TYPE.LOOKUP_WORD }),
 			context: create_context_filter({ }),
 			action: message_set_action(validate_case_frame),
 		},

--- a/app/src/lib/rules/index.js
+++ b/app/src/lib/rules/index.js
@@ -5,8 +5,7 @@ import { PART_OF_SPEECH_RULES } from './part_of_speech_rules'
 import { rules_applier } from './rules_processor'
 import { TRANSFORM_RULES } from './transform_rules'
 import { PRONOUN_RULES } from './pronoun_rules'
-import { CASE_FRAME_RULES } from './case_frame'
-import { SENSE_RULES } from './sense_selection_rules'
+import { ARGUMENT_AND_SENSE_RULES } from './case_frame'
 
 const RULES = {
 	PRONOUN: PRONOUN_RULES,
@@ -14,8 +13,7 @@ const RULES = {
 	SYNTAX: SYNTAX_RULES,
 	PART_OF_SPEECH: PART_OF_SPEECH_RULES,
 	TRANSFORM: TRANSFORM_RULES,
-	CASE_FRAME: CASE_FRAME_RULES,
-	SENSE: SENSE_RULES,	// TODO maybe these can be lumped in with the case-frame rules?
+	ARGUMENT_AND_SENSE: ARGUMENT_AND_SENSE_RULES,
 	CHECKER: CHECKER_RULES,
 }
 

--- a/app/src/lib/rules/part_of_speech_rules.js
+++ b/app/src/lib/rules/part_of_speech_rules.js
@@ -423,7 +423,7 @@ const builtin_part_of_speech_rules = [
  */
 export function parse_part_of_speech_rule(rule_json) {
 	const category = category_filter(rule_json['category'])
-	const trigger = create_token_filter(rule_json['trigger']) 
+	const trigger = create_token_filter(rule_json['trigger'] ?? 'all') 
 	const context = create_context_filter(rule_json['context'])
 	const action = create_remove_action(rule_json['remove'])
 

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -6,7 +6,10 @@ import { TOKEN_TYPE, set_message, set_token_concept, token_has_tag } from '$lib/
  * @returns {TokenFilter}
  */
 export function create_token_filter(filter_json) {
-	if (filter_json === undefined || filter_json === 'all') {
+	if (filter_json === undefined || filter_json === 'none') {
+		return () => false
+	}
+	if (filter_json === 'all') {
 		return () => true
 	}
 

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -392,7 +392,6 @@ const transform_rules_json = [
 		},
 		'transform': { 'tag': { 'role': 'addressee' } },
 	},
-
 	{
 		'name': 'tag adjectives around verse references',
 		'trigger': { 'token': ':', 'stem': '-ReferenceMarker' },
@@ -400,8 +399,7 @@ const transform_rules_json = [
 			'precededby': { 'category': 'Adjective' },
 			'followedby': { 'category': 'Adjective' },
 		},
-		'context_transform': [{ 'tag': { 'syntax': '' } }, { 'tag': { 'syntax': '' } }],
-		'comment': 'remove the "predicate_adjective" tag from verse reference numbers',
+		'context_transform': [{ 'tag': { 'role': 'verse_ref' } }, { 'tag': { 'role': 'verse_ref' } }],
 	},
 ]
 

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -128,7 +128,7 @@ const transform_rules_json = [
 		'context': { 
 			'subtokens': { 'token': 'to', 'tag': { 'syntax': 'infinitive_same_subject' }, 'skip': 'all' },
 		},
-		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant' } },
+		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'none' } },
 		'comment': 'eg John wanted [to sing]',
 	},
 	{
@@ -141,7 +141,7 @@ const transform_rules_json = [
 				'skip': [{ 'token': '[' }, { 'category': 'Conjunction' }],
 			},
 		},
-		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant' } },
+		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'none' } },
 		'comment': 'eg John likes [singing]',
 	},
 	{
@@ -155,13 +155,13 @@ const transform_rules_json = [
 				'skip': 'all',
 			},
 		},
-		'transform': { 'tag': { 'clause_type': 'patient_clause_simultaneous|patient_clause_different_participant' } },
+		'transform': { 'tag': { 'clause_type': 'patient_clause_simultaneous|patient_clause_different_participant', 'role': 'none' } },
 		'comment': 'eg. "John saw [Mary walking]." This rule should apply before setting "be" as an auxilliary, but after setting the aspect verbs as auxilliaries',
 	},
 	{
 		'name': 'any remaining subordinate_clause is a \'different_participant\' patient clause by default',
 		'trigger': { 'tag': { 'clause_type': 'subordinate_clause' } },
-		'transform': { 'tag': { 'clause_type': 'patient_clause_different_participant' } },
+		'transform': { 'tag': { 'clause_type': 'patient_clause_different_participant', 'role': 'none' } },
 	},
 	{
 		'name': 'tag \'that\' at the beginning of a main clause as remove_demonstrative when followed by a noun',
@@ -262,13 +262,13 @@ const transform_rules_json = [
 		'comment': 'We have to keep this as a transform rule so we can handle the "there" properly.',
 	},
 	{
-		'name': '\'part\' after \'be\' becomes a function word',
-		'trigger': { 'token': 'part' },
+		'name': "'part/like' after 'be' becomes a function word",
+		'trigger': { 'token': 'part|like' },
 		'context': {
 			'precededby': { 'stem': 'be', 'skip': 'vp_modifiers' },
 		},
 		'transform': { 'function': {} },
-		'comment': 'Since \'part\' is also a noun, this ensures the right head noun is found for be-R',
+		'comment': "Since 'part' and 'like' are also existing words, this ensures the correct verb and arguments are identified",
 	},
 	{
 		'name': '\'made of\' after \'be\' becomes a function word',
@@ -357,38 +357,8 @@ const transform_rules_json = [
 				],
 			},
 		},
-		'transform': { 'tag': { 'syntax': 'head_np' } },
+		'transform': { 'tag': { 'syntax': 'head_np', 'role': 'none' } },
 		'comment': "can't use 'np_modifiers' in the 'notfollowedby' skip since we don't want to skip the genitive_norman 'of'",
-	},
-	{
-		// TODO handle this in adjective case frame rules
-		'name': 'handle certain adjectives with a patient NP with "to"',
-		'trigger': { 'stem': 'faithful|attracted|cruel|kind' },
-		'context': {
-			'followedby': [{ 'token': 'to' }, { 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' }],
-		},
-		'context_transform': [{ 'function': '' }, { 'tag': { 'role': 'adjective_patient', 'syntax': 'nested_np' } }],
-		'comment': "eg 'faithful to X', 'attracted to X'. X should not be interpreted as a destination argument of a Verb",
-	},
-	{
-		// TODO handle this in adjective case frame rules
-		'name': 'handle certain adjectives with a patient NP with "from"',
-		'trigger': { 'stem': 'different|far' },
-		'context': {
-			'followedby': [{ 'token': 'from' }, { 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' }],
-		},
-		'context_transform': [{ 'function': '' }, { 'tag': { 'role': 'adjective_patient', 'syntax': 'nested_np' } }],
-		'comment': "eg 'different from X'. X should not be interpreted as a source argument of a Verb",
-	},
-	{
-		// TODO handle this in adjective case frame rules
-		'name': 'handle unit arguments for measurement adjectives',
-		'trigger': { 'stem': 'long|wide|tall|deep' },
-		'context': {
-			'precededby': { 'category': 'Noun' },
-		},
-		'context_transform': { 'tag': { 'role': 'adjective_patient', 'syntax': 'nested_np' } },
-		'comment': "eg '20 meters tall'. A unit like this should not be interpreted as an argument of a Verb",
 	},
 	{
 		'name': 'handle noun argument for relationship with X',
@@ -418,16 +388,6 @@ const transform_rules_json = [
 			],
 		},
 		'transform': { 'tag': { 'role': 'addressee' } },
-	},
-	{
-		// TODO handle this in adjective case frame rules
-		'name': 'tag predicate adjectives',
-		'trigger': { 'category': 'Adjective' },
-		'context': {
-			'precededby': { 'category': 'Verb', 'skip': 'all' },
-			'notfollowedby': { 'category': 'Noun', 'skip': ['np_modifiers', 'adjp_modifiers_predicative'] },
-		},
-		'transform': { 'tag': { 'syntax': 'predicate_adjective' } },
 	},
 ]
 


### PR DESCRIPTION
# Afraid

## Predicative with no argument
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/2d65ba2e-7f19-4cce-80a4-31985d2bc601)

## Predicative with nominal argument
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/c4af4c31-f283-44a3-a447-197778bc135d)

## Missing nominal argument
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/3eba1d3b-f172-4335-b657-36c7113a8599)

## Predicative with same-participant clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/5a6095b7-9147-4801-801c-067611a38086)

## Predicative with different-participant clause
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/6f73b118-0b02-4a52-9b4e-67b4e286bef6)

## Wrong clause argument
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/13bf0d29-939f-490f-8264-36d73b685219)

# Sad
sad-A can be used attributively, predicatively, and predicatively with an argument.

## Attributive
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/fab2ccbb-8cf0-4791-88a2-a9fba1a2734c)

## Predicative
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/2403bc66-ed5f-4b96-9533-b88cb4f247ca)

## Predicative with argument (sad-A)
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/cf01373c-c757-44f5-a0cc-9d718342b6dc)

## Predicative with argument (sad-B)
because sad-B found a nominal argument, but not sad-A, it takes priority
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/72253fee-b835-495d-a0ff-a62438b75544)

# Long

## Attributive
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/a4b648f9-54da-4cfa-8e73-e83a6252f609)

## Predicative as measurement
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/f363e1a9-8215-40dd-ad90-e626fc7253a0)

# Patient
Patient has so far not been used attributively, so it's usage does not include it. But because it has been used predicatively without an argument, it may be valid to use attributively.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/4168384d-013d-4f84-888f-0aac2a009c50)

# Narrow
Narrow has so far not been used predicatively, so it's usage does not include it. But because it has been used attributively, it may be valid to use predicatively.
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/e9758337-29e2-45b2-9162-14574430c492)