### PR TITLE
Add more verb case frames

### DIFF
--- a/src/lib/backtranslator/phrasify.js
+++ b/src/lib/backtranslator/phrasify.js
@@ -194,7 +194,7 @@ const ORDERED_PHRASE_PRE_FILTERS = [
 			// did(auxiliary) not(polarity) start(auxiliary) to(infinitive) go
 			// to(infinitive) not(polarity) go
 			{ 'tag': 'verb_polarity' },
-			{ 'tag': { 'syntax': 'infinitive' } },
+			{ 'tag': { 'syntax': 'infinitive|gerundifier' } },
 			{ 'tag': 'auxiliary' },
 			{ 'tag': 'verb_polarity' },
 			{ 'tag': 'auxiliary' },

--- a/src/lib/lookup_filters.js
+++ b/src/lib/lookup_filters.js
@@ -82,6 +82,14 @@ function HAS_EXTRA_ARGUMENT(argument) {
 	return lookup => lookup.case_frame.extra_arguments.some(({ role_tag }) => role_tag.includes(argument))
 }
 
+/**
+ * 
+ * @returns {(lookup: { case_frame: CaseFrameResult }) => boolean}
+ */
+function HAS_INVALID_CASE_FRAME() {
+	return ({ case_frame }) => !case_frame.is_checked || !case_frame.is_valid
+}
+
 export const LOOKUP_FILTERS = {
 	IS_IN_ONTOLOGY,
 	IS_OR_WILL_BE_IN_ONTOLOGY,
@@ -93,4 +101,5 @@ export const LOOKUP_FILTERS = {
 	MATCHES_SENSE,
 	HAS_MISSING_ARGUMENT,
 	HAS_EXTRA_ARGUMENT,
+	HAS_INVALID_CASE_FRAME,
 }

--- a/src/lib/rules/case_frame/rules.js
+++ b/src/lib/rules/case_frame/rules.js
@@ -4,6 +4,7 @@ import { select_sense } from './sense_selection'
 import { check_adjective_case_frames } from './adjectives/case_frames'
 import { check_verb_case_frames, check_verb_case_frames_passive } from './verbs/case_frames'
 import { check_adposition_case_frames } from './adpositions/case_frames'
+import { LOOKUP_FILTERS } from '$lib/lookup_filters'
 
 
 /** @type {BuiltInRule[]} */
@@ -44,8 +45,8 @@ const argument_and_sense_rules = [
 		rule: {
 			trigger: create_token_filter({ 'category': 'Verb' }),
 			context: create_context_filter({
-				'notprecededby': { 'tag': [{ 'syntax': 'relativizer|infinitive_same_subject' }, { 'auxiliary': 'passive' }], 'skip': 'all' },
-				'notfollowedby': { 'token': '?', 'skip': 'all' },
+				'notprecededby': { 'tag': [{ 'syntax': 'relativizer|infinitive_same_subject' }], 'skip': 'all' },
+				'notfollowedby': { 'tag': [{ 'syntax': 'question' }, { 'pre_np_adposition': 'agent_of_passive' }], 'skip': 'all' },
 			}),
 			action: simple_rule_action(check_verb_case_frames),
 		},
@@ -54,7 +55,8 @@ const argument_and_sense_rules = [
 		name: 'Verb case frame, passive',
 		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around or are missing',
 		rule: {
-			trigger: create_token_filter({ 'category': 'Verb' }),
+			trigger: token => create_token_filter({ 'category': 'Verb' })(token)
+				&& token.lookup_results.every(LOOKUP_FILTERS.HAS_INVALID_CASE_FRAME),
 			context: create_context_filter({
 				'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
 				'notprecededby': { 'tag': { 'syntax': 'relativizer|infinitive_same_subject' }, 'skip': 'all' },

--- a/src/lib/rules/case_frame/sense_selection.js
+++ b/src/lib/rules/case_frame/sense_selection.js
@@ -29,6 +29,9 @@ const verb_sense_priority_overrides = [
 	['appear', [
 		['appear-B', { }],
 	]],
+	['argue', [
+		['argue-B', { }],
+	]],
 	['ask', [
 		['ask-B', { }],	
 		['ask-D', { }],	
@@ -75,6 +78,10 @@ const verb_sense_priority_overrides = [
 		['be-D', { }],	// predicative
 		['be-F', { }],	// general locative
 	]],
+	['beat', [
+		['beat-A', { 'instrument': { } }],
+		['beat-B', { 'patient': { 'stem': 'chest' } }],
+	]],
 	['become', [
 		// 'become' is very particular and so each sense is specified to make the priority clear. Not all verbs will need this.
 		['become-G', { }],	// become like
@@ -91,6 +98,10 @@ const verb_sense_priority_overrides = [
 	['believe', [
 		['believe-B', { 'patient': { 'stem': 'Christ|God|Jesus' } }],
 	]],
+	['break', [
+		['break-C', { 'patient': { 'stem': 'law' } }],
+		['break-E', { 'patient': { 'stem': 'promise|agreement' } }],
+	]],
 	['bring', [
 		// TODO use a lexicon feature for bring-B to check for any person.
 		['bring-B', { 'patient': { 'stem': 'baby|brother|child|girl|man|person|son|woman' } }],
@@ -100,8 +111,23 @@ const verb_sense_priority_overrides = [
 		['call-B', { }],
 		['call-C', { }],
 	]],
+	['care', [
+		['care-C', { 'patient': { 'stem': 'thing' } }],
+	]],
+	['carry', [
+		['carry-B', { 'patient': { 'stem': 'disease|germ' } }],
+	]],
+	['catch', [
+		['catch-C', { 'patient': { 'stem': 'fish' } }],
+		['catch-D', { 'patient': { 'stem': 'disease|cold' } }],
+	]],
 	['change', [
 		['change-B', { 'patient': { } }],
+	]],
+	['close', [
+		['close-B', { 'patient': { 'stem': 'book|scroll' } }],
+		['close-C', { 'patient': { 'stem': 'eye' } }],
+		['close-D', { 'patient': { 'stem': 'mouth' } }],
 	]],
 	['cover', [
 		['cover-C', { 'agent': { 'stem': 'cloud' } }],
@@ -109,6 +135,22 @@ const verb_sense_priority_overrides = [
 	['dream', [
 		['dream-A', { 'patient': { } }],	// when dream-A has a patient, prioritize it over dream-B
 		['dream-B', { }],
+	]],
+	['escape', [
+		['escape-C', { 'source': { 'stem': 'fire' } }],
+	]],
+	['fall', [
+		// TODO add an entry for fall-B to use a lexicon feature to check for any person.
+		['fall-D', { 'agent': { 'stem': 'soldier' } }],	// Nahum 2:5 'The soldiers fell in the streets.'  When soldiers fall, it will usually be because they're dead.
+	]],
+	['follow', [
+		['follow-D', { 'patient': { 'stem': 'road|path' } }],
+	]],
+	['forgive', [
+		['forgive-B', { 'patient': { 'stem': 'sin' } }],
+	]],
+	['gather', [
+		['gather-B', { 'patient': { 'stem': 'grain|wheat|wood' } }],
 	]],
 	['give', [
 		['give-B', { 'patient': { 'stem': 'ring|vaccine' } }],
@@ -132,6 +174,9 @@ const verb_sense_priority_overrides = [
 		['have-E', { 'state': { 'stem': 'AIDS|Avian-Influenza|cold|disease|fever|HIV|pain|sore|leprosy' } }],
 		['have-A', { }],
 		['have-I', { }],	// TODO use a lexicon feature to check for the agent being a place
+	]],
+	['hurt', [
+		['hurt-C', { 'be_auxiliary': { } }],
 	]],
 	['know', [
 		['know-C', { 'patient': { 'stem': 'law|meaning|name|secret|thing' } }],

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -1,5 +1,5 @@
 import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from '../common'
-import { by_adposition, by_clause_tag, by_relative_context, directly_after_verb, directly_after_verb_with_adposition, directly_before_verb, patient_from_subordinate_clause, predicate_adjective } from './presets'
+import { by_adposition, by_clause_tag, by_complementizer, by_relative_context, directly_after_verb, directly_after_verb_with_adposition, directly_before_verb, patient_from_subordinate_clause, predicate_adjective, with_be_auxiliary } from './presets'
 
 /** @type {RoleRuleJson<VerbRoleTag>} */
 const default_verb_case_frame_json = {
@@ -44,6 +44,13 @@ const default_verb_case_frame_json = {
  * @type {Map<WordStem, [WordSense, SenseRuleJson<VerbRoleTag>][]>}
  */
 const verb_case_frames = new Map([
+	['accept', []],
+	['act', []],
+	['admit', []],
+	['advise', [
+		['advise-B', patient_from_subordinate_clause()],
+	]],
+	['affect', []],
 	['agree', [
 		['agree-A', { 'patient': directly_after_verb_with_adposition('with') }],
 		['agree-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
@@ -62,6 +69,30 @@ const verb_case_frames = new Map([
 				directly_after_verb_with_adposition('like'),
 			],
 		}],
+	]],
+	['approve', [
+		['approve-A', {
+			'patient': [
+				directly_after_verb(),
+				directly_after_verb_with_adposition('of'),
+			],
+		}],
+	]],
+	['argue', [
+		['argue-A', {
+			'patient': by_adposition('with'),
+			'destination': by_adposition('about'),
+		}],
+		['argue-B', {
+			'patient': by_adposition('with'),
+			'patient_clause_different_participant': by_complementizer('about'),
+		}],
+	]],
+	['arrive', [
+		['arrive-A', { 'patient': directly_after_verb_with_adposition('at|in') }],
+	]],
+	['attach', [
+		['attach-A', { 'instrument': by_adposition('with') }],
 	]],
 	['ask', [
 		['ask-A', {
@@ -104,18 +135,13 @@ const verb_case_frames = new Map([
 					...by_clause_tag('patient_clause_different_participant'),
 					'missing_message': "ask-F should be written in the format 'asked X [(if//whether) ...]' (with or without the if/whether)",
 				},
-				{
-					...by_clause_tag('adverbial_clause'),
-					'context': {
-						'subtokens': { 'token': 'if|whether', 'skip': 'clause_start' },
-					},
-					// TODO make if/whether function words using a subtoken context transform
-				},
+				by_complementizer('if|whether'),
 			],
 			'comment': "This can be written as 'asked X [(if//whether) ...]' (with or without the if/whether)",
 		}],
 	]],
 	['attack', []],
+	['avoid', []],
 	['be', [
 		['be-D', {
 			'other_required': 'predicate_adjective',
@@ -213,6 +239,9 @@ const verb_case_frames = new Map([
 		['be-W', { 'state': directly_after_verb_with_adposition('in') }],
 		['be-X', { 'state': directly_after_verb() }],
 	]],
+	['beat', [
+		['beat-A', { 'instrument': by_adposition('with') }],
+	]],
 	['become', [
 		['become-A', {
 			'other_required': 'predicate_adjective',
@@ -250,7 +279,34 @@ const verb_case_frames = new Map([
 	['believe', [
 		['believe-B', { 'patient': directly_after_verb_with_adposition('in') }],
 	]],
+	['belong', []],
+	['birth', [
+		['birth-A', {
+			'patient': [
+				// 'X birthed Y' OR 'X gave birth to Y'
+				directly_after_verb(),
+				directly_after_verb_with_adposition('to'),
+			],
+			'destination': { },	// clear the rule so the 'to' doesn't trigger it
+		}],
+	]],
+	['blow', []],
+	['born', [
+		['born-A', with_be_auxiliary()]
+	]],
+	['break', [
+		['break-A', { 'destination': by_adposition('to|into') }],
+	]],
+	['breathe', [
+		['breathe-B', { 'destination': by_adposition('to|into') }],
+	]],
 	['bring', []],
+	['burn', [
+		['burn-A', { 'instrument': by_adposition('with') }],
+	]],
+	['buy', [
+		['buy-A', { 'instrument': by_adposition('with|for') }],
+	]],
 	['call', [
 		['call-A', { 'state': { 'trigger': 'none' } }],
 		['call-B', {
@@ -268,7 +324,30 @@ const verb_case_frames = new Map([
 			},
 		}],
 	]],
+	['care', [
+		['care-A', { 'patient': directly_after_verb_with_adposition('for|of') }],
+		['care-B', { 'patient': directly_after_verb_with_adposition('about') }],
+		['care-C', { 'patient': directly_after_verb_with_adposition('for|of') }],
+	]],
+	['carry', [
+		['carry-A', {
+			'destination': by_adposition('to|into'),
+			'instrument': by_adposition('with'),
+		}],
+	]],
+	['carry', [
+		['carry-B', { 'instrument': by_adposition('with') }],
+		['carry-C', { 'instrument': by_adposition('with') }],
+		['carry-E', { 'instrument': by_adposition('with') }],
+	]],
 	['cause', []],
+	['celebrate', [
+		['celebrate-A', { 'instrument': by_adposition('with') }],
+		['celebrate-B', {
+			'destination': by_adposition('until'),
+			'instrument': by_adposition('with'),
+		}],
+	]],
 	['change', [
 		['change-A', { 'patient': directly_after_verb_with_adposition('into') }],
 		['change-B', {
@@ -290,14 +369,125 @@ const verb_case_frames = new Map([
 		['choose-B', patient_from_subordinate_clause()],
 		['choose-C', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
+	['close', []],
 	['come', []],
+	['come-out', [
+		['come-out-A', { 'source': by_adposition('from|of') }],
+	]],
+	['command', [
+		['command-A', {
+			...patient_from_subordinate_clause(),
+			'instrument': by_adposition('with'),
+		}],
+		['command-B', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['complain', [
+		['complain-A', { 'patient': by_adposition('about') }],
+	]],
+	['contain', []],
+	['cost', []],
 	['cover', [
 		['cover-A', { 'instrument': by_adposition('with') }],
 		['cover-B', { 'instrument': by_adposition('with') }],
 	]],
+	['cry-out', [
+		['cry-out-A', { 'patient': by_adposition('about') }],
+		['cry-out-B', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['decide', [
+		['decide-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['demand', [
+		['demand-B', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['deserve', [
+		['deserve-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+		['deserve-C', {
+			'patient_clause_different_participant': [
+				by_clause_tag('patient_clause_different_participant'),
+				by_complementizer('for'),	// 'John didn't deserve [for Jesus to come].'
+			],
+		}],
+	]],
 	['die', []],
+	['discover', []],
+	['divide', [
+		['divide-A', {
+			'destination': by_adposition('into'),	// divided the kingdom into regions
+			'instrument': by_adposition('with'),
+			'beneficiary': by_adposition('among'),	// divided the lang among the tribes
+		}],
+		['divide-B', { 'patient': by_adposition('into') }],
+	]],
 	['dream', [
 		['dream-A', { 'patient': by_adposition('about') }],
+	]],
+	['doubt', []],
+	['drop', [
+		['drop-A', { 'destination': by_adposition('to|on|into') }],
+	]],
+	['eat', [
+		['eat-A', { 'instrument': by_adposition('with') }],
+	]],
+	['encourage', [
+		['encourage-B', patient_from_subordinate_clause()],
+	]],
+	['end', [
+		['end-B', { 'destination': by_adposition('at') }],
+	]],
+	['enjoy', [
+		['enjoy-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['escape', []],
+	['expect', [
+		['expect-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['explain', []],
+	['explain-how', []],
+	['fail', [
+		['fail-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['fall', [
+		['fall-A', { 'destination': by_adposition('to|on|into') }],
+		['fall-B', { 'destination': by_adposition('to|on|into') }],
+		['fall-D', { 'destination': by_adposition('to|on|into') }],
+		['fall-E', { 'destination': by_adposition('to|on|into') }],
+	]],
+	['fight', [
+		['fight-A', {
+			'patient': [
+				directly_after_verb(),
+				by_adposition('against|with'),
+			],
+			'instrument': {
+				...by_adposition('with'),
+				'trigger': { 'tag': { 'syntax': 'head_np' }, 'level': '0|1|2|3' },	// the instrument can't be a level 4 word (proper name)
+			},
+		}],
+		['fight-B', { 'instrument': by_adposition('with') }],
+	]],
+	['find-out', [
+		['find-out-B', {
+			'patient': [
+				directly_after_verb(),
+				by_adposition('about'),
+			],
+		}],
+	]],
+	['follow', []],
+	['forget', [
+		['forget-A', { 'patient': by_adposition('about') }],
+		['forget-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['forgive', [
+		['forgive-C', {
+			'destination': by_adposition('for'),
+			'beneficiary': { },
+		}],
+		['forgive-D', patient_from_subordinate_clause()],
+	]],
+	['gather', [
+		['gather-B', { 'instrument': by_adposition('with') }],
 	]],
 	['give', [
 		['give-A', {
@@ -332,6 +522,9 @@ const verb_case_frames = new Map([
 	]],
 	['help', [
 		['help-B', patient_from_subordinate_clause()],
+	]],
+	['hurt', [
+		['hurt-C', with_be_auxiliary()],
 	]],
 	['kill', []],
 	['know', [
@@ -388,6 +581,9 @@ const verb_case_frames = new Map([
 			'other_optional': 'just_like_clause',
 		}],
 	]],
+	['lock', [
+		['lock-B', with_be_auxiliary()],
+	]],
 	['look', [
 		['look-A', { 'patient': directly_after_verb_with_adposition('at') }],
 		['look-B', { 'other_required': 'predicate_adjective' }],	// X looked happy/sad/excited
@@ -421,6 +617,9 @@ const verb_case_frames = new Map([
 			],
 		}],
 		['make-E', { 'instrument': by_adposition('with') }],
+	]],
+	['marry', [
+		['marry-B', with_be_auxiliary()],
 	]],
 	['pray', [
 		['pray-A', { 'patient': by_adposition('about') }],
@@ -467,13 +666,10 @@ const verb_case_frames = new Map([
 	['speak', [
 		['speak-A', {
 			'patient': by_adposition('about') ,
-			'instrument': {
-				...by_adposition('in'),	// in a language
-				// 'context_transform': { 'concept': 'in-K' },
-			},
+			'instrument': by_adposition('in'),	// in a language
 			'other_rules': {
 				'extra_patient': {
-					'directly_after_verb': {},
+					'directly_after_verb': { },
 					'extra_message': 'speak-A cannot be used with a regular object. The patient is expressed as \'speak about X\'',
 				},
 			},
@@ -545,6 +741,23 @@ const verb_case_frames = new Map([
 		}],
 		['throw-E', { 'destination': by_adposition('into') }],
 	]],
+	['tie', [
+		['tie-A', { 'instrument': by_adposition('with') }],
+		['tie-B', {
+			...with_be_auxiliary(),
+			'instrument': by_adposition('with'),
+		}],
+		['tie-C', { 'instrument': by_adposition('with') }],
+	]],
+	['unite', [
+		['unite-A', { 'destination': by_adposition('to|with') }],
+		['unite-B', { 'destination': by_adposition('to|with') }],
+		['unite-C', {
+			...with_be_auxiliary(),
+			'patient': by_adposition('to|with'),
+			'destination': { },
+		}],
+	]],
 	['want', [
 		['want-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
@@ -552,7 +765,11 @@ const verb_case_frames = new Map([
 		['work-A', { 'instrument': by_adposition('with') }],
 	]],
 	['worry', [
-		['worry-A', { 'patient': directly_after_verb_with_adposition('about') }],
+		['worry-A', {
+			...with_be_auxiliary(),
+			'patient': directly_after_verb_with_adposition('about'),
+		}],
+		['worry-B', with_be_auxiliary()],
 	]],
 ])
 

--- a/src/lib/rules/case_frame/verbs/presets.js
+++ b/src/lib/rules/case_frame/verbs/presets.js
@@ -22,6 +22,26 @@ export function patient_from_subordinate_clause() {
 
 /**
  * 
+ * @returns {SenseRuleJson<VerbRoleTag>}
+ */
+export function with_be_auxiliary() {
+	return {
+		'other_rules': {
+			'be_auxiliary': {
+				...by_relative_context({
+					'precededby': { 'tag': { 'auxiliary': 'passive|generic' }, 'skip': 'all' },
+				}),
+				'context_transform': { 'tag': { 'auxiliary': 'generic' } },
+				'tag_role': false,
+			},
+		},
+		'other_optional': 'be_auxiliary',
+		'comment': "some verbs look like passives but aren't eg. 'John's hand was hurt', 'John was married to Mary', etc. Leave as optional in case of 'John's hand hurt-C'",
+	}
+}
+
+/**
+ * 
  * @param {string} adposition 
  * @returns {CaseFrameRuleJson}
  */
@@ -42,6 +62,22 @@ export function by_adposition(adposition) {
 export function by_clause_tag(clause_type) {
 	return {
 		'trigger': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': clause_type, 'role': 'none' } },
+	}
+}
+
+/**
+ * 
+ * @param {string} complementizer 
+ * @returns {CaseFrameRuleJson}
+ */
+export function by_complementizer(complementizer) {
+	return {
+		'trigger': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': 'adverbial_clause' } },
+		'context': {
+			'subtokens': { 'token': complementizer, 'skip': 'clause_start' },
+		},
+		'transform': { 'tag': { 'clause_type': 'patient_clause_different_participant', 'role': 'patient_clause_different_participant' } },
+		'subtoken_transform': { 'function': { 'syntax': 'complementizer' } },
 	}
 }
 

--- a/src/lib/rules/lookup_rules.js
+++ b/src/lib/rules/lookup_rules.js
@@ -91,6 +91,13 @@ const lookup_rules_json = [
 		'combine': 1,
 	},
 	{
+		'name': 'take care',
+		'trigger': { 'stem': 'take' },
+		'context': { 'followedby': { 'token': 'care' } },
+		'lookup': 'care',
+		'combine': 1,
+	},
+	{
 		'name': 'look for -> search',
 		'trigger': { 'stem': 'look' },
 		'context': { 'followedby': { 'token': 'for' } },

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -201,6 +201,18 @@ const part_of_speech_rules_json = [
 		'comment': "Infected Eye 1:1 Melissa's eye is sore(N/Adj).  Infected Eye 1:15 Janet's eyes were still sore(N/Adj).",
 	},
 	{
+		'name': 'If Noun-Adverb preceded by a determiner or possessive, remove Adverb',
+		'category': 'Noun|Adverb',
+		'context': {
+			'precededby': {
+				'tag': ['determiner', { 'relation': 'genitive_saxon' }],
+				'skip': { 'category': 'Adjective' },
+			},
+		},
+		'remove': 'Adverb',
+		'comment': "eg 'John argued with Mary about the well.'",
+	},
+	{
 		'name': 'If Verb-Adjective preceded by an article or possessive, remove Verb',
 		'category': 'Verb|Adjective',
 		'context': {

--- a/src/lib/rules/rules_parser.js
+++ b/src/lib/rules/rules_parser.js
@@ -466,7 +466,7 @@ const SKIP_GROUPS = new Map([
 		{ 'category': 'Noun' },
 	]],
 	['vp_modifiers', [
-		{ 'tag': ['verb_polarity|modal|auxiliary', { 'syntax': 'infinitive' }] },
+		{ 'tag': ['verb_polarity|modal|auxiliary', { 'syntax': 'infinitive|gerundifier' }] },
 		'advp',
 	]],
 	['vp', [

--- a/src/lib/rules/transform_rules.js
+++ b/src/lib/rules/transform_rules.js
@@ -25,8 +25,8 @@ const transform_rules_json = [
 		'transform': { 'function': { 'syntax': 'infinitive|infinitive_same_subject' } },
 	},
 	{
-		'name': '"from" before a verb gets tagged as gerundifier',
-		'trigger': { 'token': 'from' },
+		'name': '"from" or "for" before a verb gets tagged as gerundifier',
+		'trigger': { 'token': 'from|for' },
 		'context': {
 			'followedby': {
 				'category': 'Verb',
@@ -35,7 +35,7 @@ const transform_rules_json = [
 			},
 		},
 		'transform': { 'function': { 'syntax': 'gerundifier' } },
-		'comment': '"prevent [X from Ving]". May be needed for other verbs as well',
+		'comment': '"prevent [X from Ving]", "forgive [X for Ving]". May be needed for other verbs as well',
 	},
 	{
 		'name': 'tag "in-order-to" and "by" as "same subject"',
@@ -227,6 +227,11 @@ const transform_rules_json = [
 		'comment': 'this clears the relativizer tag but keeps the determiner tag',
 	},
 	// General function words
+	{
+		'name': 'tag "?" with "question"',
+		'trigger': { 'token': '?' },
+		'transform': { 'tag': { 'syntax': 'question' } },
+	},
 	{
 		'name': '"no" before a noun becomes negative_noun_polarity',
 		'trigger': { 'token': 'no' },


### PR DESCRIPTION
Added case frame and sense selection rules for the following 59 verbs:
- accept
- act
- admit
- advise
- affect
- approve
- argue
- arrive
- attach
- avoid
- beat
- belong
- birth
- blow
- born
- break
- breathe
- burn
- buy
- care
- carry
- catch
- celebrate
- close
- come-out
- command
- complain
- contain
- cost
- cry-out
- decide
- demand
- deserve
- discover
- divide
- doubt
- drop
- eat
- encourage
- end
- enjoy
- escape
- expect
- explain
- explain-how
- fail
- fall
- fight
- find-out
- follow
- forget
- forgive
- gather
- hurt
- lock
- marry
- tie
- unite
- worry

This also resolves #105 