### PR TITLE
Fix 'chiefest' and move handling of missing inflections

### DIFF
--- a/app/src/lib/lookups/common.js
+++ b/app/src/lib/lookups/common.js
@@ -1,0 +1,18 @@
+/**
+ * @param {LookupWord} lookup1
+ * @param {LookupWord} lookup2
+ * @returns {boolean}
+ */
+export function lookups_match(lookup1, lookup2) {
+	return lookup1.stem === lookup2.stem && lookup1.part_of_speech === lookup2.part_of_speech
+}
+
+/**
+ * @param {LookupResult} lookup 
+ * @param {HowToResult} how_to_result 
+ * @returns {boolean}
+ */
+export function senses_match(lookup, how_to_result) {
+	return lookup.concept?.sense === how_to_result.sense
+		|| lookup.how_to.some(result => result.sense === how_to_result.sense)
+}

--- a/app/src/lib/lookups/form.js
+++ b/app/src/lib/lookups/form.js
@@ -1,4 +1,5 @@
 import { create_lookup_result } from '$lib/parser/token'
+import { lookups_match } from './common'
 
 /**
  * @param {import('@cloudflare/workers-types').D1Database} db
@@ -26,6 +27,7 @@ export function check_forms(db) {
 		const { results } = await db.prepare(sql).bind(`%|${term}|%`, term).all()
 
 		const lookup_results = results.map(result => transform_db_result(result, term))
+		add_missing_forms(lookup_results, term)
 
 		if (lookup_results.length === 0) {
 			return
@@ -67,6 +69,20 @@ export function check_forms(db) {
 
 		return create_lookup_result(result, { form })
 	}
+
+	/**
+	 * 
+	 * @param {LookupResult[]} results 
+	 * @param {string} term 
+	 */
+	function add_missing_forms(results, term) {
+		const missing_form = MISSING_FORMS.get(term.toLowerCase())
+
+		// Some missing forms may become not missing before the code here is updated. Avoid duplicate results in that case.
+		if (missing_form && !results.some(result => lookups_match(result, missing_form))) {
+			results.push(create_lookup_result(missing_form, missing_form))
+		}
+	}
 }
 
 const FORM_NAMES = new Map([
@@ -74,6 +90,30 @@ const FORM_NAMES = new Map([
 	['Verb', ['past', 'past participle', 'participle', 'present']],
 	['Adjective', ['comparative', 'superlative']],
 	['Adverb', ['comparative', 'superlative']],
+])
+
+/** @type {Map<string, { stem: string, part_of_speech: string, form: string }>} */
+const MISSING_FORMS = new Map([
+	// TODO add more or remove some when we include Analyzer inflections as well
+	// see https://github.com/presciencelabs/tabitha-editor/issues/37
+	['left', { stem: 'left', part_of_speech: 'Adjective', form: 'stem' }],	// important for disambiguation with 'leave'
+	['chiefer', { stem: 'chief', part_of_speech: 'Adjective', form: 'comparative' }],
+	['chiefest', { stem: 'chief', part_of_speech: 'Adjective', form: 'superlative' }],
+	['am', { stem: 'be', part_of_speech: 'Verb', form: 'present' }],
+	['are', { stem: 'be', part_of_speech: 'Verb', form: 'present' }],
+	['were', { stem: 'be', part_of_speech: 'Verb', form: 'past' }],
+	['goodbye', { stem: 'goodbye', part_of_speech: 'Verb', form: 'stem' }],
+	['goodbied', { stem: 'goodbye', part_of_speech: 'Verb', form: 'past|past participle' }],
+	['goodbying', { stem: 'goodbye', part_of_speech: 'Verb', form: 'participle' }],
+	['goodbyes', { stem: 'goodbye', part_of_speech: 'Verb', form: 'present' }],
+	['pity', { stem: 'pity', part_of_speech: 'Verb', form: 'stem' }],
+	['pitied', { stem: 'pity', part_of_speech: 'Verb', form: 'past|past participle' }],
+	['pitying', { stem: 'pity', part_of_speech: 'Verb', form: 'participle' }],
+	['pities', { stem: 'pity', part_of_speech: 'Verb', form: 'present' }],
+	['sex', { stem: 'sex', part_of_speech: 'Verb', form: 'stem' }],
+	['sexed', { stem: 'sex', part_of_speech: 'Verb', form: 'past|past participle' }],
+	['sexing', { stem: 'sex', part_of_speech: 'Verb', form: 'participle' }],
+	['sexes', { stem: 'sex', part_of_speech: 'Verb', form: 'present' }],
 ])
 
 //|was|been|being|is|am|are|were|

--- a/app/src/lib/lookups/how_to.js
+++ b/app/src/lib/lookups/how_to.js
@@ -1,5 +1,6 @@
 import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
 import { create_lookup_result, split_stem_and_sense } from '$lib/parser/token'
+import { lookups_match, senses_match } from './common'
 
 /**
  * @param {Token} lookup_token
@@ -64,25 +65,4 @@ async function get_matches_from_how_to(lookup_term) {
 	if (!response.ok) return []
 
 	return response.json()
-}
-
-/**
- * 
- * @param {LookupWord} lookup1 
- * @param {LookupWord} lookup2 
- * @returns {boolean}
- */
-function lookups_match(lookup1, lookup2) {
-	return lookup1.stem === lookup2.stem && lookup1.part_of_speech === lookup2.part_of_speech
-}
-
-/**
- * 
- * @param {LookupResult} lookup 
- * @param {HowToResult} how_to_result 
- * @returns {boolean}
- */
-function senses_match(lookup, how_to_result) {
-	return lookup.concept?.sense === how_to_result.sense
-		|| lookup.how_to.some(result => result.sense === how_to_result.sense)
 }

--- a/app/src/lib/lookups/ontology.js
+++ b/app/src/lib/lookups/ontology.js
@@ -1,5 +1,6 @@
 import { PUBLIC_ONTOLOGY_API_HOST } from '$env/static/public'
 import { create_lookup_result } from '$lib/parser/token'
+import { lookups_match } from './common'
 
 /**
  * @param {Token} lookup_token
@@ -43,14 +44,4 @@ async function get_matches_from_ontology(lookup_term) {
 	if (!response.ok) return []
 
 	return response.json()
-}
-
-/**
- *
- * @param {LookupWord} lookup1
- * @param {LookupWord} lookup2
- * @returns {boolean}
- */
-function lookups_match(lookup1, lookup2) {
-	return lookup1.stem === lookup2.stem && lookup1.part_of_speech === lookup2.part_of_speech
 }

--- a/database/inflections/to_csv.mjs
+++ b/database/inflections/to_csv.mjs
@@ -76,8 +76,6 @@ function output() {
 	Array.from(extracted_data)
 		.filter(has_inflections)
 		.filter(has_no_space)
-		.map(add_missing_inflections)
-		.concat(add_missing_words())
 		.map(log_csv)
 
 	function has_inflections([, inflections]) {
@@ -86,32 +84,6 @@ function output() {
 
 	function has_no_space([stem]) {
 		return !stem.includes(' ')
-	}
-
-	function add_missing_inflections([stem, inflections]) {
-		if (stem === 'be') {
-			// these forms are not present in TBTA's lexical data because be is so irregular...
-			// they are only produced during the rules phase so they need to be added manually here.
-			inflections.push('am', 'are', 'were')
-		}
-
-		return [stem, inflections]
-	}
-
-	function add_missing_words() {
-		// TODO add more or remove some when we include Analyzer inflections as well
-		// see https://github.com/presciencelabs/tabitha-editor/issues/37
-		const missing_words = {
-			Adjective: [
-				['left', ['','']],	// important for disambiguation with 'leave'
-			],
-			Verb: [
-				['goodbye', ['goodbied','goodbied','goodbying','goodbyes']],
-				['pity', ['pitied','pitied','pitying','pities']],
-				['sex', ['sexed','sexed','sexing','sexes']],
-			],
-		}
-		return missing_words[part_of_speech] || []
 	}
 
 	function log_csv([stem, inflections]) {


### PR DESCRIPTION
### Resolves the issue with 'chiefest'
`And Christ became-C the chiefest priest of the good things [that now exist].`
'chief' is found in the form lookup, but not 'chiefest' - this form is only used within the Analyzer. The inflection is now added for this word.

![image](https://github.com/presciencelabs/tabitha-editor/assets/152427351/133fb4c2-ab2a-4b0d-bb8c-e5567e52c758)

### Move missing inflections to runtime
Previously we added missing inflections directly into the database. In preparation for using the upcoming targets API, these missing inflections have been moved to runtime, when the form lookup is performed. These inflections won't be present in the Lexicon and thus won't be returned in the API, so we need to handle it this way anyway.