### PR TITLE
Add support for 'as Adj as...'

### DIFF
--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -239,7 +239,7 @@ const transform_rules_json = [
 		'name': '"as" in "as Adj/Adv as..." becomes a function word',
 		'trigger': { 'stem': 'as' },
 		'context': {
-			'followedby': [{ 'category': 'Adjective|Adverb' }, { 'stem': 'as }],
+			'followedby': [{ 'category': 'Adjective|Adverb' }, { 'stem': 'as' }],
 		},
 		'transform': { 'function': { 'degree': 'equality' } },
 		'context_transform': [{ }, { 'function': { 'syntax': 'comparative_as' } }],

--- a/app/src/lib/rules/transform_rules.js
+++ b/app/src/lib/rules/transform_rules.js
@@ -236,6 +236,16 @@ const transform_rules_json = [
 		'comment': "eg 'more content than X', etc ",
 	},
 	{
+		'name': '"as" in "as Adj/Adv as..." becomes a function word',
+		'trigger': { 'stem': 'as' },
+		'context': {
+			'followedby': [{ 'category': 'Adjective|Adverb' }, { 'stem': 'as }],
+		},
+		'transform': { 'function': { 'degree': 'equality' } },
+		'context_transform': [{ }, { 'function': { 'syntax': 'comparative_as' } }],
+		'comment': "eg 'as valuable as X', etc ",
+	},
+	{
 		'name': '\'who\'/\'what\' gets tagged with interrogative_which when in a question',
 		'trigger': { 'token': 'Who|who|What|what' },
 		'context': {


### PR DESCRIPTION
`That faith is as valuable as our(Peter's) faith.`

Before:
![image](https://github.com/user-attachments/assets/797e0eb9-23c5-46a8-ad0a-b0a2a1d8be66)

After:
![image](https://github.com/user-attachments/assets/6fe22ec1-db6f-49c8-b6cd-885b5c3ac379)