### PR TITLE
Add more verb case frames

### DIFF
--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -208,7 +208,11 @@ type SimpleHowToResult = {
 type SimpleCaseFrameResult = {
 	is_valid: boolean
 	is_checked: boolean
-	valid_arguments: RoleTag[]
-	extra_arguments: RoleTag[]
+	valid_arguments: SimpleRoleArgResult
+	extra_arguments: SimpleRoleArgResult
 	missing_arguments: RoleTag[]
+}
+
+type SimpleRoleArgResult = {
+	[role: RoleTag]: string
 }

--- a/app/src/lib/rules/case_frame/common.js
+++ b/app/src/lib/rules/case_frame/common.js
@@ -77,11 +77,6 @@ export function parse_case_frame_rule([role_tag, rule_json], presets=[]) {
 		}
 	}
 
-	// An empty object means no rule applies. Since a valid rule always needs a trigger, this test works
-	if (!('trigger' in rule_json)) {
-		return []
-	}
-
 	const tag_role = rule_json['tag_role'] ?? true
 	const tag_transform = tag_role ? { 'tag': { 'role': role_tag } } : {}
 

--- a/app/src/lib/rules/case_frame/sense_selection.js
+++ b/app/src/lib/rules/case_frame/sense_selection.js
@@ -145,6 +145,10 @@ const verb_sense_rules = [
 	['pray', [
 		['pray-D', { }],	// prioritize pray-D over pray-A
 	]],
+	['prepare', [
+		['prepare-B', { 'patient': { 'stem': 'feast|food|meal' } }],
+		['prepare-C', { }],
+	]],
 	['return', [
 		['return-D', { 'destination': { 'stem': 'king|person' } }],
 	]],

--- a/app/src/lib/rules/case_frame/sense_selection.js
+++ b/app/src/lib/rules/case_frame/sense_selection.js
@@ -13,10 +13,21 @@ import { create_context_filter, create_token_filter } from '../rules_parser'
  * @type {[WordStem, SenseRules[]][]}
  */
 const verb_sense_rules = [
+	['answer', [
+		['answer-B', { 'patient': { 'stem': 'prayer' } }],
+		['answer-C', { 'patient': { 'stem': 'question' } }],
+	]],
+	['appear', [
+		['appear-B', { }],	// prioritize appear-B over appear-A
+	]],
 	['ask', [
 		['ask-B', { }],	// prioritize ask-B over ask-A
 		['ask-D', { }],	// prioritize ask-D over ask-A
 		['ask-F', { }],	// prioritize ask-F over ask-A
+	]],
+	['attack', [
+		['attack-B', { 'agent': { 'stem': 'goat|lion|sheep' } }],
+		['attack-C', { 'agent': { 'stem': 'child|person' } }],
 	]],
 	['be', [
 		// 'be' is very particular and so each sense is specified to make the priority clear. Not all verbs will need this.
@@ -68,6 +79,29 @@ const verb_sense_rules = [
 		['become-J', { }],	// metaphorical
 		['become-A', { }],	// predicative
 	]],
+	['believe', [
+		['believe-B', { 'patient': { 'stem': 'Christ|God|Jesus' } }],
+	]],
+	['bring', [
+		// TODO use a lexicon feature for bring-B to check for any person.
+		['bring-B', { 'patient': { 'stem': 'baby|brother|child|girl|man|person|son|woman' } }],
+		['bring-C', { 'patient': { 'stem': 'animal|cattle|chicken|cow|horse|goat' } }],
+	]],
+	['call', [
+		// prioritize call-B and call-C over call-A
+		['call-B', { }],
+		['call-C', { }],
+	]],
+	['change', [
+		['change-B', { 'patient': { } }],
+	]],
+	['cover', [
+		['cover-C', { 'agent': { 'stem': 'cloud' } }],
+	]],
+	['dream', [
+		['dream-A', { 'patient': { } }],	// when dream-A has a patient, prioritize it over dream-B
+		['dream-B', { }],
+	]],
 	['give', [
 		['give-B', { 'patient': { 'stem': 'ring|vaccine' } }],
 		// TODO add another give-B entry to use a lexicon feature to check for any person.
@@ -75,6 +109,10 @@ const verb_sense_rules = [
 	]],
 	['go', [
 		['go-B', { 'agent': { 'stem': 'border' } }],
+	]],
+	['grow', [
+		['grow-B', { 'up': {  } }],	// if 'up' is present, select grow-B
+		['grow-D', { 'patient': { 'stem': 'food|crop' } }],
 	]],
 	['have', [
 		['have-H', { 'state': { 'stem': 'eunuch|man|servant|slave' } }],
@@ -90,6 +128,9 @@ const verb_sense_rules = [
 	['know', [
 		['know-C', { 'patient': { 'stem': 'law|meaning|name|secret|thing' } }],
 	]],
+	['laugh', [
+		['laugh-B', { }],	// prioritize laugh-B over laugh-A
+	]],
 	['leave', [
 		['leave-B', { 'patient': { 'stem': 'father|king|man|Mary|Naomi|person|woman|Simon|Jesus|boy' } }],	// TODO use lexicon rules. these values were copied from the analyzer
 	]],
@@ -101,12 +142,18 @@ const verb_sense_rules = [
 		['make-C', { 'patient': { 'stem': 'command|fire|god|peace|promise|wave|covenant' } }],
 		['make-E', { 'patient': { 'stem': 'bread|food' } }],
 	]],
+	['pray', [
+		['pray-D', { }],	// prioritize pray-D over pray-A
+	]],
+	['return', [
+		['return-D', { 'destination': { 'stem': 'king|person' } }],
+	]],
 	['say', [
 		['say-D', { 'agent': { 'stem': 'law' } }],
 	]],
 	['see', [
 		['see-D', { 'patient': { 'stem': 'dream|vision' } }],
-		['see-C', { }],	// prioritize see-C over see-B gets selected
+		['see-C', { }],	// prioritize see-C over see-B
 	]],
 	['send', [
 		['send-B', { 'patient': { 'stem': 'letter|message' } }],
@@ -121,6 +168,11 @@ const verb_sense_rules = [
 		['take-D', { 'source': { 'stem': 'person|man|woman|child|son|daughter' } }], // TODO use a lexicon feature to check for any person.
 		['take-E', { 'destination': { 'stem': 'person|man|woman|child|son|daughter' } }], // TODO use a lexicon feature to check for any person.
 	]],
+	['teach', [
+		['teach-A', { 'patient': { } }],	// when teach-A has a patient, prioritize it over teach-B
+		['teach-B', { 'patient': { 'stem': 'lesson|message|thing|law'} }],
+		['teach-C', { }],
+	]],
 	['tell', [
 		// prioritize tell-C over tell-A due to the presence of the 'about'. tell-A may count as valid if there is a relative clause on its patient.
 		['tell-C', { }],
@@ -132,6 +184,9 @@ const verb_sense_rules = [
 	]],
 	['want', [
 		['want-D', { 'patient': { 'stem': 'peace|health|life' } }],
+	]],
+	['worry', [
+		['worry-B', { }],	// prioritize worry-B over worry-A
 	]],
 ]
 

--- a/app/src/lib/rules/case_frame/sense_selection.js
+++ b/app/src/lib/rules/case_frame/sense_selection.js
@@ -174,7 +174,7 @@ const verb_sense_rules = [
 	]],
 	['teach', [
 		['teach-A', { 'patient': { } }],	// when teach-A has a patient, prioritize it over teach-B
-		['teach-B', { 'patient': { 'stem': 'lesson|message|thing|law'} }],
+		['teach-B', { 'patient': { 'stem': 'lesson|message|thing|law' } }],
 		['teach-C', { }],
 	]],
 	['tell', [

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -496,7 +496,7 @@ const verb_case_frames = new Map([
 				{
 					'trigger': { 'tag': { 'syntax': 'head_np' } },
 					'context': { 'precededby': [{ 'stem': 'covenant' }, { 'token': 'with', 'skip': 'np_modifiers' }] },
-					'context_transform': [{}, { 'function': '' }],
+					'context_transform': [{}, { 'function': {} }],
 				},
 			],
 		}],
@@ -595,7 +595,7 @@ const verb_case_frames = new Map([
 				'context': {
 					'precededby': { 'token': 'about' },
 				},
-				'context_transform': { 'function': '' },
+				'context_transform': { 'function': {} },
 				'missing_message': "think-D should be written in the format 'think about [Verb-ing]'",
 			},
 			'patient_clause_different_participant': {
@@ -617,7 +617,7 @@ const verb_case_frames = new Map([
 						{ 'token': 'of', 'skip': 'np_modifiers' },
 					],
 				},
-				'context_transform': [{ 'function': {} }, { 'relation': '' }],
+				'context_transform': [{ 'function': {} }, { 'remove_tag': 'relation' }],
 			},
 		}],
 		['throw-E', { 'destination': { 'by_adposition': 'into' } }],

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -506,6 +506,14 @@ const verb_case_frames = new Map([
 		['pray-A', { 'patient': { 'by_adposition': 'about' } }],
 		['pray-C', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 	]],
+	['prepare', []],
+	['promise', [
+		['promise-A', { 'instrument': { 'by_adposition': 'with' } }],
+		['promise-B', {
+			'instrument': { 'by_adposition': 'with' },
+			'patient_clause_type': 'patient_clause_quote_begin',
+		}],
+	]],
 	['return', []],
 	['say', [
 		['say-A', { 'patient_clause_type': 'patient_clause_quote_begin' }],

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -214,7 +214,7 @@ const verb_case_frames = new Map([
 				},
 				'missing_message': 'be-E requires the format \'there be X\'.',
 			},
-			'state': { },
+			'state': { 'trigger': 'none' },
 		}],
 		['be-F', {
 			'state': {
@@ -224,7 +224,7 @@ const verb_case_frames = new Map([
 		}],
 		['be-G', {
 			'state': { 'directly_after_verb_with_adposition': 'for' },
-			'beneficiary': { },
+			'beneficiary': { 'trigger': 'none' },
 		}],
 		['be-H', {
 			'state': {
@@ -287,7 +287,7 @@ const verb_case_frames = new Map([
 		}],
 		['be-T', {
 			'state': { 'directly_after_verb_with_adposition': 'from' },
-			'source': { },
+			'source': { 'trigger': 'none' },
 		}],
 		['be-U', { 'state': { 'directly_after_verb_with_adposition': 'like' } }],
 		['be-V', { 'other_required': 'predicate_adjective' }],
@@ -582,7 +582,7 @@ const verb_case_frames = new Map([
 		['tell-D', { 'instrument': { 'by_adposition': 'with' } }],
 		['tell-E', {
 			'destination': { 'directly_after_verb': { } },
-			'patient': { },		// clear the patient so it doesn't get confused with the destination
+			'patient': { 'trigger': 'none' },		// clear the patient so it doesn't get confused with the destination
 			'patient_clause_type': 'patient_clause_quote_begin',
 		}],
 	]],

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -20,6 +20,7 @@ const default_verb_case_frame_json = {
 		'by_adposition': 'to',
 	},
 	'instrument': {
+		'trigger': 'none',
 		// TODO check feature on lexicon word like the Analyzer does. instruments have to be a thing, not a person
 		'comment': 'An instrument is not present by default ("with" could mean other things as well)',
 	},
@@ -129,8 +130,19 @@ const ROLE_RULE_PRESETS = [
  * @type {Map<WordStem, [WordSense, any][]>}
  */
 const verb_case_frames = new Map([
+	['agree', [
+		['agree-A', { 'patient': { 'directly_after_verb_with_adposition': 'with' } }],
+		['agree-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+		['agree-C', { 'patient': { 'directly_after_verb_with_adposition': 'with' } }],
+	]],
 	['allow', [
 		['allow-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['answer', [
+		['answer-A', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['appear', [
+		['appear-B', { 'patient': { 'directly_after_verb_with_adposition': 'like' } }],
 	]],
 	['ask', [
 		['ask-A', {
@@ -184,6 +196,7 @@ const verb_case_frames = new Map([
 			'comment': "This can be written as 'asked X [(if//whether) ...]' (with or without the if/whether)",
 		}],
 	]],
+	['attack', []],
 	['be', [
 		['be-D', {
 			'other_required': 'predicate_adjective',
@@ -315,8 +328,58 @@ const verb_case_frames = new Map([
 			],
 		}],
 	]],
+	['believe', [
+		['believe-B', { 'patient': { 'directly_after_verb_with_adposition': 'in',  } }],
+	]],
+	['bring', []],
+	['call', [
+		['call-A', { 'state': { 'trigger': 'none' } }],
+		['call-B', {
+			'state': {
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': { 'precededby': { 'tag': { 'syntax': 'head_np' } } },
+				'comment': 'The state is a single word that immediately follows the patient. eg. "Paul called that child(P) John(S)."',
+			},
+		}],
+		['call-C', {
+			'state': {
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': { 'precededby': { 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' } },
+				'comment': 'The state is an NP that immediately follows the patient. eg. "Jesus called the temple(P) the house(S) of God."',
+			},
+		}],
+	]],
 	['cause', []],
+	['change', [
+		['change-A', { 'patient': { 'directly_after_verb_with_adposition': 'into' } }],
+		['change-B', {
+			'patient': { 'by_adposition': 'about' },
+			'other_rules': {
+				'mind': {
+					'directly_after_verb': { 'stem': 'mind' },
+					'transform': { 'function': { 'syntax': 'extra_patient' } },
+					'missing_message': "Write 'change X's mind' for change-B",
+				},
+			},
+			'other_required': 'mind',
+			'comment': "'mind' ban be included in the phase 1 (eg. Pharoah changed Pharoah's mind) but it is not included in the semantic representation."
+		}],
+		['change-C', { 'destination': { 'by_adposition': 'to|into' } }],
+		['change-E', { 'destination': { 'by_adposition': 'to|into' } }],
+	]],
+	['choose', [
+		['choose-B', 'patient_from_subordinate_clause'],
+		['choose-C', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
 	['come', []],
+	['cover', [
+		['cover-A', { 'instrument': { 'by_adposition': 'with' } }],
+		['cover-B', { 'instrument': { 'by_adposition': 'with' } }],
+	]],
+	['die', []],
+	['dream', [
+		['dream-A', { 'patient': { 'by_adposition': 'about' } }],
+	]],
 	['give', [
 		['give-A', {
 			'patient': {
@@ -326,8 +389,21 @@ const verb_case_frames = new Map([
 		}],
 	]],
 	['go', []],
+	['grow', [
+		['grow-B', {
+			'other_rules': {
+				'up': {
+					'by_relative_context': { 'followedby': { 'token': 'up' } },
+					'context_transform': { 'function': { 'syntax': 'argument_adposition' } },
+					'tag_role': false,
+				},
+			},
+			'other_optional': 'up',
+			'comment': 'The boys grew up. OR The boys grew-B.',
+		}],
+	]],
 	['have', [
-		['know-J', { 'instrument': { 'by_adposition': 'with' } }],
+		['have-J', { 'instrument': { 'by_adposition': 'with' } }],
 	]],
 	['hear', [
 		['hear-A', { 'instrument': { 'by_adposition': 'with' } }],
@@ -343,7 +419,14 @@ const verb_case_frames = new Map([
 		['know-D', { 'patient': { 'directly_after_verb_with_adposition': 'about' } }],
 		['know-B', { 'instrument': { 'by_adposition': 'with' } }],
 	]],
+	['laugh', [
+		['laugh-B', { 'patient': { 'directly_after_verb_with_adposition': 'at' } }],
+	]],
+	['learn', [
+		['learn-C', { 'patient': { 'directly_after_verb_with_adposition': 'about' } }],
+	]],
 	['leave', []],
+	['lift', []],
 	['like', [
 		['like-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
@@ -385,6 +468,10 @@ const verb_case_frames = new Map([
 			'other_optional': 'just_like_clause',
 		}],
 	]],
+	['look', [
+		['look-A', { 'patient': { 'directly_after_verb_with_adposition': 'at' } }],
+		['look-B', { 'other_required': 'predicate_adjective' }],	// X looked happy/sad/excited
+	]],
 	['make', [
 		['make-A', {
 			'instrument': { 'by_adposition': 'with' },
@@ -415,10 +502,22 @@ const verb_case_frames = new Map([
 		}],
 		['make-E', { 'instrument': { 'by_adposition': 'with' } }],
 	]],
+	['pray', [
+		['pray-A', { 'patient': { 'by_adposition': 'about' } }],
+		['pray-C', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['return', []],
 	['say', [
 		['say-A', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 		['say-E', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 		['say-F', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['search', [
+		['search-A', {
+			'patient': { 'directly_after_verb_with_adposition': 'for' },
+			'destination': { 'by_adposition': 'in' },
+			'comment': 'eg. Genesis 44:12 The servant searched [for the cup(P)] [in the bags(d)].',
+		}],
 	]],
 	['see', [
 		['see-B', { 'other_optional': 'patient_clause_simultaneous' }],
@@ -453,6 +552,13 @@ const verb_case_frames = new Map([
 		}],
 	]],
 	['take', []],
+	['teach', [
+		['teach-A', {
+			'destination': { 'directly_after_verb': { } },
+			'patient': { 'by_adposition': 'about' },
+		}],
+		['teach-D', 'patient_from_subordinate_clause'],
+	]],
 	['tell', [
 		['tell-A', {
 			'instrument': { 'by_adposition': 'with' },
@@ -511,6 +617,12 @@ const verb_case_frames = new Map([
 	['want', [
 		['want-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
+	['work', [
+		['work-A', { 'instrument': { 'by_adposition': 'with' } }],
+	]],
+	['worry', [
+		['worry-A', { 'patient': { 'directly_after_verb_with_adposition': 'about' } }],
+	]],
 ])
 
 /**
@@ -545,6 +657,11 @@ function create_verb_argument_rules() {
  * @returns {ArgumentRoleRule[]}
  */
 function get_default_rules_for_stem(stem) {
+	if (stem === 'call') {
+		// 'call' is the only verb that can have both a patient and a state
+		return DEFAULT_CASE_FRAME_RULES
+	}
+
 	const role_to_remove = ['be', 'become', 'have'].includes(stem) ? 'patient' : 'state'
 	return DEFAULT_CASE_FRAME_RULES.filter(rule => rule.role_tag !== role_to_remove)
 }

--- a/app/src/lib/rules/case_frame/verbs.js
+++ b/app/src/lib/rules/case_frame/verbs.js
@@ -329,7 +329,7 @@ const verb_case_frames = new Map([
 		}],
 	]],
 	['believe', [
-		['believe-B', { 'patient': { 'directly_after_verb_with_adposition': 'in',  } }],
+		['believe-B', { 'patient': { 'directly_after_verb_with_adposition': 'in' } }],
 	]],
 	['bring', []],
 	['call', [
@@ -362,7 +362,7 @@ const verb_case_frames = new Map([
 				},
 			},
 			'other_required': 'mind',
-			'comment': "'mind' ban be included in the phase 1 (eg. Pharoah changed Pharoah's mind) but it is not included in the semantic representation."
+			'comment': "'mind' ban be included in the phase 1 (eg. Pharoah changed Pharoah's mind) but it is not included in the semantic representation.",
 		}],
 		['change-C', { 'destination': { 'by_adposition': 'to|into' } }],
 		['change-E', { 'destination': { 'by_adposition': 'to|into' } }],

--- a/app/src/lib/rules/lookup_rules.js
+++ b/app/src/lib/rules/lookup_rules.js
@@ -33,6 +33,12 @@ const lookup_rules_json = [
 		'combine': 1,
 	},
 	{
+		'name': 'like -> just-like (the adposition)',
+		'trigger': { 'token': 'like' },
+		'lookup': 'like|just-like',
+		'comment': 'this is needed so the adposition is found as well, which is handled by words like be/seem/sound/etc',
+	},
+	{
 		'name': 'even-if',
 		'trigger': { 'token': 'Even|even' },
 		'context': { 'followedby': { 'token': 'if' } },
@@ -90,71 +96,28 @@ const lookup_rules_json = [
 		'combine': 1,
 	},
 	{
-		'name': 'grow up',
-		'trigger': { 'stem': 'grow' },
-		'context': { 'followedby': { 'token': 'up' } },
-		'lookup': 'grow-B',
-		'combine': 1,
-	},
-	{
-		'name': 'laugh at',
-		'trigger': { 'stem': 'laugh' },
-		'context': { 'followedby': { 'token': 'at' } },
-		'lookup': 'laugh-B',		// TODO make this a case frame rule
-		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
-	},
-	{
-		'name': 'lift up',
-		'trigger': { 'stem': 'lift' },
-		'context': { 'followedby': { 'token': 'up', 'skip': 'all' } },
-		'lookup': 'lift',		// TODO make this a case frame rule
-		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
-	},
-	{
-		'name': 'look at',
-		'trigger': { 'stem': 'look' },
-		'context': { 'followedby': { 'token': 'at' } },
-		'lookup': 'look-A',		// TODO make this a case frame rule
-		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
-	},
-	{
 		'name': 'look for -> search',
 		'trigger': { 'stem': 'look' },
 		'context': { 'followedby': { 'token': 'for' } },
 		'lookup': 'search',
-		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
 	},
 	{
 		'name': 'look like -> appear-B',
 		'trigger': { 'stem': 'look' },
 		'context': { 'followedby': { 'token': 'like' } },
-		'lookup': 'appear-B',
-		'combine': 1,
-	},
-	{
-		'name': 'like -> just-like (the adposition)',
-		'trigger': { 'token': 'like' },
-		'lookup': 'like|just-like',
-		'comment': 'this is needed so the adposition is found as well, which is handled by words like be/seem/sound/etc',
-	},
-	{
-		'name': 'worry about',
-		'trigger': { 'stem': 'worry' },
-		'context': { 'followedby': { 'token': 'about' } },
-		'lookup': 'worry',		// TODO make this a case frame rule
-		'context_transform': { 'type': TOKEN_TYPE.FUNCTION_WORD },
+		'lookup': 'appear',
 	},
 	{
 		'name': 'what becomes thing-A in a question',
 		'trigger': { 'token': 'What|what' },
 		'context': { 'followedby': { 'token': '?', 'skip': 'all' } },
-		'lookup': 'thing-A',
+		'lookup': 'thing',
 	},
 	{
 		'name': 'who becomes person-A in a question',
 		'trigger': { 'token': 'Who|who' },
 		'context': { 'followedby': { 'token': '?', 'skip': 'all' } },
-		'lookup': 'person-A',
+		'lookup': 'person',
 	},
 ]
 

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -338,6 +338,11 @@ export function create_token_transform(transform_json) {
 		transforms.push(token => ({ ...token, tag: add_value_to_tag(token.tag, tag) }))
 	}
 
+	const remove_tag = transform_json['remove_tag']
+	if (remove_tag !== undefined) {
+		transforms.push(token => ({ ...token, tag: remove_tag_labels(token.tag, remove_tag) }))
+	}
+
 	const function_tag = transform_json['function']
 	if (function_tag !== undefined) {
 		// TODO keep form name value from lookup somehow
@@ -387,12 +392,20 @@ export function create_token_transform(transform_json) {
 	 * @returns {Tag}
 	 */
 	function add_value_to_tag(old_tag, new_values) {
-		const result = { ...old_tag, ...new_values }
-		// completely remove tags that are being set as empty
-		Object.entries(new_values)
-			.filter(([, v]) => v === '')
-			.forEach(([k]) => delete result[k])
-		return result
+		return { ...old_tag, ...new_values }
+	}
+
+	/**
+	 * 
+	 * @param {Tag} old_tag 
+	 * @param {string|string[]} tags_to_remove 
+	 * @returns {Tag}
+	 */
+	function remove_tag_labels(old_tag, tags_to_remove) {
+		if (!Array.isArray(tags_to_remove)) {
+			tags_to_remove = [tags_to_remove]
+		}
+		return Object.fromEntries(Object.entries(old_tag).filter(([k]) => !tags_to_remove.includes(k)))
 	}
 }
 

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -390,7 +390,7 @@ export function create_token_transform(transform_json) {
 		const result = { ...old_tag, ...new_values }
 		// completely remove tags that are being set as empty
 		Object.entries(new_values)
-			.filter(([_,v]) => v === '')
+			.filter(([, v]) => v === '')
 			.forEach(([k]) => delete result[k])
 		return result
 	}

--- a/app/src/lib/rules/rules_parser.js
+++ b/app/src/lib/rules/rules_parser.js
@@ -387,7 +387,12 @@ export function create_token_transform(transform_json) {
 	 * @returns {Tag}
 	 */
 	function add_value_to_tag(old_tag, new_values) {
-		return { ...old_tag, ...new_values }
+		const result = { ...old_tag, ...new_values }
+		// completely remove tags that are being set as empty
+		Object.entries(new_values)
+			.filter(([_,v]) => v === '')
+			.forEach(([k]) => delete result[k])
+		return result
 	}
 }
 

--- a/app/src/lib/rules/rules_parser.test.js
+++ b/app/src/lib/rules/rules_parser.test.js
@@ -534,6 +534,41 @@ describe('token transforms', () => {
 		expect(result.tag).toEqual({ 'key': 'value' })
 		expect(result.messages).toEqual(token.messages)
 	})
+	test('remove tag', () => {
+		const transform_json = { 'remove_tag': 'key1' }
+		const transform = create_token_transform(transform_json)
+
+		const tokens = [
+			create_token('token', TOKEN_TYPE.FUNCTION_WORD, { tag: { 'key1': 'value1', 'key2': 'value2' } }),
+			create_token('token', TOKEN_TYPE.FUNCTION_WORD, { tag: { 'key2': 'value2' } }),
+		]
+		const results = tokens.map(transform)
+
+		expect(results[0].tag).toEqual({ 'key2': 'value2' })
+		expect(results[1].tag).toEqual({ 'key2': 'value2' })
+	})
+	test('remove multiple tags', () => {
+		const transform_json = { 'remove_tag': ['key1', 'key2'] }
+		const transform = create_token_transform(transform_json)
+
+		const tokens = [
+			create_token('token', TOKEN_TYPE.FUNCTION_WORD, { tag: { 'key1': 'value1', 'key2': 'value2' } }),
+			create_token('token', TOKEN_TYPE.FUNCTION_WORD, { tag: { 'key2': 'value2', 'key3': 'value3' } }),
+		]
+		const results = tokens.map(transform)
+
+		expect(results[0].tag).toEqual({ })
+		expect(results[1].tag).toEqual({ 'key3': 'value3' })
+	})
+	test('add and remove tag', () => {
+		const transform_json = { 'tag': { 'key5': 'value5' }, 'remove_tag': 'key1' }
+		const transform = create_token_transform(transform_json)
+
+		const token = create_token('token', TOKEN_TYPE.FUNCTION_WORD, { tag: { 'key1': 'value1', 'key2': 'value2' } })
+		const result = transform(token)
+
+		expect(result.tag).toEqual({ 'key2': 'value2', 'key5': 'value5' })
+	})
 	test('type and tag', () => {
 		const transform_json = { 'type': TOKEN_TYPE.FUNCTION_WORD, 'tag': { 'key': 'value' } }
 		const transform = create_token_transform(transform_json)

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -77,7 +77,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'tag': { 'clause_type': 'relative_clause' } },
-		'subtoken_transform': { 'tag': { 'determiner': '' } },
+		'subtoken_transform': { 'remove_tag': 'determiner' },
 		'comment': 'removes extra tags for words like "who" and "which". clear the determiner tag but keep the syntax one. This also handles coordinate relative clauses.',
 	},
 	{
@@ -102,7 +102,7 @@ const transform_rules_json = [
 				'skip': [{ 'token': '[' }, { 'category': 'Conjunction' }],
 			},
 		},
-		'subtoken_transform': { 'tag': { 'syntax': '' } },
+		'subtoken_transform': { 'remove_tag': 'syntax' },
 		'comment': '"that" should only be a demonstrative in this case. clear the syntax tag but keep the determiner one',
 	},
 	{
@@ -131,7 +131,7 @@ const transform_rules_json = [
 		'comment': 'It is true that John read that book',
 	},
 	{
-		'name': 'tag \'that\' relative clauses that occur with \'it\' as agent clauses',
+		'name': "tag 'that' relative clauses that occur with 'it' as agent clauses",
 		'trigger': { 'tag': { 'clause_type': 'relative_clause_that' } },
 		'context': {
 			'precededby': { 'tag': { 'syntax': 'agent_proposition_subject' }, 'skip': ['np', 'vp'] },
@@ -140,7 +140,7 @@ const transform_rules_json = [
 		'comment': 'It please Mary [that John read this book]. - this was originally tagged as a relative clause but the \'it\' takes priority',
 	},
 	{
-		'name': 'tag subordinate clauses starting with the infinitive \'to\' as \'same_participant\'',
+		'name': "tag subordinate clauses starting with the infinitive 'to' as 'same_participant'",
 		'trigger': { 'tag': { 'clause_type': 'subordinate_clause' } },
 		'context': { 
 			'subtokens': { 'token': 'to', 'tag': { 'syntax': 'infinitive_same_subject' }, 'skip': 'all' },
@@ -149,7 +149,7 @@ const transform_rules_json = [
 		'comment': 'eg John wanted [to sing]',
 	},
 	{
-		'name': 'tag subordinate clauses starting with a participle Verb as \'same_participant\'',
+		'name': "tag subordinate clauses starting with a participle Verb as 'same_participant'",
 		'trigger': { 'tag': { 'clause_type': 'subordinate_clause' } },
 		'context': {
 			'subtokens': {
@@ -193,7 +193,7 @@ const transform_rules_json = [
 			'notprecededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
 			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
 		},
-		'transform': { 'tag': { 'syntax': '' } },
+		'transform': { 'remove_tag': 'syntax' },
 		'comment': 'this clears the relativizer tag but keeps the determiner tag',
 	},
 	{
@@ -265,7 +265,7 @@ const transform_rules_json = [
 		'context': {
 			'precededby': { 'stem': 'so', 'category': 'Adposition' },
 		},
-		'transform': { 'tag': { 'syntax': '', 'determiner' : '' } },
+		'transform': { 'remove_tag': ['syntax', 'determiner'] },
 		'comment': 'both "so that" and "so-that" are supported and map to the Adposition "so"',
 	},
 	{
@@ -274,7 +274,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': { 'token': '?', 'skip': 'all' },
 		},
-		'transform': { 'tag': { 'determiner': 'interrogative', 'syntax': '' } },
+		'transform': { 'tag': { 'determiner': 'interrogative' }, 'remove_tag': 'syntax' },
 		'comment': '"who/what" becomes "which person-A/thing-A" respectively when in a question',
 	},
 	{
@@ -391,8 +391,7 @@ const transform_rules_json = [
 		'name': 'remove head_np tag from saxon genitives and made_of relations',
 		'trigger': { 'tag': { 'relation': 'genitive_saxon|made_of' } },
 		'context': { },
-		'transform': { 'tag': { 'syntax': '', 'role': '' } },
-		'comment': '',
+		'transform': { 'remove_tag': ['syntax', 'role'] },
 	},
 	{
 		'name': 'handle noun argument for relationship with X',
@@ -400,7 +399,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': [{ 'token': 'with' }, { 'category': 'Noun', 'skip': 'np_modifiers' }],
 		},
-		'context_transform': [{ 'function': '' }, { 'tag': { 'syntax': 'nested_np' } }],
+		'context_transform': [{ 'function': {} }, { 'tag': { 'syntax': 'nested_np' } }],
 		'comment': "eg 'relationship with X'. X should not be interpreted as an argument of a Verb",
 	},
 	{
@@ -409,7 +408,7 @@ const transform_rules_json = [
 		'context': {
 			'followedby': [{ 'token': 'in' }, { 'category': 'Noun', 'skip': 'np_modifiers' }],
 		},
-		'context_transform': [{ 'function': '' }, { 'tag': { 'syntax': 'nested_np' } }],
+		'context_transform': [{ 'function': {} }, { 'tag': { 'syntax': 'nested_np' } }],
 		'comment': "eg 'faith in X'. X should not be interpreted as an argument of a Verb",
 	},
 	{

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -253,6 +253,13 @@ const transform_rules_json = [
 		'transform': { 'function': { 'relation': 'group' } },
 	},
 	{
+		'name': 'certain Noun-Noun combinations are "made_of"',
+		'trigger': { 'category': 'Noun', 'stem': 'bamboo|bronze|gold|iron|leather|marble|metal|plastic|silver|wood' },
+		'context': { 'followedby': { 'category': 'Noun' } },
+		'transform': { 'tag': { 'relation': 'made_of' } },
+		'comment': 'eg. a gold statue; a bamboo chair. The Nouns are always right next to each other',
+	},
+	{
 		'name': '\'that\' followed by the Adposition \'so\' does not have any function',
 		'trigger': { 'token': 'that' },
 		'context': {
@@ -271,6 +278,7 @@ const transform_rules_json = [
 		'comment': '"who/what" becomes "which person-A/thing-A" respectively when in a question',
 	},
 	{
+		// TODO replace with adposition sense-selection
 		'name': 'Adposition \'so\' followed by \'would\' becomes so-C',
 		'trigger': { 'stem': 'so', 'category': 'Adposition' },
 		'context': {
@@ -375,16 +383,16 @@ const transform_rules_json = [
 		'trigger': { 'category': 'Noun' },
 		'context': {
 			'notprecededby': [{ 'category': 'Noun' }, { 'token': 'of', 'skip': 'np_modifiers' }],
-			'notfollowedby': {
-				'category': 'Noun',
-				'skip': [
-					{ 'tag': [{ 'relation': 'genitive_saxon' }, { 'clause_type': 'relative_clause' }, 'determiner'] },
-					'adjp_attributive',
-				],
-			},
 		},
 		'transform': { 'tag': { 'syntax': 'head_np', 'role': 'none' } },
 		'comment': "can't use 'np_modifiers' in the 'notfollowedby' skip since we don't want to skip the genitive_norman 'of'",
+	},
+	{
+		'name': 'remove head_np tag from saxon genitives and made_of relations',
+		'trigger': { 'tag': { 'relation': 'genitive_saxon|made_of' } },
+		'context': { },
+		'transform': { 'tag': { 'syntax': '', 'role': '' } },
+		'comment': '',
 	},
 	{
 		'name': 'handle noun argument for relationship with X',

--- a/app/src/routes/check/+server.js
+++ b/app/src/routes/check/+server.js
@@ -99,9 +99,22 @@ function simplify_tokens(sentences) {
 		return {
 			is_valid,
 			is_checked,
-			valid_arguments: valid_arguments.map(match => match.role_tag),
-			extra_arguments: extra_arguments.map(match => match.role_tag),
+			valid_arguments: valid_arguments.reduce(simplify_argument_result, {}),
+			extra_arguments: extra_arguments.reduce(simplify_argument_result, {}),
 			missing_arguments: missing_arguments.map(rule => rule.role_tag),
+		}
+
+		/**
+		 * 
+		 * @param {SimpleRoleArgResult} result 
+		 * @param {RoleMatchResult} match 
+		 */
+		function simplify_argument_result(result, match) {
+			const { trigger_token } = match.trigger_context
+			return {
+				...result,
+				[match.role_tag]: trigger_token.lookup_results.at(0)?.stem ?? trigger_token.token,
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Verb Case Frames
Added case frame and sense selection rules for the following 25 verbs:
- agree
- answer
- appear
- attack
- believe
- bring
- call
- change
- choose
- cover
- die
- dream
- grow
- laugh
- learn
- lift
- look
- pray
- prepare
- promise
- return
- search
- teach
- work
- worry

### Lookup Rules
Removed lookup rules that are now handled via case-frame rules.

### Head-Noun identification
Changed a couple transform rules to better handle neighboring Noun Phrases. This improves identifying the right Noun for Verb arguments.

- Modifying nouns such as 'gold', 'wood', 'iron', etc which indicate a 'made-of' relation are now tagged as such. eg. John had a **bronze** necklace. Only 'necklace' is a head noun. 
- 's genitives are also still not tagged as a head noun. eg. John saw **John's** house. Only 'house' is a head noun
- Previously, for a sentence like 'John called the child Peter', only 'Peter' was tagged as a head noun, assuming 'child' was a modifier. Now both are tagged as head nouns, which means the case frame for 'call' can be checked properly.
- Previously, for a sentence like 'Daniel prayed to God many times', only 'times' was tagged as a head noun, assuming 'God' was a modifier. Now both are tagged as head nouns.

### API data structure
The data sent over the API regarding a word's case frame arguments was changed to include the token itself that is identified as that argument. This makes debugging case frames easier and I think is generally a good idea.

Before:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/8a69ef97-bd9c-46f0-b41b-41788c91cec7)

After:
![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/b4d26039-acf2-46a8-8db6-43fa9d9c2e9c)
