### PR TITLE
Re-add level 3 complex word check

### DIFF
--- a/src/routes/check/+server.js
+++ b/src/routes/check/+server.js
@@ -29,7 +29,7 @@ export async function GET({ url: { searchParams } }) {
  * @returns {CheckStatus}
  */
 function get_status(tokens) {
-	const all_messages = tokens.flatMap(token => [token, token.complex_pairing, token.pronoun, ...token.sub_tokens].flatMap(token => token?.messages ?? []))
+	const all_messages = tokens.flatMap(expand_token).flatMap(token => token.messages)
 	const has_error = all_messages.some(msg => msg.label === 'error')
 	const has_warning = all_messages.some(msg => msg.label === 'warning')
 
@@ -40,6 +40,23 @@ function get_status(tokens) {
 	}
 
 	return 'ok'
+}
+
+/**
+ * 
+ * @param {SimpleToken} token 
+ * @returns {SimpleToken[]}
+ */
+function expand_token(token) {
+	if (token.complex_pairing) {
+		return [token, token.complex_pairing]
+	} else if (token.pronoun) {
+		return [token, token.pronoun]
+	} else if (token.sub_tokens.length) {
+		return [token, ...token.sub_tokens.flatMap(expand_token)]
+	} else {
+		return [token]
+	}
 }
 
 /**


### PR DESCRIPTION
Resolves #151 

### Complex words outside of complex alternate, not nested (invalid)
- both level 3 and level 2 words should show an error
`Those people will not enter the kingdom-B with the righteous people.`
Before:
![image](https://github.com/user-attachments/assets/e952e8e9-8d78-484a-952a-b08cd49f0a6c)

After:
![image](https://github.com/user-attachments/assets/b1e821e7-d416-49af-a56f-93f1ddfe7d1f)

### Complex words outside of complex alternate, nested (invalid)
- both level 3 and level 2 words should show an error, even when in a subordinate clause
`Those people were not united by God with the people [who accepted God's message through-B faith].`
Before:
![image](https://github.com/user-attachments/assets/0a5dc28d-ec5e-4935-a812-9fcc82025bce)

After:
![image](https://github.com/user-attachments/assets/f91f9869-fac7-466c-8d7e-9366ff1acd5b)

### Complex words after a complex alternate (invalid)
- Make sure any state of tracking the complex alternate gets reset once outside the complex alternate
`(complex) Those people will not enter the kingdom-B with the people. (simple) Those people will not enter the kingdom-B with the people.`
Before:
![image](https://github.com/user-attachments/assets/e33eb328-276f-43fa-9904-353f35993a5b)

After:
![image](https://github.com/user-attachments/assets/d017faa7-e177-466e-9b30-ef5359683c58)

### Complex words inside a complex alternate, not nested (valid)
- Both level 3 and level 2 words are accepted in a complex alternate
`(complex) Those people will not enter the kingdom-B with the righteous people. (simple) Those people will not let [God rule those people].`
Before:
![image](https://github.com/user-attachments/assets/9b12f9b9-b45c-46eb-b5b5-a41f0476a703)

After:
![image](https://github.com/user-attachments/assets/f638c1fb-a89d-4157-9d93-c4e40e692de6)

### Complex words inside a complex alternate, nested (valid)
- both level 3 and level 2 words are accepted, even when in a subordinate clause
`(complex) Those people were not united by God with the righteous people [who accepted God's message through-B faith]. (simple) Those people did not believe the message [that those people heard] with the people [who accepted God's message].`
Before:
![image](https://github.com/user-attachments/assets/c536ece6-67b3-4e53-a3d0-ccb95628df1b)

After:
![image](https://github.com/user-attachments/assets/7e801f96-ec46-4010-bfe6-e1847b7f98fe)

### Complex words inside a subordinate complex alternate, nested (valid)
- The original sentence that presented the nesting as an issue.
`But the message was bad for those people [because (complex) those people were not united by God with the people [who accepted God's message through-B faith]] [because (simple) those people did not believe the message [that those people heard] with the people [who accepted God's message]].`

After:
![image](https://github.com/user-attachments/assets/89502d70-17a5-4423-a29f-23529254d3c3)
