### PR TITLE
Improve handling of empty theta grids

### DIFF
--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -338,7 +338,7 @@ function get_adjective_usage_info(categorization, role_rules) {
 	if (role_letters.length === 0) {
 		return {
 			possible_roles: DEFAULT_CASE_FRAME_RULES.map(({ role_tag }) => role_tag),
-			required_roles: [],
+			required_roles: role_rules.other_required,
 		}
 	}
 

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -860,10 +860,11 @@ function get_verb_usage_info(categorization, role_rules) {
 	
 	// some categorizations are blank (eg become-J)
 	// treat all arguments as possible and not required
+	// also accept any values specified in a role rule
 	if (role_letters.length === 0) {
 		return {
-			possible_roles: [...VERB_LETTER_TO_ROLE.values()],
-			required_roles: [],
+			possible_roles: [...VERB_LETTER_TO_ROLE.values(), role_rules.patient_clause_type],
+			required_roles: role_rules.other_required,
 		}
 	}
 


### PR DESCRIPTION
Improved the handling of empty theta grids to take into account any hard-coded rules for that sense - previously parts of it were being ignored. That way the editor code can specify that fail-B takes a patient clause, even when the ontology does not. This makes the sentence from the description pass the checker.

- `I(Paul) do not mean-E [God failed [to (implicit-situational) complete/fulfill the promise of God]].`
![image](https://github.com/user-attachments/assets/fcfcc4df-761e-4351-999b-cd87835acf91)

In fact, fail-B already had a rule, so this code simply gives it effect.
![image](https://github.com/user-attachments/assets/0d85dd52-b6e0-44ce-9497-654f976a20d4)

Resolves #158 