### PR TITLE
Adjust some messaging

### DIFF
--- a/src/lib/parser/error_messages.js
+++ b/src/lib/parser/error_messages.js
@@ -1,12 +1,12 @@
 const MISSING_OPENING_PAREN = 'Missing an opening parenthesis.'
 const MISSING_CLOSING_PAREN = 'Missing a closing parenthesis.'
 
-const MISSING_OPENING_BRACKET = 'Missing an opening bracket in the following sentence.'
-const MISSING_CLOSING_BRACKET = 'Missing a closing bracket in the previous sentence.'
+const MISSING_OPENING_BRACKET = 'Missing an opening bracket somewhere in the following sentence.'
+const MISSING_CLOSING_BRACKET = 'Missing a closing bracket somewhere in the previous sentence.'
 const NO_SPACE_BEFORE_OPENING_BRACKET = 'Missing a space before [.'
 
 const INVALID_PAIRING_SYNTAX = 'Pairings should have the form simple/complex, e.g., follower/disciple.'
-const UNRECOGNIZED_CLAUSE_NOTATION = 'This clause notation is not recognized.'
+const UNRECOGNIZED_CLAUSE_NOTATION = 'This clause notation is not recognized.' // TODO show what IS recognized
 const NO_SPACE_BEFORE_UNDERSCORE = 'Notes notation should have a space before the underscore, e.g., ⎕_implicit.'
 const UNRECOGNIZED_CHAR = 'Unrecognized character.'
 

--- a/src/lib/rules/case_frame/adjectives/presets.js
+++ b/src/lib/rules/case_frame/adjectives/presets.js
@@ -41,7 +41,7 @@ export function by_adposition(adposition) {
 		'argument_context_index': 1,
 		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
 		'context_transform': { 'function': { 'pre_np_adposition': 'adjective_argument', 'relation': '' } },	// make the adposition a function word and clear other tag values
-		'missing_message': `Couldn't find the nominal argument, which in this case should have '${adposition}' before it.`,
+		'missing_message': `{sense} expects a nominal argument, i.e. '{stem} ${adposition} N'.`,
 	}
 }
 

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -45,7 +45,7 @@ function extra_argument_message(role_tag) {
 /** @type {[RoleTag, string][]} */
 const ALL_HAVE_MISSING_ARGUMENT_MESSAGES = [
 	// If no Verb sense could find an agent (or agent_clause), there's probably a bracketing issue. Make the message more clear.
-	['agent', 'No agent could be found for this verb. Make sure to add explicit agents for imperatives and passives, and make sure your brackets are correct.'],
+	['agent', 'Could not find the agent of this verb. Check other errors and warnings for more help.'],
 	['opening_subordinate_clause', "Missing '[' bracket before adverbial clause."],
 ]
 
@@ -295,7 +295,8 @@ export function* validate_case_frame(trigger_context) {
 			const [, message] = missing_role
 			yield { error: message }
 		} else {
-			yield { error: 'No senses match the argument structure found in this sentence. Specify a sense (eg. {token}-A) to get more info about its expected structure.' }
+			yield { error: "This use of '{stem}' does not match any sense in the Ontology. Check other errors and warnings for more information." }
+			yield { info: 'For more detailed error messages, specify a sense (eg. {token}-A) and recheck.' }
 		}
 
 		// Some extra arguments are common mistakes and can be flagged even when no sense is specified
@@ -310,10 +311,7 @@ export function* validate_case_frame(trigger_context) {
 	const case_frame = selected_result.case_frame
 
 	if (!case_frame.is_valid) {
-		const message = selected_result.part_of_speech === 'Verb'
-			? 'Invalid argument structure for {sense}. Consult the Ontology for correct usage.'
-			: 'Invalid usage of {sense}. Consult the Ontology.'
-		yield { error: message }
+		yield { error: 'Incorrect usage of {sense}. Check other errors and warnings for more information, and consult the Ontology.' }
 	}
 
 	// Show errors for missing and unexpected arguments

--- a/src/lib/rules/case_frame/rules.js
+++ b/src/lib/rules/case_frame/rules.js
@@ -56,7 +56,7 @@ const argument_and_sense_rules = [
 		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around or are missing',
 		rule: {
 			trigger: token => create_token_filter({ 'category': 'Verb' })(token)
-				&& token.lookup_results.every(LOOKUP_FILTERS.HAS_INVALID_CASE_FRAME),
+					&& token.lookup_results.every(LOOKUP_FILTERS.HAS_INVALID_CASE_FRAME()),
 			context: create_context_filter({
 				'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
 				'notprecededby': { 'tag': { 'syntax': 'relativizer|infinitive_same_subject' }, 'skip': 'all' },

--- a/src/lib/rules/case_frame/verbs/presets.js
+++ b/src/lib/rules/case_frame/verbs/presets.js
@@ -139,7 +139,7 @@ export function predicate_adjective() {
 		'followedby': {
 			'category': 'Adjective',
 			'tag': { 'adj_usage': 'predicative' },
-			'skip': ['adjp_modifiers_predicative', 'advp', { 'tag': 'verb_polarity' }],
+			'skip': 'all',
 		},
 	})
 }

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -19,7 +19,6 @@ const checker_rules_json = [
 			'message': 'Third person pronouns should be replaced with the Noun they represent, e.g., Paul (instead of him).',
 		},
 	},
-	// TODO make an error again when certain passive-like verbs are dealt with better (eg. united-C with, married with, locked, etc, see #105)
 	{
 		'name': 'Expect an agent of a passive',
 		'trigger': { 'category': 'Verb' },
@@ -27,11 +26,11 @@ const checker_rules_json = [
 			'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
 			'notfollowedby': { 'tag': [{ 'role': 'agent' }, { 'pre_np_adposition': 'agent_of_passive' }], 'skip': 'all' },
 		},
-		'suggest': {
+		'error': {
 			'followedby': 'by X',
-			'message': 'If this is a passive Verb, make sure to include an explicit agent. Use _implicitActiveAgent if necessary.',
+			'message': 'A passive verb must have an explicit agent. Use _implicitActiveAgent if necessary.',
 		},
-		'comment': 'A passive verb requires a "by X" agent. Some verbs that look like passives aren\'t actually passives, so make this a suggestion instead of error.',
+		'comment': 'A passive verb requires a "by X" agent.',
 	},
 	{
 		'name': 'Suggest avoiding the Perfect aspect',
@@ -52,18 +51,18 @@ const checker_rules_json = [
 		},
 	},
 	{
-		'name': 'Suggest expanding \'there\' to \'at that place\' for clarity',
+		'name': "Suggest expanding 'there' to 'at that place' for clarity",
 		'trigger': { 'token': 'There|there' },
 		'context': { 'notfollowedby': { 'stem': 'be', 'skip': 'vp_modifiers' } },	// TODO trigger on 'not tag existential' instead
 		'suggest': {
-			'message': 'Consider using \'at that place\' instead of \'there\', especially if a preposition other than \'at\' is wanted.',
+			'message': "Consider using 'at that place' instead of 'there', especially if a preposition other than 'at' is wanted.",
 		},
 	},
 	{
-		'name': 'Suggest expanding \'here\' to \'at this place\' for clarity',
+		'name': "Suggest expanding 'here' to 'at this place' for clarity",
 		'trigger': { 'token': 'Here|here' },
 		'suggest': {
-			'message': 'Consider using \'at this place\' instead of \'here\', especially if a preposition other than \'at\' is wanted.',
+			'message': "Consider using 'at this place' instead of 'here', especially if a preposition other than 'at' is wanted.",
 		},
 	},
 	{
@@ -118,13 +117,13 @@ const checker_rules_json = [
 		},
 	},
 	{
-		'name': 'Check for \'Let X...\'',
+		'name': "Check for 'Let X...'",
 		'trigger': { 'token': 'Let' },
 		'context': {
 			'followedby': [{ 'category': 'Noun' }, { 'category': 'Verb', 'form': 'stem', 'skip': 'vp_modifiers' }],
 		},
 		'error': {
-			'message': 'For the jussive write \'{0:token} {1:stem} (jussive) ...\' instead of \'Let {0:token} {1:stem}...\'. Or use \'(imp)\' for expressing permission. See P1 Checklist section 15.',
+			'message': "For the jussive write '{0:token} {1:stem} (jussive) ...' instead of 'Let {0:token} {1:stem}...'. Or use '(imp)' for expressing permission. See P1 Checklist section 15.",
 		},
 	},
 	{
@@ -154,18 +153,18 @@ const checker_rules_json = [
 		'comment': 'See section 17 of the Phase 1 checklist',
 	},
 	{
-		'name': 'Cannot use \'any\'',
+		'name': "Cannot use 'any'",
 		'trigger': { 'stem': 'any' },
 		'error': {
-			'message': 'Cannot use \'any\'. Simply use \'a\' instead. See P1 Checklist section 17.',
+			'message': "Cannot use 'any'. Simply use 'a' instead. See P1 Checklist section 17.",
 		},
 		'comment': 'See section 17 of the Phase 1 checklist',
 	},
 	{
-		'name': 'Cannot use \'really\'',
+		'name': "Cannot use 'really'",
 		'trigger': { 'token': 'really' },
 		'error': {
-			'message': 'Cannot use \'really\'. Use \'actually\', \'truly\', \'very\', or \'much\' instead.',
+			'message': "Cannot use 'really'. Use 'actually', 'truly', 'very', or 'much' instead.",
 		},
 		'comment': 'See section 1 of the Phase 1 checklist',
 	},
@@ -181,17 +180,18 @@ const checker_rules_json = [
 		},
 		'comment': 'See section 17 of the Phase 1 checklist',
 	},
-	{
-		'name': 'Avoid vague units of time',
-		'trigger': { 'stem': 'short|long|some' },
-		'context': {
-			'precededby': { 'token': 'For|for', 'skip': { 'token': 'a' } },
-			'followedby': { 'stem': 'time' },
-		},
-		'suggest': {
-			'message': 'Try using more specific units of time (eg. \'for many years\') or express it in a different way (eg. \'for much time\').',
-		},
-	},
+	// TODO redo with the new time-long-hours etc concepts in the Ontology
+	// {
+	// 	'name': 'Avoid vague units of time',
+	// 	'trigger': { 'stem': 'short|long|some' },
+	// 	'context': {
+	// 		'precededby': { 'token': 'For|for', 'skip': { 'token': 'a' } },
+	// 		'followedby': { 'stem': 'time' },
+	// 	},
+	// 	'suggest': {
+	// 		'message': "Try using more specific units of time (eg. 'for many years') or express it in a different way (eg. 'for much time').",
+	// 	},
+	// },
 	{
 		'name': 'Suggest a comma after "One day..."',
 		'trigger': { 'stem': 'day' },
@@ -201,7 +201,7 @@ const checker_rules_json = [
 		},
 		'suggest': {
 			'followedby': ',',
-			'message': 'Add a comma after \'One day\' so the \'that\' doesn\'t confuse the Analyzer.',
+			'message': "Add a comma after 'One day' so the 'that' doesn't confuse the Analyzer.",
 		},
 		'comment': 'The Analyzer messes up "One day that man...", but it works fine with a comma. TODO handle other phrases too?',
 	},
@@ -239,128 +239,128 @@ const checker_rules_json = [
 		},
 	},
 	{
-		'name': '\'so\' in an Adverbial clause should be followed by \'that\'',
+		'name': "'so' in an Adverbial clause should be followed by 'that'",
 		'trigger': { 'token': 'so', 'category': 'Adposition' },
 		'context': {
 			'notfollowedby': { 'token': 'that' },
 		},
 		'suggest': {
-			'message': 'Use \'so-that\' so-that it doesn\'t get mistaken for the Conjunction.',
+			'message': "Use 'so-that' so-that it doesn't get mistaken for the Conjunction.",
 		},
 	},
 	{
-		'name': 'Check for unhyphenated Verbs with \'around\'',
+		'name': "Check for unhyphenated Verbs with 'around'",
 		'trigger': { 'token': 'around' },
 		'context': {
 			'precededby': { 'stem': 'turn', 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': '\'around\' must be hyphenated with the Verb (i.e. {0:stem}-around). DO NOT inflect the Verb (e.g. NOT turned-around).',
+			'message': "'around' must be hyphenated with the Verb (i.e. {0:stem}-around). DO NOT inflect the Verb (e.g. NOT turned-around).",
 		},
 	},
 	{
-		'name': 'Check for unhyphenated Verbs with \'away\'',
+		'name': "Check for unhyphenated Verbs with 'away'",
 		'trigger': { 'token': 'away' },
 		'context': {
 			'precededby': { 'stem': 'chase|take|walk', 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': '\'away\' must be hyphenated with the Verb (i.e. {0:stem}-away). DO NOT inflect the Verb (e.g. NOT took-away).',
+			'message': "'away' must be hyphenated with the Verb (i.e. {0:stem}-away). DO NOT inflect the Verb (e.g. NOT took-away).",
 		},
 	},
 	{
-		'name': 'Check for unhyphenated Verbs with \'down\'',
+		'name': "Check for unhyphenated Verbs with 'down'",
 		'trigger': { 'token': 'down' },
 		'context': {
 			'precededby': { 'stem': 'cut|knock|lie|run|sit|walk|write', 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': '\'down\' must be hyphenated with the Verb (i.e. {0:stem}-down). DO NOT inflect the Verb (e.g. NOT ran-down).',
+			'message': "'down' must be hyphenated with the Verb (i.e. {0:stem}-down). DO NOT inflect the Verb (e.g. NOT ran-down).",
 		},
 	},
 	{
-		'name': 'Check for unhyphenated Verbs with \'off\'',
+		'name': "Check for unhyphenated Verbs with 'off'",
 		'trigger': { 'token': 'off' },
 		'context': {
 			'precededby': { 'stem': 'cut|pull|take', 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': '\'off\' must be hyphenated with the Verb (i.e. {0:stem}-off). DO NOT inflect the Verb (e.g. NOT took-off).',
+			'message': "'off' must be hyphenated with the Verb (i.e. {0:stem}-off). DO NOT inflect the Verb (e.g. NOT took-off).",
 		},
 	},
 	{
-		'name': 'Check for unhyphenated \'put on\' (clothes)',
+		'name': "Check for unhyphenated 'put on' (clothes)",
 		'trigger': { 'stem': 'on' },
 		'context': {
 			'precededby': { 'stem': 'put', 'category': 'Verb' },
 			'followedby': { 'stem': 'clothes|glove|sandal|shirt|shoe' },
 		},
 		'error': {
-			'message': '\'on\' must be hyphenated with the Verb (i.e. put-on).',
+			'message': "'on' must be hyphenated with the Verb (i.e. put-on).",
 		},
-		'comment': 'The clothing-related nouns must be present because we don\'t want this rule applying to \'put on\' in general',
+		'comment': "The clothing-related nouns must be present because we don't want this rule applying to 'put on' in general",
 	},
 	{
-		'name': 'Check for unhyphenated Verbs with \'out\'',
+		'name': "Check for unhyphenated Verbs with 'out'",
 		'trigger': { 'token': 'out' },
 		'context': {
 			'precededby': { 'stem': 'come|cry|pour|pull', 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': '\'out\' must be hyphenated with the Verb (i.e. {0:stem}-out). DO NOT inflect the Verb (e.g. NOT cried-out).',
+			'message': "'out' must be hyphenated with the Verb (i.e. {0:stem}-out). DO NOT inflect the Verb (e.g. NOT cried-out).",
 		},
 	},
 	{
-		'name': 'Check for unhyphenated Verbs with \'up\'',
+		'name': "Check for unhyphenated Verbs with 'up'",
 		'trigger': { 'token': 'up' },
 		'context': {
 			'precededby': { 'stem': 'go|pick|run|sit|stand|wake|walk', 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': '\'up\' must be hyphenated with the Verb (i.e. {0:stem}-up). DO NOT inflect the Verb (e.g. NOT picked-up).',
+			'message': "'up' must be hyphenated with the Verb (i.e. {0:stem}-up). DO NOT inflect the Verb (e.g. NOT picked-up).",
 		},
 	},
 	{
 		'name': 'Some noun plurals aren\'t recognized',
 		'trigger': { 'token': 'troubles|lands' },
 		'error': {
-			'message': 'TBTA does not use the plural \'{token}\'. Put \'_plural\' after the singular form to indicate plurality.',
+			'message': "TBTA does not use the plural '{token}'. Put '_plural' after the singular form to indicate plurality.",
 		},
 	},
 	{
-		'name': 'Don\'t allow \'what\' as a relativizer',
+		'name': "Don't allow 'what' as a relativizer",
 		'trigger': { 'token': 'what' },
 		'context': {
 			'precededby': { 'token': '[' },
 			'notfollowedby': { 'token': '?', 'skip': 'all' },
 		},
 		'error': {
-			'message': 'Cannot use \'what\' as a relativizer. Use \'the thing [that...]\' instead.',
+			'message': "Cannot use 'what' as a relativizer. Use 'the thing [that...]' instead.",
 		},
 		'comment': 'See section 0.41 of the Phase 1 checklist',
 	},
 	{
-		'name': 'Warn about using \'what\' instead of \'which thing\'',
+		'name': "Warn about using 'what' instead of 'which thing'",
 		'trigger': { 'token': 'What|what' },
 		'warning': {
-			'message': '\'what\' always becomes \'which thing-A\'. Consider writing \'which X\' if you want something different.',
+			'message': "'what' always becomes 'which thing-A'. Consider writing 'which X' if you want something different.",
 		},
 		'comment': 'See section 0.41 of the Phase 1 checklist',
 	},
 	{
-		'name': 'Don\'t allow \'where\' as a relativizer',
+		'name': "Don\'t allow 'where' as a relativizer",
 		'trigger': { 'token': 'where' },
 		'context': {
 			'precededby': { 'token': '[' },
 			'notfollowedby': { 'token': '?', 'skip': 'all' },
 		},
 		'error': {
-			'message': 'Cannot use \'where\' as a relativizer. Use \'the place [that...]\' instead.',
+			'message': "Cannot use 'where' as a relativizer. Use 'the place [that...]' instead.",
 		},
 		'comment': 'See section 0.8 of the Phase 1 checklist',
 	},
 	{
-		'name': 'Don\'t allow \'when\' as a relativizer',
+		'name': "Don\'t allow 'when' as a relativizer",
 		'trigger': { 'type': TOKEN_TYPE.CLAUSE },
 		'context': {
 			'precededby': { 'token': 'time' },
@@ -368,27 +368,27 @@ const checker_rules_json = [
 		},
 		'error': {
 			'on': 'subtokens:0',
-			'message': 'Cannot use \'when\' as a relativizer. Use \'the time [that...]\' instead. See P1 Checklist 0.8.',
+			'message': "Cannot use 'when' as a relativizer. Use 'the time [that...]' instead. See P1 Checklist 0.8.",
 		},
 		'comment': 'See section 0.8 of the Phase 1 checklist.',
 	},
 	{
-		'name': 'Don\'t allow \'whose\' as a relativizer',
+		'name': "Don't allow 'whose' as a relativizer",
 		'trigger': { 'token': 'whose' },
 		'error': {
-			'message': 'Cannot use \'whose\'. Use \'X [who had...]\' instead. See P1 Checklist section 6.',
+			'message': "Cannot use 'whose'. Use 'X [who had...]' instead. See P1 Checklist section 6.",
 		},
 		'comment': 'See section 6 of the Phase 1 checklist',
 	},
 	{
-		'name': 'Use \'all of\' rather than \'all\' for non-generic Nouns',
+		'name': "Use 'all of' rather than 'all' for non-generic Nouns",
 		'trigger': { 'stem': 'all' },
 		'context': {
 			'followedby': { 'tag': 'determiner' },
 		},
 		'error': {
 			'followedby': 'of',
-			'message': 'Use \'all of\', unless the modified Noun is generic. See P1 Checklist 0.17.',
+			'message': "Use 'all of', unless the modified Noun is generic. See P1 Checklist 0.17.",
 		},
 		'comment': 'Catches "all the|these|those people" but allows "all people"',
 	},
@@ -399,65 +399,65 @@ const checker_rules_json = [
 			'notfollowedby': { 'category': 'Verb', 'skip': 'all' },
 		},
 		'error': {
-			'message': 'Must use \'{stem}\' with another Verb. See P1 Checklist 0.19.',
+			'message': "Must use '{stem}' with another Verb. See P1 Checklist 0.19.",
 		},
 		'comment': 'See section 0.19 of the Phase 1 checklist.',
 	},
 	{
-		'name': 'Must use \'X is able to\' instead of \'X can\'',
+		'name': "Must use 'X is able to' instead of 'X can'",
 		'trigger': { 'token': 'can' },
 		'error': {
-			'message': 'Use \'be able [to...]\' instead of \'can\'. See P1 Checklist 2.1.',
+			'message': "Use 'be able [to...]' instead of 'can'. See P1 Checklist 2.1.",
 		},
 		'comment': 'See section 2.1 of the Phase 1 checklist.',
 	},
 	{
-		'name': 'Cannot use \'could\' unless in a \'so\' adverbial clause',
+		'name': "Cannot use 'could' unless in a 'so' adverbial clause",
 		'trigger': { 'token': 'could' },
 		'context': {
 			'notprecededby': [{ 'token': '[', 'skip': { 'category': 'Conjunction' } }, { 'stem': 'so', 'skip': 'all' }],
 		},
 		'error': {
-			'message': 'Use \'be able [to...]\' instead of \'could\', unless in a \'so-that\' clause. See P1 Checklist 2.1.',
+			'message': "Use 'be able [to...]' instead of 'could', unless in a 'so-that' clause. See P1 Checklist 2.1.",
 		},
 		'comment': 'See section 2.1 of the Phase 1 checklist.',
 	},
 	{
-		'name': 'Cannot use \'is going to\' as a future marker',
+		'name': "Cannot use 'is going to' as a future marker",
 		'trigger': { 'token': 'going' },
 		'context': {
 			'followedby': [{ 'token': 'to' }, { 'category': 'Verb' }],
 		},
 		'error': {
-			'message': 'Use \'will {1:stem}\' instead of \'going to {1:token}\' to express future tense. See P1 Checklist 0.28.',
+			'message': "Use 'will {1:stem}' instead of 'going to {1:token}' to express future tense. See P1 Checklist 0.28.",
 		},
 		'comment': 'See section 0.28 of the Phase 1 checklist.',
 	},
 	{
-		'name': 'Cannot use \'is to {Verb}\' as an obligation',
+		'name': "Cannot use 'is to {Verb}' as an obligation",
 		'trigger': { 'stem': 'be' },
 		'context': {
 			'followedby': [{ 'token': 'to' }, { 'category': 'Verb' }],
 		},
 		'error': {
-			'message': 'Use \'will\', \'must\', or \'should\' instead of \'{token} to...\' to express a future obligation.',
+			'message': "Use 'will', 'must', or 'should' instead of '{token} to...' to express a future obligation.",
 		},
 	},
 	{
-		'name': 'Cannot use \'have to {Verb}\' as an obligation',
+		'name': "Cannot use 'have to {Verb}' as an obligation",
 		'trigger': { 'stem': 'have' },
 		'context': {
 			'followedby': [{ 'token': 'to' }, { 'category': 'Verb' }],
 		},
 		'error': {
-			'message': 'Use \'must\' or \'should\' instead of \'{token} to...\' to express an obligation.',
+			'message': "Use 'must' or 'should' instead of '{token} to...' to express an obligation.",
 		},
 	},
 	{
-		'name': 'Warn that \'come\' cannot be used for events, only things that move',
+		'name': "Warn that 'come' cannot be used for events, only things that move",
 		'trigger': { 'stem': 'come' },
 		'warning': {
-			'message': 'Note that \'come\' can only be used for things that move, NOT for events.',
+			'message': "Note that 'come' can only be used for things that move, NOT for events.",
 		},
 	},
 	{
@@ -487,23 +487,23 @@ const checker_rules_json = [
 			],
 		},
 		'suggest': {
-			'message': 'Consider writing \'{stem} X\' instead of \'X [{0:token} be {stem}]\'. The attributive adjective is generally preferred over a relative clause.',
+			'message': "Consider writing '{stem} X' instead of 'X [{0:token} be {stem}]'. The attributive adjective is generally preferred over a relative clause.",
 		},
 	},
 	{
-		'name': 'Check for an errant \'that\' in a complement clause',
+		'name': "Check for an errant 'that' in a complement clause",
 		'trigger': { 'tag': { 'clause_type': 'patient_clause_different_participant|agent_clause' } },
 		'context': {
 			'subtokens': { 'token': 'that', 'skip': 'clause_start' },
 		},
 		'suggest': {
 			'on': 'subtokens:0',
-			'message': 'Unless this \'that\' is supposed to be a demonstrative, consider removing it. Avoid using \'that\' as a complementizer in general.',
+			'message': "Unless this 'that' is supposed to be a demonstrative, consider removing it. Avoid using 'that' as a complementizer in general.",
 		},
 		'comment': 'While TBTA sometimes accepts it, using "that" as a complementizer is too inconsistent and so is not allowed in P1',
 	},
 	{
-		'name': 'Don\'t allow passives in \'same subject\' patient clauses',
+		'name': "Don't allow passives in 'same subject' patient clauses",
 		'trigger': { 'tag': { 'clause_type': 'patient_clause_same_participant' } },
 		'context': {
 			'precededby': { 'category': 'Verb', 'skip': 'all' },
@@ -516,7 +516,7 @@ const checker_rules_json = [
 		'comment': 'eg. John wanted XX[to be seen by Mary]XX.',
 	},
 	{
-		'name': 'Don\'t allow passives in \'in-order-to\' adverbial clauses',
+		'name': "Don't allow passives in 'in-order-to' adverbial clauses",
 		'trigger': { 'tag': { 'auxiliary': 'passive' } },
 		'context': {
 			'precededby': { 'stem': 'in-order-to', 'skip': 'all' },
@@ -687,7 +687,7 @@ const builtin_checker_rules = [
 			context: create_context_filter({}),
 			action: message_set_action(function* () {
 				yield { warning: 'The editor cannot determine which part of speech this word is, so some errors and warnings within the same clause may not be accurate.' }
-				yield { suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after '{token}' if you want the editor to check the syntax more accurately." }
+				yield { suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after '{token}' so the editor can check the syntax more accurately." }
 			}),
 		},
 	},
@@ -850,18 +850,18 @@ function* check_ontology_status(token) {
 	}
 
 	if (token.lookup_results.length === 0) {
-		yield { token_to_flag: token, warning: '\'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
+		yield { token_to_flag: token, warning: '\'{token}\' is not recognized. Consult the How-To document or consider using a different word.' }
 		yield { token_to_flag: token, warning: 'WARNING: Because this word is not recognized, errors and warnings within the same clause may not be accurate.' }
-		yield { token_to_flag: token, suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after the unknown word if you want the editor to check the syntax more accurately." }
+		yield { token_to_flag: token, suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after the unknown word so the editor can check the syntax more accurately." }
 
 	} else if (token.lookup_results.some(result => result.sense)) {
-		yield { token_to_flag: token, info: 'The {category} \'{stem}\' is not yet in the Ontology, but should be soon. Consult the How-To document for more info.' }
+		yield { token_to_flag: token, info: 'The {category} \'{stem}\' will be added to the Ontology in a future update. Consult the How-To document for more info.' }
 
 	} else if (token.lookup_results.some(result => result.how_to_entries.length > 0)) {
 		yield { token_to_flag: token, error: 'The {category} \'{stem}\' is not in the Ontology. Hover over the word for hints from the How-To document.' }
 		
 	} else {
 		// a dummy result for an unknown word
-		yield { token_to_flag: token, warning: 'The {category} \'{token}\' is not in the Ontology, or its form is not recognized. Consult the How-To document or consider using a different word.' }
+		yield { token_to_flag: token, warning: 'The {category} \'{token}\' is not recognized. Consult the How-To document or consider using a different word.' }
 	}
 }

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -192,6 +192,16 @@ const part_of_speech_rules_json = [
 		'comment': 'Daniel 3:4 The one official(N/Adj) shouted ...',
 	},
 	{
+		'name': 'If Noun-Adjective preceded and followed by "as", remove Noun',
+		'category': 'Noun|Adjective',
+		'context': {
+			'precededby': { 'stem': 'as' },
+			'followedby': { 'stem': 'as' },
+		},
+		'remove': 'Noun',
+		'comment': '...as good as...',
+	},
+	{
 		'name': 'If Noun-Adjective preceded by \'be\' or \'feel\', remove Noun',
 		'category': 'Noun|Adjective',
 		'context': {

--- a/src/lib/rules/transform_rules.js
+++ b/src/lib/rules/transform_rules.js
@@ -38,8 +38,8 @@ const transform_rules_json = [
 		'comment': '"prevent [X from Ving]", "forgive [X for Ving]". May be needed for other verbs as well',
 	},
 	{
-		'name': 'tag "in-order-to" and "by" as "same subject"',
-		'trigger': { 'stem': 'in-order-to|by' },
+		'name': 'tag "in-order-to/by/without" as "same subject"',
+		'trigger': { 'stem': 'in-order-to|by|without' },
 		'context': {
 			'precededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
 		},

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
 	let entered_text = $saved
 	$: checking = false
-	$: check_response = { has_error: false, tokens: [], back_translation: '' }
+	$: check_response = { status: 'ok', tokens: [], back_translation: '' }
 
 	async function check_text() {
 		checking = true
@@ -54,16 +54,23 @@
 		<Icon icon="line-md:loading-twotone-loop" class="h-16 w-16 text-warning" />
 	</div>
 {:else}
-	{@const { has_error, tokens, back_translation } = check_response}
-	{@const success = tokens.length > 0 && !has_error}
+	{@const { status, tokens, back_translation } = check_response}
 
-	<div class="divider my-12" class:divider-success={success} class:divider-error={has_error}>
-		{#if success}
+	{#if tokens.length === 0}
+		<div class="divider my-12"></div>
+	{:else if status === 'ok'}
+		<div class="divider divider-success my-12">
 			<Icon icon="mdi:check-circle" class="h-16 w-16 text-success" />
-		{:else if has_error}
+		</div>
+	{:else if status === 'error'}
+		<div class="divider divider-error my-12">
 			<Icon icon="mdi:close-circle" class="h-16 w-16 text-error" />
-		{/if}
-	</div>
+		</div>
+	{:else if status === 'warning'}
+		<div class="divider divider-warning my-12">
+			<Icon icon="mdi:alert-circle" class="h-16 w-16 text-warning" />
+		</div>
+	{/if}
 
 	<section class="prose flex max-w-none flex-wrap items-center justify-center gap-x-4 gap-y-8">
 		<Tokens {tokens} />

--- a/src/routes/check/api.d.ts
+++ b/src/routes/check/api.d.ts
@@ -1,8 +1,10 @@
 type CheckResponse = {
-	has_error: boolean
+	status: CheckStatus
 	tokens: SimpleToken[]
 	back_translation: string
 }
+
+type CheckStatus = 'ok' | 'error' | 'warning'
 
 type SimpleToken = TokenBase & {
 	lookup_results: SimpleLookupResult[]


### PR DESCRIPTION
### Improve/simplify some errors/warning
eg. 'John said.'
Before:
![image](https://github.com/user-attachments/assets/97e334f6-62fb-4247-8453-cdb8131d11a9)

After:
![image](https://github.com/user-attachments/assets/5ddb822e-6a52-4c35-b40a-452cf5d49edc)

### Show divider as 'warning' when one is present
I noticed sometimes warning messages got glossed over, and this brings them more to attention.
Before:
![image](https://github.com/user-attachments/assets/fddc6589-b5ee-4ee1-9910-0c2dd062b5ec)

After:
![image](https://github.com/user-attachments/assets/bcfe8142-3553-4673-86e1-acc6887b6ec0)

We may want to rethink the divider thing in general. We want the phase 1 people to understand that just because it passes the check doesn't mean it's perfect. And even if the editor shows errors, the text might still be ok.

### Fix an issue with passive-like verbs
Before (this should be accepted):
![image](https://github.com/user-attachments/assets/e0dc4300-fdcf-47c8-b6ac-18fc395141b8)

After:
![image](https://github.com/user-attachments/assets/c5acd2ab-e2e5-4ad0-b382-1ea893d9a5ba)

### Handle 'without' adverbial clause
eg. 'John slept [without eating].'
Before (should be accepted):
![image](https://github.com/user-attachments/assets/f5334281-fac7-4b76-b943-3cfc71bbcf6f)

After:
![image](https://github.com/user-attachments/assets/5ba9c42a-6d15-4946-bee9-c35a10ee299d)
