### PR TITLE
157 minor fixes

### DIFF
--- a/src/lib/backtranslator/structural_rules.js
+++ b/src/lib/backtranslator/structural_rules.js
@@ -61,6 +61,31 @@ const structural_rules_json = [
 		},
 	},
 	{
+		name: 'insert "that" into some agent clauses',
+		comment: '',
+		rule: {
+			trigger: create_token_filter({ 'tag': { 'clause_type': 'agent_clause' } }),
+			context: create_context_filter({
+				// only agent clauses preceded by the agentive 'it' (eg. It is true [John saw Mary])
+				'precededby': { 'tag': { 'syntax': 'agent_proposition_subject' }, 'skip': 'all' },
+			}),
+			action: simple_rule_action(({ trigger_token }) => {
+				const that_index = get_index_for_that()
+				trigger_token.sub_tokens.splice(that_index, 0, create_token('that', TOKEN_TYPE.FUNCTION_WORD))
+
+				function get_index_for_that() {
+					// Put the 'that' after a conjunction, if present. eg 'It is true that Y and that Z.'
+					const first_word_index = trigger_token.sub_tokens.findIndex(create_token_filter({ 'type': TOKEN_TYPE.LOOKUP_WORD }))
+					if (first_word_index !== -1 && create_token_filter({ 'category': 'Conjunction' })(trigger_token.sub_tokens[first_word_index])) {
+						return first_word_index + 1
+					} else {
+						return 1
+					}
+				}
+			}),
+		},
+	},
+	{
 		name: 'Add commas around descriptive relative clauses, headed by level 4 words',
 		comment: '',
 		rule: {
@@ -458,6 +483,9 @@ function fix_capitalization(old_tokens, new_tokens, decapitalize=false) {
 	const new_first_word = find_next_word(new_tokens, 0)
 	if (new_first_word) {
 		new_first_word.token = capitalize_token(new_first_word)
+		if (new_first_word.complex_pairing) {
+			new_first_word.complex_pairing.token = capitalize_token(new_first_word.complex_pairing)
+		}
 	}
 
 	/**

--- a/src/lib/backtranslator/structural_rules.js
+++ b/src/lib/backtranslator/structural_rules.js
@@ -238,6 +238,12 @@ const structural_rules_json = [
 				// move 'of' to the end of the inner phrase and add the implicit markers
 				const inner_phrase_start = find_phrase_start(tokens, of_index)
 				const inner_phrase_end = find_phrase_end(tokens, of_index)
+
+				if (inner_phrase_start === -1 || inner_phrase_end === -1) {
+					// the 'of' was found outside an NP, and continuing may cause errors
+					return trigger_index + 1
+				}
+
 				const new_inner_phrase = [
 					...is_literal ? [] : [create_token('<<', TOKEN_TYPE.PUNCTUATION)],
 					...tokens.slice(inner_phrase_start, of_index),

--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -60,7 +60,7 @@ const adjective_case_frames = new Map([
 		['fair-A', {
 			'nominal_argument': by_adposition('to'),
 			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated',
 		}],
 	]],
 	['faithful', [
@@ -87,7 +87,7 @@ const adjective_case_frames = new Map([
 		['guilty-A', {
 			'nominal_argument': by_adposition('of'),
 			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated',
 		}],
 		['guilty-B', {
 			'patient_clause_same_participant': by_same_participant_complementizer('of'),
@@ -197,7 +197,7 @@ const adjective_case_frames = new Map([
 		['satisfied-A', {
 			'nominal_argument': by_adposition('with'),
 			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated',
 		}],
 	]],
 	['several', [
@@ -211,7 +211,7 @@ const adjective_case_frames = new Map([
 		['similar-A', {
 			'nominal_argument': by_adposition('to'),
 			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated',
 		}],
 	]],
 	['sorry', [
@@ -229,7 +229,7 @@ const adjective_case_frames = new Map([
 		['surprised-C', {
 			'nominal_argument': by_adposition('by'),
 			'other_optional': 'nominal_argument',
-			'comment': 'TODO remove the "other_optional" when the Ontology gets updated'
+			'comment': 'TODO remove the "other_optional" when the Ontology gets updated',
 		}],
 	]],
 	['tall', [

--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -113,8 +113,8 @@ const adjective_case_frames = new Map([
 	['interested', [
 		['interested-A', {
 			'patient_clause_same_participant': [
-				by_clause_tag('patient_clause_same_participant'),
 				by_same_participant_complementizer('in'),
+				by_clause_tag('patient_clause_same_participant'),
 			],
 			'patient_clause_different_participant': { 'trigger': 'none' },
 		}],

--- a/src/lib/rules/case_frame/adjectives/presets.js
+++ b/src/lib/rules/case_frame/adjectives/presets.js
@@ -36,7 +36,7 @@ export function by_adposition(adposition) {
 		'argument_context_index': 1,
 		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
 		'context_transform': { 'function': { 'pre_np_adposition': 'adjective_argument' }, 'remove_tag': 'relation' },	// make the adposition a function word and clear other tag values
-		'missing_message': `{sense} expects a nominal argument, i.e. '{stem} ${adposition} N'.`,
+		'missing_message': `'{stem} ${adposition} N'`,
 	}
 }
 
@@ -84,7 +84,7 @@ export function by_same_participant_complementizer(complementizer) {
 		},
 		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'adjective_clausal_argument' } },
 		'subtoken_transform': { 'function': { 'syntax': 'infinitive_same_subject' } },
-		'missing_message': "The patient clause for {sense} should be written like '{stem} [in singing]').",
+		'missing_message': `'[${complementizer} Verb-ing]'`,
 		'comment': "need to set to 'infinitive_same_subject' so that the clause is skipped for verb case frame checking"
 	}
 }
@@ -117,7 +117,7 @@ export function unit_with_measure(unit_type) {
 		}),
 		'transform': { 'tag': { 'role': 'adjective_nominal_argument', 'syntax': 'nested_np' } },
 		'main_word_tag': { 'adj_type': 'measure' },
-		'missing_message': `{sense} must be in the format 'N X {stem}' where N is a number/quantity and X is a unit of ${unit_type}.`,
+		'missing_message': `write 'N X {stem}' where N is a number/quantity and X is a unit of ${unit_type}`,
 	}
 }
 

--- a/src/lib/rules/case_frame/adjectives/presets.js
+++ b/src/lib/rules/case_frame/adjectives/presets.js
@@ -85,7 +85,7 @@ export function by_same_participant_complementizer(complementizer) {
 		'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'adjective_clausal_argument' } },
 		'subtoken_transform': { 'function': { 'syntax': 'infinitive_same_subject' } },
 		'missing_message': `'[${complementizer} Verb-ing]'`,
-		'comment': "need to set to 'infinitive_same_subject' so that the clause is skipped for verb case frame checking"
+		'comment': "need to set to 'infinitive_same_subject' so that the clause is skipped for verb case frame checking",
 	}
 }
 

--- a/src/lib/rules/case_frame/adpositions/presets.js
+++ b/src/lib/rules/case_frame/adpositions/presets.js
@@ -9,7 +9,6 @@ export function opening_subordinate_clause() {
 		}),
 		'tag_role': false,
 		'main_word_tag': { 'syntax': 'adverbial_clause_adposition' },
-		'missing_message': "Missing '[' bracket before adverbial clause.",
 	}
 }
 
@@ -24,7 +23,6 @@ export function head_noun() {
 		}),
 		'tag_role': false,
 		'main_word_tag': { 'pre_np_adposition': 'oblique' },
-		'missing_message': 'Could not find the Noun associated with this Adposition.',
 	}
 }
 
@@ -39,7 +37,7 @@ export function head_noun_post() {
 		}),
 		'tag_role': false,
 		'main_word_tag': { 'post_np_adposition': 'oblique' },
-		'missing_message': 'Could not find the Noun associated with this Adposition.',
+		'missing_message': "'X {stem}'",
 	}
 }
 

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -1,6 +1,6 @@
 import { TOKEN_TYPE } from '$lib/token'
 import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from '../common'
-import { by_adposition, by_clause_tag, by_complementizer, by_relative_context, directly_after_verb, directly_after_verb_with_adposition, directly_before_verb, patient_from_subordinate_clause, predicate_adjective, with_be_auxiliary } from './presets'
+import { by_adposition, by_clause_tag, by_complementizer, by_relative_context, directly_after_verb, directly_after_verb_with_adposition, directly_before_verb, patient_from_subordinate_clause, predicate_adjective, with_be_auxiliary, with_no_double_patient } from './presets'
 
 /** @type {RoleRuleJson<VerbRoleTag>} */
 const default_verb_case_frame_json = {
@@ -17,7 +17,7 @@ const default_verb_case_frame_json = {
 		'trigger': { 'tag': { 'syntax': 'head_np' } },
 		'context': { 'precededby': { 'token': 'from', 'type': TOKEN_TYPE.FUNCTION_WORD, 'skip': 'np_modifiers' } },
 		'context_transform': { 'function': { 'pre_np_adposition': 'verb_argument' } },
-		'missing_message': `Couldn't find the source, which in this case should have 'from' before it.`,
+		'missing_message': "'from X'",
 		'comment': "Can't use by_adposition() because we also need to specify that 'from' has to be a function word. It's the same otherwise",
 	},
 	'destination': by_adposition('to'),
@@ -110,7 +110,6 @@ const verb_case_frames = new Map([
 					'notfollowedby': { 'category': 'Noun', 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' },
 				},
 				'transform': { 'tag': { 'role': 'patient' } },
-				'missing_message': "ask-A should be written in the format 'X asked (destination) (patient)' e.g. 'John asked Mary a question'.",
 			},
 			'destination': [
 				by_adposition('to'),
@@ -140,11 +139,11 @@ const verb_case_frames = new Map([
 			'patient_clause_different_participant': [
 				{
 					...by_clause_tag('patient_clause_different_participant'),
-					'missing_message': "ask-F should be written in the format 'asked X [(if//whether) ...]' (with or without the if/whether)",
+					'missing_message': "'[(if//whether) ...]', with or without the if/whether",
 				},
 				by_complementizer('if|whether'),
 			],
-			'comment': "This can be written as 'asked X [(if//whether) ...]' (with or without the if/whether)",
+			'comment': "This can be written as 'asked X [(if//whether) ...]', with or without the if/whether",
 		}],
 	]],
 	['attack', []],
@@ -164,7 +163,7 @@ const verb_case_frames = new Map([
 						{ 'category': 'Verb', 'skip': ['vp_modifiers', 'np_modifiers'] },
 					],
 				},
-				'missing_message': 'be-E requires the format \'there be X\'.',
+				'missing_message': "'there be X'",
 			},
 			'state': { 'trigger': 'none' },
 		}],
@@ -190,25 +189,25 @@ const verb_case_frames = new Map([
 		['be-J', {
 			'agent': {
 				...directly_before_verb({ 'stem': 'date' }),
-				'missing_message': 'be-J requires the format \'The date be X\'.',
+				'missing_message': "write 'The date be X'",
 			},
 		}],
 		['be-K', {
 			'agent': {
 				...directly_before_verb({ 'stem': 'name' }),
-				'missing_message': 'be-K requires the format "X\'s name be Y" or "The name of X be Y".',
+				'missing_message': "write 'X's name be Y' or 'The name of X be Y'",
 			},
 		}],
 		['be-N', {
 			'agent': {
 				...directly_before_verb({ 'stem': 'time' }),
-				'missing_message': 'be-N requires the format \'The time be X\' where X is a temporal noun (eg 4PM//morning).',
+				'missing_message': "write 'The time be X' where X is a temporal noun like 4PM or morning",
 			},
 		}],
 		['be-O', {
 			'agent': {
 				...directly_before_verb({ 'stem': 'weather' }),
-				'missing_message': 'be-O requires the format \'The weather be X\' where X can be a noun (eg rain) or adjective (eg hot).',
+				'missing_message': "write 'The weather be X' where X can be a noun (eg rain) or adjective (eg hot)",
 			},
 			'other_optional': 'predicate_adjective',
 		}],
@@ -225,14 +224,14 @@ const verb_case_frames = new Map([
 		['be-R', {
 			'state': {
 				...directly_after_verb_with_adposition('part'),
-				'missing_message': 'be-R requires the format \'X be part of Y\'',
+				'missing_message': "'X be part of Y'",
 			},
 		}],
 		['be-S', {
 			'predicate_adjective': {
 				'trigger': { 'stem': 'old' },
 				'context': { 'precededby': [{ 'category': 'Adjective' }, { 'stem': 'year|month|day' }] },
-				'missing_message': 'be-S requires the format \'be X years//months//etc old(-B)\'.',
+				'missing_message': "'be X years//months//etc old(-B)'",
 			},
 			'other_required': 'predicate_adjective',
 			'comment': "clear the 'state' argument so it doesn't get triggered by 'year/month/day' etc. 'old' is the predicate adjective.",
@@ -258,7 +257,7 @@ const verb_case_frames = new Map([
 		['become-F', {
 			'agent': {
 				...directly_before_verb({ 'stem': 'weather' }),
-				'missing_message': 'become-F requires the format \'The weather be X\' where X can be a noun (eg rain) or adjective (eg hot).',
+				'missing_message': "write 'The weather be X' where X can be a noun (eg rain) or adjective (eg hot)",
 			},
 			'other_optional': 'predicate_adjective',
 		}],
@@ -363,11 +362,11 @@ const verb_case_frames = new Map([
 				'mind': {
 					...directly_after_verb({ 'stem': 'mind' }),
 					'transform': { 'function': { 'syntax': 'extra_patient' } },
-					'missing_message': "Write 'change X's mind' for change-B",
+					'missing_message': "write 'change X's mind'",
 				},
 			},
 			'other_required': 'mind',
-			'comment': "'mind' ban be included in the phase 1 (eg. Pharoah changed Pharoah's mind) but it is not included in the semantic representation.",
+			'comment': "'mind' can be included in the phase 1 (eg. Pharoah changed Pharoah's mind) but it is not included in the semantic representation.",
 		}],
 		['change-C', { 'destination': by_adposition('to|into') }],
 		['change-E', { 'destination': by_adposition('to|into') }],
@@ -497,12 +496,9 @@ const verb_case_frames = new Map([
 		['gather-B', { 'instrument': by_adposition('with') }],
 	]],
 	['give', [
-		['give-A', {
-			'patient': {
-				...directly_after_verb(),
-				'missing_message': "'give' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
-			},
-		}],
+		['give-A', with_no_double_patient()],
+		['give-B', with_no_double_patient()],
+		['give-C', with_no_double_patient()],
 	]],
 	['go', []],
 	['grow', [
@@ -663,26 +659,17 @@ const verb_case_frames = new Map([
 		['see-B', { 'other_optional': 'patient_clause_simultaneous' }],
 	]],
 	['send', [
-		['send-B', {
-			'patient': {
-				...directly_after_verb(),
-				'missing_message': "'send' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
-			},
-		}],
-		['send-C', {
-			'patient': {
-				...directly_after_verb(),
-				'missing_message': "'send' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
-			},
-		}],
+		['send-A', with_no_double_patient()],
+		['send-B', with_no_double_patient()],
+		['send-C', with_no_double_patient()],
 	]],
 	['speak', [
 		['speak-A', {
-			'patient': by_adposition('about') ,
+			'patient': by_adposition('about'),
 			'instrument': by_adposition('in'),	// in a language
 			'other_rules': {
 				'extra_patient': {
-					'directly_after_verb': { },
+					...directly_after_verb(),
 					'extra_message': 'speak-A cannot be used with a regular object. The patient is expressed as \'speak about X\'',
 				},
 			},
@@ -725,7 +712,7 @@ const verb_case_frames = new Map([
 					'precededby': { 'token': 'about' },
 				},
 				'context_transform': { 'function': {} },
-				'missing_message': "think-D should be written in the format 'think about [Verb-ing]'",
+				'missing_message': "write 'think about [Verb-ing]'",
 			},
 			'patient_clause_different_participant': {
 				...by_clause_tag('patient_clause_different_participant'),
@@ -896,6 +883,7 @@ function get_verb_usage_info(categorization, role_rules) {
 	const required_roles = role_letters
 		.map(c => VERB_LETTER_TO_ROLE.get(c))
 		.map(role => role === 'patient_clause' ? patient_clause_type : role)
+		.filter(role => role !== 'beneficiary')	// beneficiaries are never required
 		.concat(role_rules.other_required)
 		.filter(role => role)
 
@@ -911,11 +899,9 @@ export function check_verb_case_frames_passive(trigger_context) {
 	const passive_rules_json = {
 		'patient': {
 			...directly_before_verb(),
-			'missing_message': 'A patient is required, which goes before the Verb in the passive.',
 		},
 		'agent': {
 			...by_adposition('by'),
-			'missing_message': 'An agent is required, which for a passive is preceded by \'by\'.',
 		},
 	}
 	const passive_rules = Object.entries(passive_rules_json)

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -298,7 +298,7 @@ const verb_case_frames = new Map([
 	]],
 	['blow', []],
 	['born', [
-		['born-A', with_be_auxiliary()]
+		['born-A', with_be_auxiliary()],
 	]],
 	['break', [
 		['break-A', { 'destination': by_adposition('to|into') }],

--- a/src/lib/rules/case_frame/verbs/presets.js
+++ b/src/lib/rules/case_frame/verbs/presets.js
@@ -8,7 +8,7 @@ export function patient_from_subordinate_clause() {
 	return {
 		'patient': {
 			...by_clause_tag('patient_clause_different_participant'),
-			'missing_message': "{sense} should be written in the format 'X {stem} [Y to Verb]'.",
+			'missing_message': "write 'X {stem} [Y to Verb]'",
 		},
 		'other_rules': {
 			'extra_patient': {
@@ -42,6 +42,22 @@ export function with_be_auxiliary() {
 
 /**
  * 
+ * @returns {SenseRuleJson<VerbRoleTag>}
+ */
+export function with_no_double_patient() {
+	return {
+		'other_rules': {
+			'double_patient': {
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': { 'precededby': { 'tag': { 'syntax': 'head_np' }, 'skip': 'np_modifiers' } },
+				'extra_message': "'{stem}' requires the patient to immediately follow the Verb. Make sure to use 'to X' for the destination.",
+			},
+		},
+	}
+}
+
+/**
+ * 
  * @param {string} adposition 
  * @returns {CaseFrameRuleJson}
  */
@@ -50,7 +66,7 @@ export function by_adposition(adposition) {
 		'trigger': { 'tag': { 'syntax': 'head_np' } },
 		'context': { 'precededby': { 'token': adposition, 'skip': 'np_modifiers' } },
 		'context_transform': { 'function': { 'pre_np_adposition': 'verb_argument' } },
-		'missing_message': `Couldn't find the {role}, which in this case should have '${adposition}' before it.`,
+		'missing_message': `'${adposition} X'`,
 	}
 }
 
@@ -78,6 +94,7 @@ export function by_complementizer(complementizer) {
 		},
 		'transform': { 'tag': { 'clause_type': 'patient_clause_different_participant', 'role': 'patient_clause_different_participant' } },
 		'subtoken_transform': { 'function': { 'syntax': 'complementizer' } },
+		'missing_message': `'[${complementizer} ...]'`,
 	}
 }
 
@@ -126,7 +143,7 @@ export function directly_after_verb_with_adposition(adposition) {
 		}),
 		'argument_context_index': 1,
 		'context_transform': { 'function': { 'pre_np_adposition': 'verb_argument' } },	// make the adposition a function word
-		'missing_message': `Couldn't find the {role}, which for {sense} should have '${adposition}' before it.`,
+		'missing_message': `'${adposition} X'`,
 	}
 }
 

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -348,7 +348,7 @@ const checker_rules_json = [
 		'comment': 'See section 0.41 of the Phase 1 checklist',
 	},
 	{
-		'name': "Don\'t allow 'where' as a relativizer",
+		'name': "Don't allow 'where' as a relativizer",
 		'trigger': { 'token': 'where' },
 		'context': {
 			'precededby': { 'token': '[' },
@@ -360,7 +360,7 @@ const checker_rules_json = [
 		'comment': 'See section 0.8 of the Phase 1 checklist',
 	},
 	{
-		'name': "Don\'t allow 'when' as a relativizer",
+		'name': "Don't allow 'when' as a relativizer",
 		'trigger': { 'type': TOKEN_TYPE.CLAUSE },
 		'context': {
 			'precededby': { 'token': 'time' },
@@ -565,9 +565,9 @@ const checker_rules_json = [
 			'notprecededby': { 'stem': 'be', 'skip': 'all' },
 		},
 		'error': {
-			'message': "Adjectives cannot be negated. Negate the Verb instead or find another way to word it.",
+			'message': 'Adjectives cannot be negated. Negate the Verb instead or find another way to word it.',
 		},
-		'comment': 'eg. "Not all of the people of Israel are true people of God." But something like "John is not happy" is still valid.'
+		'comment': 'eg. "Not all of the people of Israel are true people of God." But something like "John is not happy" is still valid.',
 	},
 ]
 

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -457,13 +457,6 @@ const checker_rules_json = [
 		'comment': "The 'have' verb is already a function token, and so we can't use 'stem'",
 	},
 	{
-		'name': "Warn that 'come' cannot be used for events, only things that move",
-		'trigger': { 'stem': 'come' },
-		'warning': {
-			'message': "Note that 'come' can only be used for things that move, NOT for events.",
-		},
-	},
-	{
 		'name': 'Cannot have two conjunctions to begin a sentence',
 		'trigger': { 'category': 'Conjunction' },
 		'context': {

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -557,6 +557,18 @@ const checker_rules_json = [
 			'message': "For literal/dynamic expansions, write 'X of Y {token}' instead of 'X Y of {token}'.",
 		},
 	},
+	{
+		'name': 'Check for negation on Adjectives',
+		'trigger': { 'tag': { 'verb_polarity': 'negative' } },
+		'context': {
+			'followedby': { 'category': 'Adjective', 'skip': 'adjp_modifiers_attributive' },
+			'notprecededby': { 'stem': 'be', 'skip': 'all' },
+		},
+		'error': {
+			'message': "Adjectives cannot be negated. Negate the Verb instead or find another way to word it.",
+		},
+		'comment': 'eg. "Not all of the people of Israel are true people of God." But something like "John is not happy" is still valid.'
+	},
 ]
 
 /** @type {BuiltInRule[]} */

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -546,6 +546,17 @@ const checker_rules_json = [
 		},
 		'comment': "See Phase 1 Checklist section 27. eg 'John did not go [in-order-to buy food].' - does this mean he didn't go at all or he went for a different reason?",
 	},
+	{
+		'name': "Check for if 'of' is in the wrong place before a _literalExpansion/_dynamicExpansion token",
+		'trigger': { 'token': '_literalExpansion|_dynamicExpansion' },
+		'context': {
+			'precededby': { 'token': 'of' },
+		},
+		'error': {
+			'on': 'context:0',
+			'message': "For literal/dynamic expansions, write 'X of Y {token}' instead of 'X Y of {token}'.",
+		},
+	},
 ]
 
 /** @type {BuiltInRule[]} */

--- a/src/lib/rules/lookup_rules.js
+++ b/src/lib/rules/lookup_rules.js
@@ -1,5 +1,5 @@
 import { create_context_filter, create_token_filter } from '$lib/rules/rules_parser'
-import { TOKEN_TYPE, split_stem_and_sense } from '../token'
+import { TOKEN_TYPE } from '../token'
 
 /**
  * These words/phrases (and some others) are accepted by the Analyzer as alternates for

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -444,14 +444,14 @@ const part_of_speech_rules_json = [
 			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
 		},
 		'remove': 'Noun',
-		'comment': 'eg. On that day...'
+		'comment': 'eg. On that day...',
 	},
 	{
 		'name': 'If Noun-Adposition "On" is followed by anything else, remove Adposition',
 		'category': 'Noun|Adposition',
 		'trigger': { 'token': 'On' },
 		'remove': 'Adposition',
-		'comment': 'eg. On saw a lion.'
+		'comment': 'eg. On saw a lion.',
 	},
 ]
 

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -120,18 +120,26 @@ const part_of_speech_rules_json = [
 		'comment': 'Preceded by a Verb: Daniel 3:2 people that collect tax(N/V)... Sometimes wrongly selects Noun when preceded by "be": You(people) should be teaching(N/V) other people about those things. (handled in a hard-coded rule)',
 	},
 	{
-		'name': 'If Adposition-Conjunction is the first word of a sentence, remove Adposition',
+		'name': 'If Adposition-Conjunction "so/instead" is the first word of a sentence, remove Adposition',
 		'category': 'Adposition|Conjunction',
-		'trigger': { 'tag': { 'position': 'first_word' }, 'stem': 'so' },
+		'trigger': { 'tag': { 'position': 'first_word' }, 'stem': 'so|instead' },
 		'remove': 'Adposition',
 		'comment': 'only for \'so\'. \'for\' might be the \'for each...\' sense',
 	},
 	{
-		'name': 'If "so/for" appears anywhere else in the sentence, remove Conjunction',
+		'name': 'If Adposition-Conjunction is the first word of a (non-quote) subordinate clause, remove Conjunction',
 		'category': 'Adposition|Conjunction',
-		'trigger': { 'token': 'so|so-that|for' },
+		'context': {
+			'precededby': { 'token': '[', 'skip': { 'category': 'Conjunction' } },
+		},
 		'remove': 'Conjunction',
-		'comment': 'This relies on the fact these conjunctions must be the first word and therefore capitalized',
+	},
+	{
+		'name': 'If Adposition-Conjunction "for" appears anywhere else in the sentence, remove Conjunction',
+		'category': 'Adposition|Conjunction',
+		'trigger': { 'token': 'for' },
+		'remove': 'Conjunction',
+		'comment': 'This relies on the fact the conjunction must be the first word and therefore capitalized',
 	},
 	{
 		'name': 'If Adverb-Adjective followed by Noun, remove Adverb',
@@ -427,6 +435,23 @@ const part_of_speech_rules_json = [
 		},
 		'remove': 'Verb',
 		'comment': 'Daniel 2:40  The fourth kingom will be strong [like(V/Adp) iron is strong].',
+	},
+	{
+		'name': 'If Noun-Adposition "On" is followed by a Noun, remove Noun',
+		'category': 'Noun|Adposition',
+		'trigger': { 'token': 'On' },
+		'context': {
+			'followedby': { 'category': 'Noun', 'skip': 'np_modifiers' },
+		},
+		'remove': 'Noun',
+		'comment': 'eg. On that day...'
+	},
+	{
+		'name': 'If Noun-Adposition "On" is followed by anything else, remove Adposition',
+		'category': 'Noun|Adposition',
+		'trigger': { 'token': 'On' },
+		'remove': 'Adposition',
+		'comment': 'eg. On saw a lion.'
 	},
 ]
 

--- a/src/lib/rules/transform_rules.js
+++ b/src/lib/rules/transform_rules.js
@@ -357,12 +357,13 @@ const transform_rules_json = [
 		'transform': { 'function': { 'auxiliary': 'negation' } },
 	},
 	{
-		'name': 'do in a question becomes an auxiliary',
+		'name': 'do followed by another verb is an interrogative auxiliary',
 		'trigger': { 'stem': 'do' },
 		'context': {
-			'followedby': [{ 'category': 'Verb', 'skip': 'all' }, { 'token': '?', 'skip': 'all' }],
+			'followedby': { 'category': 'Verb', 'skip': 'all' },
 		},
 		'transform': { 'function': { 'auxiliary': 'yes_no_interrogative' } },
+		'comment': 'removed the question mark from the context, because the punctuation may be outside the closing clause bracket',
 	},
 	{
 		'name': 'have before a Verb indicates flashback/perfect',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,9 +10,16 @@
 
 	async function check_text() {
 		checking = true
-		const response = await fetch(`/check?text=${entered_text}`)
+		const response = await fetch(`/check?text=${sanitize_input(entered_text)}`)
 		check_response = await response.json()
 		checking = false
+	}
+
+	/**
+	 * @param {string} text 
+	 */
+	function sanitize_input(text) {
+		return text.replaceAll('\n', ' ')
 	}
 
 	function clear() {


### PR DESCRIPTION
# UI Issues

### Support newlines in the editor text box
- Now converts them to spaces before sending through the API. Previously, it was combining the last word with the first word of the next line, causing a tokenizing error.

# BT Issues

### Capitalize paired words in the BT when they become the first in the sentence
- `You(John) (imp) honor/worship God.` -> 'Worship God.'
![image](https://github.com/user-attachments/assets/c06c28e9-ca94-422a-a2d0-62833e1c3b1d)

### In the BT, add 'that' to agent clauses which use the 'It is...' construction
- `It is true [John left Jerusalem].`
![image](https://github.com/user-attachments/assets/f0d5e866-2d51-4012-b3c4-b9709faa1af6)

### Fix hanging error with a badly constructed _dynamicExpansion
- `And bad-B actions the power of _dynamicExpansion controls me(Paul).`
- Should be `And bad-B actions of the power _dynamicExpansion controls me(Paul).` and the wrong placement of the 'of' caused an internal error. Now it detects and shows the user an error when the 'of' is in the wrong place
![image](https://github.com/user-attachments/assets/cbc80d9c-c407-4725-bb3a-b6fdff8c9295)

# Checker Issues

### 'Instead' and 'On' disambiguation
- `You(Jesus) are now speaking clearly [instead of using stories/parables]. Instead, we(followers) understand you(Jesus).`
![image](https://github.com/user-attachments/assets/debcb9bc-f5de-4c22-bff8-0530d76babc7)

- `On that day, On went to Jerusalem. On saw John on the mountain.`
![image](https://github.com/user-attachments/assets/ce64971f-3d9a-4283-a2cd-4e840e6b31a0)

### Flag negation on Adjectives
- Invalid: `For _conj not all of Israel are true people of God.`
![image](https://github.com/user-attachments/assets/cedcec9a-bbc3-4a26-8307-22d7821a4574)

- Valid: `Was John not happy? John was not happy. All of Israel are not true people of God.`
![image](https://github.com/user-attachments/assets/09ee47c7-ca5e-421b-ae58-e99448c5adb2)

### Fix where 'do' was not interpreted as an auxiliary
- `But I(Paul) ask, ["Did those people hear the message _implicitNecessary]"?`
![image](https://github.com/user-attachments/assets/3dd391f4-66b4-4230-b699-6b1892103343)

- `John said, ["Why did you(person) make/create [me(thing) to be like [I(thing) am]]]?”`
![image](https://github.com/user-attachments/assets/664776a4-6959-4564-a326-01646ce5cef5)

### Add more helpful messages when no sense has a valid case frame/arguments
- `John said to Mary.`
![image](https://github.com/user-attachments/assets/7b1ea3f0-3b1f-49b5-97a2-7db2c32a98e5)

- `John left ago.`
![image](https://github.com/user-attachments/assets/7677298f-5864-4921-99c2-14ea15890e6b)

- `John went around.`
![image](https://github.com/user-attachments/assets/9400f36e-5a84-42d0-ab3b-5bd65314cad9)

- `The bread was taken.`
![image](https://github.com/user-attachments/assets/01972ed6-ba71-43f9-a53c-a241e06a4154)

- `John ate bread while Mary slept.`
![image](https://github.com/user-attachments/assets/9871ce08-0c06-433d-bc33-c23f35cc4269)

- `John made Mary happy.`
![image](https://github.com/user-attachments/assets/e3dd5eaa-c979-4e1e-9ffc-2bf9ae0246ce)

- `John spoke, ["Yes"].`
![image](https://github.com/user-attachments/assets/dec28c4a-ab17-4a61-bb02-234496f188cd)

- `John left [to buy food].`
![image](https://github.com/user-attachments/assets/c9988e92-7532-4ab5-93c9-87f604e47ee9)

