### PR TITLE
Add more adj case frames

### DIFF
--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -1,5 +1,5 @@
 import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from '../common'
-import { by_adposition, by_clause_tag, by_complementizer, modified_noun_of_adjective, modified_noun_with_subgroup, unit_with_measure } from './presets'
+import { by_adposition, by_clause_tag, by_complementizer, by_same_participant_complementizer, modified_noun_of_adjective, modified_noun_with_subgroup, unit_with_measure } from './presets'
 
 /** @type {RoleRuleJson<AdjectiveRoleTag>} */
 const default_adjective_case_frame_json = {
@@ -7,6 +7,7 @@ const default_adjective_case_frame_json = {
 	'nominal_argument': { 'trigger': 'none' },
 	'patient_clause_different_participant': by_clause_tag('patient_clause_different_participant'),
 	'patient_clause_same_participant': by_clause_tag('patient_clause_same_participant'),
+	'modified_noun_with_subgroup': { 'trigger': 'none' },
 }
 
 /**
@@ -52,6 +53,16 @@ const adjective_case_frames = new Map([
 			'other_optional': 'modified_noun_with_subgroup',
 		}],
 	]],
+	['equal', [
+		['equal-A', { 'nominal_argument': by_adposition('to') }],
+	]],
+	['fair', [
+		['fair-A', {
+			'nominal_argument': by_adposition('to'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+	]],
 	['faithful', [
 		['faithful-B', { 'nominal_argument': by_adposition('to') }],
 		['faithful-C', { 'nominal_argument': by_adposition('with') }],
@@ -59,17 +70,67 @@ const adjective_case_frames = new Map([
 	['far', [
 		['far-A', { 'nominal_argument': by_adposition('from') }],
 	]],
+	['few', [
+		['few-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+		}],
+	]],
+	['full', [
+		['full-B', { 'nominal_argument': by_adposition('of') }],
+	]],
 	['gentle', [
 		['gentle-B', { 'nominal_argument': by_adposition('with|to') }],
+	]],
+	['guilty', [
+		['guilty-A', {
+			'nominal_argument': by_adposition('of'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+		['guilty-B', {
+			'patient_clause_same_participant': by_same_participant_complementizer('of'),
+			'patient_clause_different_participant': { 'trigger': 'none' },
+		}],
 	]],
 	['happy', [
 		['happy-A', { 'nominal_argument': by_adposition('with') }],
 	]],
+	['hard', [
+		['hard-B', {
+			'nominal_argument': by_adposition('for'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+	]],
+	['high', [
+		['high-A', {
+			'nominal_argument': unit_with_measure('length'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+	]],
 	['honest', [
 		['honest-A', { 'nominal_argument': by_adposition('with') }],
 	]],
+	['hundreds', [
+		['hundreds-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+			'comment': 'TODO remove when hundreds is marked as a Quantity',
+		}],
+	]],
 	['important', [
 		['important-A', { 'nominal_argument': by_adposition('to') }],
+	]],
+	['interested', [
+		['interested-A', {
+			'patient_clause_same_participant': [
+				by_clause_tag('patient_clause_same_participant'),
+				by_same_participant_complementizer('in'),
+			],
+			'patient_clause_different_participant': { 'trigger': 'none' },
+		}],
 	]],
 	['jealous', [
 		['jealous-A', { 'nominal_argument': by_adposition('of|by') }],
@@ -80,14 +141,42 @@ const adjective_case_frames = new Map([
 	['long', [
 		['long-C', { 'nominal_argument': unit_with_measure('length') }],
 	]],
+	['loyal', [
+		['loyal-B', { 'nominal_argument': by_adposition('to') }],
+	]],
 	['merciful', [
 		['merciful-B', { 'nominal_argument': by_adposition('to') }],
+	]],
+	['millions', [
+		['millions-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+			'comment': 'TODO remove when millions is marked as a Quantity',
+		}],
+	]],
+	['more', [
+		['more-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+		}],
+	]],
+	['most', [
+		['most-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+		}],
 	]],
 	['old', [
 		['old-B', { 'nominal_argument': unit_with_measure('time') }],
 	]],
 	['one', [
 		['one-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+		}],
+	]],
+	['other', [
+		['other-A', {
 			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
 			'other_optional': 'modified_noun_with_subgroup',
 		}],
@@ -116,6 +205,45 @@ const adjective_case_frames = new Map([
 		['sad-A', { 'nominal_argument': by_adposition('about') }],
 		['sad-B', { 'nominal_argument': by_adposition('for') }],
 	]],
+	['satisfied', [
+		['satisfied-A', {
+			'nominal_argument': by_adposition('with'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+	]],
+	['several', [
+		['several-A', {
+			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
+			'other_optional': 'modified_noun_with_subgroup',
+			'comment': 'TODO remove when several is marked as a Quantity',
+		}],
+	]],
+	['similar', [
+		['similar-A', {
+			'nominal_argument': by_adposition('to'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+	]],
+	['sorry', [
+		['sorry-A', {
+			'patient_clause_same_participant': [
+				by_same_participant_complementizer('for'),
+				by_clause_tag('patient_clause_same_participant|patient_clause_different_participant'),
+			],
+			'patient_clause_different_participant': { 'trigger': 'none' },
+			'other_optional': 'patient_clause_same_participant',
+			'comment': "support 'sorry [for doing X]', 'sorry [that they did X]', and 'sorry [to do X]'. TODO remove the 'other_optional' when the Ontology gets updated",
+		}],
+	]],
+	['surprised', [
+		['surprised-A', {
+			'nominal_argument': by_adposition('by'),
+			'other_optional': 'nominal_argument',
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+		}],
+	]],
 	['tall', [
 		['tall-A', { 'nominal_argument': unit_with_measure('length') }],
 	]],
@@ -124,7 +252,10 @@ const adjective_case_frames = new Map([
 		['upset-C', { 'nominal_argument': by_adposition('about') }],
 	]],
 	['wide', [
-		['wide-C', { 'nominal_argument': unit_with_measure('length') }],
+		['wide-B', { 'nominal_argument': unit_with_measure('length') }],
+	]],
+	['zealous', [
+		['zealous-A', { 'nominal_argument': by_adposition('for') }],
 	]],
 ])
 
@@ -196,7 +327,8 @@ function is_subgroupable_category(categorization) {
  */
 function get_adjective_default_rules(lookup) {
 	if (is_subgroupable_category(lookup.categorization)) {
-		return [...DEFAULT_CASE_FRAME_RULES, ...SUBGROUPABLE_CASE_FRAME_RULE]
+		const subgroup_index = DEFAULT_CASE_FRAME_RULES.findIndex(({ role_tag }) => role_tag === 'modified_noun_with_subgroup')
+		return DEFAULT_CASE_FRAME_RULES.with(subgroup_index, SUBGROUPABLE_CASE_FRAME_RULE[0])
 	}
 	
 	return DEFAULT_CASE_FRAME_RULES
@@ -216,7 +348,7 @@ function get_adjective_usage_info(categorization, role_rules) {
 	// treat all arguments as possible and not required
 	if (role_letters.length === 0) {
 		return {
-			possible_roles: [...ADJECTIVE_LETTER_TO_ROLE.values()],
+			possible_roles: DEFAULT_CASE_FRAME_RULES.map(({ role_tag }) => role_tag),
 			required_roles: [],
 		}
 	}

--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -74,6 +74,7 @@ const adjective_case_frames = new Map([
 		['few-A', {
 			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
 			'other_optional': 'modified_noun_with_subgroup',
+			'comment': 'TODO remove when few is marked as a Quantity',
 		}],
 	]],
 	['full', [
@@ -95,20 +96,6 @@ const adjective_case_frames = new Map([
 	]],
 	['happy', [
 		['happy-A', { 'nominal_argument': by_adposition('with') }],
-	]],
-	['hard', [
-		['hard-B', {
-			'nominal_argument': by_adposition('for'),
-			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
-		}],
-	]],
-	['high', [
-		['high-A', {
-			'nominal_argument': unit_with_measure('length'),
-			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
-		}],
 	]],
 	['honest', [
 		['honest-A', { 'nominal_argument': by_adposition('with') }],
@@ -164,6 +151,7 @@ const adjective_case_frames = new Map([
 		['most-A', {
 			'modified_noun_with_subgroup': modified_noun_with_subgroup(),
 			'other_optional': 'modified_noun_with_subgroup',
+			'comment': 'TODO remove when most is marked as a Quantity',
 		}],
 	]],
 	['old', [
@@ -238,13 +226,14 @@ const adjective_case_frames = new Map([
 		}],
 	]],
 	['surprised', [
-		['surprised-A', {
+		['surprised-C', {
 			'nominal_argument': by_adposition('by'),
 			'other_optional': 'nominal_argument',
 			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
 		}],
 	]],
 	['tall', [
+		// TODO change to tall-B when added to the Ontology
 		['tall-A', { 'nominal_argument': unit_with_measure('length') }],
 	]],
 	['upset', [

--- a/src/lib/rules/case_frame/adjectives/presets.js
+++ b/src/lib/rules/case_frame/adjectives/presets.js
@@ -35,7 +35,7 @@ export function by_adposition(adposition) {
 		}),
 		'argument_context_index': 1,
 		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
-		'context_transform': { 'function': { 'pre_np_adposition': 'adjective_argument', 'relation': '' } },	// make the adposition a function word and clear other tag values
+		'context_transform': { 'function': { 'pre_np_adposition': 'adjective_argument' }, 'remove_tag': 'relation' },	// make the adposition a function word and clear other tag values
 		'missing_message': `{sense} expects a nominal argument, i.e. '{stem} ${adposition} N'.`,
 	}
 }
@@ -68,6 +68,24 @@ export function by_complementizer(complementizer) {
 		},
 		'transform': { 'tag': { 'clause_type': 'patient_clause_different_participant', 'role': 'adjective_clausal_argument' } },
 		'subtoken_transform': { 'function': { 'syntax': 'complementizer' } },
+	}
+}
+
+/**
+ * 
+ * @param {string} complementizer 
+ * @returns {CaseFrameRuleJson}
+ */
+export function by_same_participant_complementizer(complementizer) {
+	return {
+		'trigger': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': 'adverbial_clause|patient_clause_different_participant' } },
+		'context': {
+			'subtokens': { 'token': complementizer, 'skip': 'clause_start' },
+		},
+		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'adjective_clausal_argument' } },
+		'subtoken_transform': { 'function': { 'syntax': 'infinitive_same_subject' } },
+		'missing_message': "The patient clause for {sense} should be written like '{stem} [in singing]').",
+		'comment': "need to set to 'infinitive_same_subject' so that the clause is skipped for verb case frame checking"
 	}
 }
 

--- a/src/lib/rules/case_frame/sense_selection.js
+++ b/src/lib/rules/case_frame/sense_selection.js
@@ -272,11 +272,20 @@ const adjective_sense_priority_overrides = [
 		// When faithful-C has a nominal argument, it should be prioritized over -A
 		['faithful-C', { 'nominal_argument': { } }],
 	]],
+	['full', [['full-B', { }]]],
 	['gentle', [['gentle-B', { }]]],
+	['hard', [
+		// Only when hard-B has a nominal argument should it be prioritized over hard-A
+		['hard-B', { 'nominal_argument': { } }],
+	]],
 	['kind', [['kind-B', { }]]],
 	['long', [
 		['long-C', { }],
 		['long-B', { 'nominal_argument': { 'stem': 'time' } }],
+	]],
+	['loyal', [
+		// Only when loyal-B has a nominal argument should it be prioritized over loyal-A
+		['loyal-B', { 'nominal_argument': { } }],
 	]],
 	['merciful', [['merciful-B', { }]]],
 	['old', [['old-B', { }]]],

--- a/src/lib/rules/case_frame/sense_selection.js
+++ b/src/lib/rules/case_frame/sense_selection.js
@@ -274,10 +274,6 @@ const adjective_sense_priority_overrides = [
 	]],
 	['full', [['full-B', { }]]],
 	['gentle', [['gentle-B', { }]]],
-	['hard', [
-		// Only when hard-B has a nominal argument should it be prioritized over hard-A
-		['hard-B', { 'nominal_argument': { } }],
-	]],
 	['kind', [['kind-B', { }]]],
 	['long', [
 		['long-C', { }],
@@ -296,6 +292,7 @@ const adjective_sense_priority_overrides = [
 		// Only when sad-B has a nominal argument should it be prioritized over sad-A
 		['sad-B', { 'nominal_argument': { } }],
 	]],
+	['surprised', [['surprised-C', { }]]],
 	['upset', [
 		['upset-B', { }],
 		['upset-C', { }],

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -143,6 +143,16 @@ const part_of_speech_rules_json = [
 		'comment': 'Dan. 1:12 Please give only(Adj/Adv) vegetables ...  Paul like most(Adj/Adv) books.',
 	},
 	{
+		'name': 'If Adverb-Adjective "hard" preceded by "be", remove Adverb',
+		'category': 'Adverb|Adjective',
+		'trigger': { 'stem': 'hard' },
+		'context': {
+			'precededby': { 'stem': 'be', 'skip': 'adjp_modifiers_attributive' },
+		},
+		'remove': 'Adverb',
+		'comment': 'Those things are hard(Adv/Adj) for John.',
+	},
+	{
 		'name': 'If Adverb-Adjective followed by a Verb or Adposition, remove Adjective',
 		'category': 'Adverb|Adjective',
 		'context': {
@@ -150,6 +160,15 @@ const part_of_speech_rules_json = [
 		},
 		'remove': 'Adjective',
 		'comment': 'John only(Adv/Adj) saw a book.  Believe more(Adv/Adj) in Jesus.',
+	},
+	{
+		'name': 'If Adverb-Adjective followed by "of", remove Adverb',
+		'category': 'Adverb|Adjective',
+		'context': {
+			'followedby': { 'token': 'of' },
+		},
+		'remove': 'Adverb',
+		'comment': 'John saw most(Adj/Adv) of those people.',
 	},
 	{
 		'name': 'If Noun-Adjective followed by Noun, remove Noun',
@@ -277,12 +296,12 @@ const part_of_speech_rules_json = [
 		'comment': 'The man left the house.',
 	},
 	{
-		'name': '\'pleased\' followed by \'with\' is the Adjective',
+		'name': "'pleased/satisfied' followed by 'with' is the Adjective",
 		'category': 'Verb|Adjective',
-		'trigger': { 'token': 'pleased' },
+		'trigger': { 'token': 'pleased|satisfied' },
 		'context': { 'followedby': { 'token': 'with' } },
 		'remove': 'Verb',
-		'comment': 'Luke 3:22 I am pleased(V/Adj) with you.',
+		'comment': 'Luke 3:22 I am pleased(V/Adj) with you. Proverbs 30:16 ..never satisfied(V/Adj) with water.',
 	},
 	{
 		'name': 'If amazed/surprised NOT followed by any Noun, remove the Verb',

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -143,14 +143,24 @@ const part_of_speech_rules_json = [
 		'comment': 'Dan. 1:12 Please give only(Adj/Adv) vegetables ...  Paul like most(Adj/Adv) books.',
 	},
 	{
-		'name': 'If Adverb-Adjective "hard" preceded by "be", remove Adverb',
+		'name': 'If Adverb-Adjective "hard" is preceded by "be/become", remove Adverb',
 		'category': 'Adverb|Adjective',
 		'trigger': { 'stem': 'hard' },
 		'context': {
-			'precededby': { 'stem': 'be', 'skip': 'adjp_modifiers_attributive' },
+			'precededby': { 'stem': 'be|become', 'skip': 'adjp_modifiers_attributive' },
 		},
 		'remove': 'Adverb',
 		'comment': 'Those things are hard(Adv/Adj) for John.',
+	},
+	{
+		'name': 'If Adverb-Adjective "hard" is directly preceded by any other verb, remove Adjective',
+		'category': 'Adverb|Adjective',
+		'trigger': { 'stem': 'hard' },
+		'context': {
+			'precededby': { 'category': 'Verb' },
+		},
+		'remove': 'Adjective',
+		'comment': 'John worked hard(Adv/Adj).',
 	},
 	{
 		'name': 'If Adverb-Adjective followed by a Verb or Adposition, remove Adjective',

--- a/src/lib/rules/transform_rules.js
+++ b/src/lib/rules/transform_rules.js
@@ -217,7 +217,7 @@ const transform_rules_json = [
 		'comment': 'Setting up for the case frame rules',
 	},
 	{
-		'name': 'tag \'that\' at the beginning of a main clause as remove_demonstrative when followed by a noun',
+		'name': 'tag \'that\' at the beginning of a main clause as a determiner when followed by a noun',
 		'trigger': { 'token': 'That|that' },
 		'context': {
 			'notprecededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },


### PR DESCRIPTION
Added support for more adjectives with nominal and clause arguments.

See full-B for example.
Before:
![image](https://github.com/user-attachments/assets/f04875e5-df3a-4b5a-82ae-6732d22d0d33)

After:
![image](https://github.com/user-attachments/assets/9829b4da-68c8-4ca1-a29e-cfa5f94230be)


Some of these rules will be able to be removed/updated when the Ontology is next updated - Tod has already made the changes on his machine. They are marked as TODOs within the code.

Also improved a couple part-of-speech disambiguations.