### PR TITLE
Check case frames of complex pairings.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,7 +63,7 @@ type LookupResult = LookupWord & {
 	gloss: string
 	categorization: string
 	how_to_entries: HowToEntry[]
-	case_frame: CaseFrameResult
+	case_frame: CaseFrame
 }
 
 type HowToEntry = {

--- a/src/lib/lookup_filters.js
+++ b/src/lib/lookup_filters.js
@@ -67,27 +67,27 @@ function MATCHES_SENSE({ stem, sense }) {
 /**
  * 
  * @param {string} argument 
- * @returns {(lookup: { case_frame: CaseFrameResult }) => boolean}
+ * @returns {(lookup: { case_frame: CaseFrame }) => boolean}
  */
 function HAS_MISSING_ARGUMENT(argument) {
-	return lookup => lookup.case_frame.missing_arguments.some(({ role_tag }) => role_tag.includes(argument))
+	return lookup => lookup.case_frame.result.missing_arguments.some(role_tag => role_tag.includes(argument))
 }
 
 /**
  * 
  * @param {string} argument 
- * @returns {(lookup: { case_frame: CaseFrameResult }) => boolean}
+ * @returns {(lookup: { case_frame: CaseFrame }) => boolean}
  */
 function HAS_EXTRA_ARGUMENT(argument) {
-	return lookup => lookup.case_frame.extra_arguments.some(({ role_tag }) => role_tag.includes(argument))
+	return lookup => lookup.case_frame.result.extra_arguments.some(({ role_tag }) => role_tag.includes(argument))
 }
 
 /**
  * 
- * @returns {(lookup: { case_frame: CaseFrameResult }) => boolean}
+ * @returns {(lookup: { case_frame: CaseFrame }) => boolean}
  */
 function HAS_INVALID_CASE_FRAME() {
-	return ({ case_frame }) => !case_frame.is_checked || !case_frame.is_valid
+	return ({ case_frame: { result } }) => !result.is_checked || !result.is_valid
 }
 
 export const LOOKUP_FILTERS = {

--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -1,4 +1,4 @@
-import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from '../common'
+import { parse_case_frame_rule, parse_sense_rules } from '../common'
 import { by_adposition, by_clause_tag, by_complementizer, by_same_participant_complementizer, modified_noun_of_adjective, modified_noun_with_subgroup, unit_with_measure } from './presets'
 
 /** @type {RoleRuleJson<AdjectiveRoleTag>} */
@@ -277,20 +277,15 @@ const ADJECTIVE_CASE_FRAME_RULES = create_adjective_argument_rules()
 const SUBGROUPABLE_CASE_FRAME_RULE = parse_case_frame_rule(['modified_noun_with_subgroup', modified_noun_with_subgroup()])
 
 /**
- * 
- * @param {RuleTriggerContext} trigger_context
+ * @param {Token} token
  */
-export function check_adjective_case_frames(trigger_context) {
-	const adjective_token = trigger_context.trigger_token
-
-	const stem = adjective_token.lookup_results[0].stem
-	const argument_rules_by_sense = ADJECTIVE_CASE_FRAME_RULES.get(stem) ?? []
-
-	check_case_frames(trigger_context, {
-		rules_by_sense: argument_rules_by_sense,
+export function get_adjective_case_frame_rules(token) {
+	const stem = token.lookup_results[0].stem
+	return {
+		rules_by_sense: ADJECTIVE_CASE_FRAME_RULES.get(stem) ?? [],
 		default_rule_getter: get_adjective_default_rules,
 		role_info_getter: get_adjective_usage_info,
-	})
+	}
 }
 
 const ADJECTIVE_LETTER_TO_ROLE = new Map([

--- a/src/lib/rules/case_frame/adjectives/case_frames.js
+++ b/src/lib/rules/case_frame/adjectives/case_frames.js
@@ -278,6 +278,7 @@ const SUBGROUPABLE_CASE_FRAME_RULE = parse_case_frame_rule(['modified_noun_with_
 
 /**
  * @param {Token} token
+ * @returns {CaseFrameRuleInfo}
  */
 export function get_adjective_case_frame_rules(token) {
 	const stem = token.lookup_results[0].stem
@@ -285,6 +286,7 @@ export function get_adjective_case_frame_rules(token) {
 		rules_by_sense: ADJECTIVE_CASE_FRAME_RULES.get(stem) ?? [],
 		default_rule_getter: get_adjective_default_rules,
 		role_info_getter: get_adjective_usage_info,
+		should_check: true,
 	}
 }
 

--- a/src/lib/rules/case_frame/adpositions/case_frames.js
+++ b/src/lib/rules/case_frame/adpositions/case_frames.js
@@ -124,6 +124,7 @@ const ADPOSITION_USAGE_RULES = create_adposition_argument_rules()
 /**
  * 
  * @param {Token} token
+ * @returns {CaseFrameRuleInfo}
  */
 export function get_adposition_case_frame_rules(token) {
 	const stem = token.lookup_results[0].stem
@@ -131,6 +132,7 @@ export function get_adposition_case_frame_rules(token) {
 		rules_by_sense: ADPOSITION_USAGE_RULES.get(stem) ?? [],
 		default_rule_getter: get_default_usage_rules,
 		role_info_getter: get_adposition_usage_info,
+		should_check: true,
 	}
 }
 

--- a/src/lib/rules/case_frame/adpositions/case_frames.js
+++ b/src/lib/rules/case_frame/adpositions/case_frames.js
@@ -1,4 +1,4 @@
-import { check_case_frames, parse_case_frame_rule, parse_sense_rules } from '../common'
+import { parse_case_frame_rule, parse_sense_rules } from '../common'
 import { by_relative_context, head_noun, head_noun_post, opening_subordinate_clause } from './presets'
 
 /** @type {RoleRuleJson<AdpositionRoleTag>} */
@@ -123,19 +123,15 @@ const ADPOSITION_USAGE_RULES = create_adposition_argument_rules()
 
 /**
  * 
- * @param {RuleTriggerContext} trigger_context
+ * @param {Token} token
  */
-export function check_adposition_case_frames(trigger_context) {
-	const adposition_token = trigger_context.trigger_token
-
-	const stem = adposition_token.lookup_results[0].stem
-	const argument_rules_by_sense = ADPOSITION_USAGE_RULES.get(stem) ?? []
-
-	check_case_frames(trigger_context, {
-		rules_by_sense: argument_rules_by_sense,
+export function get_adposition_case_frame_rules(token) {
+	const stem = token.lookup_results[0].stem
+	return {
+		rules_by_sense: ADPOSITION_USAGE_RULES.get(stem) ?? [],
 		default_rule_getter: get_default_usage_rules,
 		role_info_getter: get_adposition_usage_info,
-	})
+	}
 }
 
 /**

--- a/src/lib/rules/case_frame/case_frame.d.ts
+++ b/src/lib/rules/case_frame/case_frame.d.ts
@@ -14,10 +14,23 @@ type ArgumentRoleRule = {
 
 type ArgumentRulesForSense = {
 	sense: WordSense
-	rules: ArgumentRoleRule[]
+	role_rules: ArgumentRoleRule[]
 	other_required: RoleTag[]
 	other_optional: RoleTag[]
 	patient_clause_type: RoleTag
+}
+type DefaultRuleGetter = (lookup: LookupResult) => ArgumentRoleRule[]
+type RoleInfoGetter = (categorization: string, role_rules: ArgumentRulesForSense) => RoleUsageInfo
+type CaseFrameRuleInfo = {
+	rules_by_sense: ArgumentRulesForSense[]
+	default_rule_getter: DefaultRuleGetter
+	role_info_getter: RoleInfoGetter
+}
+
+type CaseFrame = {
+	rules: ArgumentRoleRule[]
+	usage: RoleUsageInfo
+	result: CaseFrameResult
 }
 
 type RoleUsageInfo = {
@@ -37,7 +50,7 @@ type CaseFrameResult = {
 	is_checked: boolean
 	valid_arguments: RoleMatchResult[]
 	extra_arguments: RoleMatchResult[]
-	missing_arguments: ArgumentRoleRule[]
+	missing_arguments: RoleTag[]
 }
 
 type CaseFrameRuleJson = TransformRuleJson & {

--- a/src/lib/rules/case_frame/case_frame.d.ts
+++ b/src/lib/rules/case_frame/case_frame.d.ts
@@ -25,6 +25,7 @@ type CaseFrameRuleInfo = {
 	rules_by_sense: ArgumentRulesForSense[]
 	default_rule_getter: DefaultRuleGetter
 	role_info_getter: RoleInfoGetter
+	should_check: boolean
 }
 
 type CaseFrame = {

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -62,9 +62,9 @@ function extra_argument_message(role_tag) {
 
 /** @type {Map<RoleTag, string>} */
 const ALL_HAVE_EXTRA_ARGUMENT_MESSAGES = new Map([
-	['patient_clause_same_participant', '\'{stem}\' cannot be used with a same-participant patient clause. This likely should be \'[in-order-to...]\' or \'[so-that...]\' instead.'],
-	['patient_clause_quote_begin', '\'{stem}\' can never be used with direct speech. Consult its usage in the Ontology.'],
-	['predicate_adjective', '\'{stem}\' can never be used with a predicate adjective. Consider using something like \'cause [X to be...]\'. Consult its usage in the Ontology.'],
+	['patient_clause_same_participant', "'{stem}' cannot be used with a same-participant patient clause. This likely should be '[in-order-to...]' or '[so-that...]' instead."],
+	['patient_clause_quote_begin', "'{stem}' can never be used with direct speech. Consult its usage in the Ontology."],
+	['predicate_adjective', "'{stem}' can never be used with a predicate adjective. Consider using something like 'cause [X to be...]'. Consult its usage in the Ontology."],
 ])
 
 /**
@@ -144,9 +144,8 @@ export function initialize_case_frame_rules({ trigger_token }, rule_info_getter)
 	 * @param {Token} token 
 	 */
 	function initialize_rules(token) {
-		const { rules_by_sense, default_rule_getter, role_info_getter } = rule_info_getter(token)
-		if (rules_by_sense.length === 0) {
-			// No rules for this word, so nothing to initialize
+		const { rules_by_sense, default_rule_getter, role_info_getter, should_check } = rule_info_getter(token)
+		if (!should_check) {
 			return
 		}
 		for (const lookup of token.lookup_results.filter(LOOKUP_FILTERS.IS_IN_ONTOLOGY)) {
@@ -346,7 +345,7 @@ export function* validate_case_frame(trigger_context) {
 		// flag any extra roles common to all lookup results
 		const extra_roles_for_all = selected_result.case_frame.result.extra_arguments.filter(({ role_tag }) => role_is_extra_for_all(role_tag, token))
 		for (const extra_argument of extra_roles_for_all) {
-			const extra_message = ALL_HAVE_EXTRA_ARGUMENT_MESSAGES.get(extra_argument.role_tag)?.[1] || extra_argument.rule.extra_message
+			const extra_message = ALL_HAVE_EXTRA_ARGUMENT_MESSAGES.get(extra_argument.role_tag) || extra_argument.rule.extra_message
 			// put the error message on both the trigger token AND the argument token
 			yield { error: extra_message }
 			yield flag_extra_argument(trigger_context, extra_message)(extra_argument)

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -902,7 +902,7 @@ function get_verb_usage_info(categorization, { other_optional, other_required, p
 	// also accept any values specified in a role rule
 	if (role_letters.length === 0) {
 		return {
-			possible_roles: [...VERB_LETTER_TO_ROLE.values(), patient_clause_type],
+			possible_roles: [...Object.keys(default_verb_case_frame_json)],
 			required_roles: other_required,
 		}
 	}

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -832,6 +832,7 @@ export function get_verb_case_frame_rules(token) {
 			rules_by_sense: [],
 			default_rule_getter: () => [],
 			role_info_getter: () => ({ possible_roles: [], required_roles: [] }),
+			should_check: false,
 		}
 	}
 
@@ -839,6 +840,7 @@ export function get_verb_case_frame_rules(token) {
 		rules_by_sense: argument_rules_by_sense,
 		default_rule_getter: () => get_default_rules_for_stem(stem),
 		role_info_getter: get_verb_usage_info,
+		should_check: true,
 	}
 }
 
@@ -861,6 +863,7 @@ export function get_passive_verb_case_frame_rules(token) {
 			.map(rules_for_sense => ({ ...rules_for_sense, rules: replace_passive_rules(rules_for_sense.role_rules) })),
 		default_rule_getter: lookup => replace_passive_rules(active_rules.default_rule_getter(lookup)),
 		role_info_getter: active_rules.role_info_getter,
+		should_check: true,
 	}
 
 	/**

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -740,11 +740,11 @@ const builtin_checker_rules = [
 			}),
 			action: message_set_action(({ tokens, trigger_token, context_indexes }) => {
 				const verb_token = tokens[context_indexes[0]]
-				const case_frames = verb_token.lookup_results.map(result => result.case_frame)
+				const case_frames = verb_token.lookup_results.map(result => result.case_frame.result)
 				if (case_frames.length === 0 || case_frames[0].is_valid) {
 					return
 				}
-				const missing_arguments = new Set(case_frames.flatMap(case_frame => case_frame.missing_arguments.map(rule => rule.role_tag)))
+				const missing_arguments = new Set(case_frames.flatMap(case_frame => case_frame.missing_arguments))
 
 				// Only show the message if all senses are invalid, but some are missing a patient clause
 				if (['agent_clause', 'patient_clause_different_participant'].some(role => missing_arguments.has(role))) {

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -283,7 +283,14 @@ export function create_lookup_result(
 		gloss,
 		categorization,
 		how_to_entries: how_to,
-		case_frame: case_frame ?? create_case_frame({ is_valid: true, is_checked: false }),
+		case_frame: {
+			rules: [],
+			usage: {
+				possible_roles: [],
+				required_roles: [],
+			},
+			result: case_frame ?? create_case_frame({ is_valid: true, is_checked: false }),
+		},
 	}
 }
 
@@ -294,7 +301,7 @@ export function create_lookup_result(
  * @param {boolean} [data.is_checked=false] 
  * @param {RoleMatchResult[]} [data.valid_arguments=[]] 
  * @param {RoleMatchResult[]} [data.extra_arguments=[]] 
- * @param {ArgumentRoleRule[]} [data.missing_arguments=[]] 
+ * @param {RoleTag[]} [data.missing_arguments=[]] 
  * @returns {CaseFrameResult}
  */
 export function create_case_frame({ is_valid=false, is_checked=false, valid_arguments=[], extra_arguments=[], missing_arguments=[] }={}) {

--- a/src/routes/check/+server.js
+++ b/src/routes/check/+server.js
@@ -108,16 +108,18 @@ function simplify_tokens(sentences) {
 
 	/**
 	 * 
-	 * @param {CaseFrameResult} case_frame 
-	 * @returns {SimpleCaseFrameResult}
+	 * @param {CaseFrame} case_frame 
+	 * @returns {SimpleCaseFrame}
 	 */
-	function simplify_case_frame({ is_valid, is_checked, valid_arguments, extra_arguments, missing_arguments }) {
+	function simplify_case_frame({ usage: { possible_roles, required_roles }, result: { is_valid, is_checked, valid_arguments, extra_arguments, missing_arguments } }) {
 		return {
 			is_valid,
 			is_checked,
 			valid_arguments: valid_arguments.reduce(simplify_argument_result, {}),
 			extra_arguments: extra_arguments.reduce(simplify_argument_result, {}),
-			missing_arguments: missing_arguments.map(rule => rule.role_tag),
+			missing_arguments,
+			possible_roles,
+			required_roles,
 		}
 
 		/**

--- a/src/routes/check/api.d.ts
+++ b/src/routes/check/api.d.ts
@@ -23,15 +23,17 @@ type SimpleLookupResult = LookupWord & {
 	gloss: string
 	categorization: string
 	how_to_entries: HowToEntry[]
-	case_frame: SimpleCaseFrameResult
+	case_frame: SimpleCaseFrame
 }
 
-type SimpleCaseFrameResult = {
+type SimpleCaseFrame = {
 	is_valid: boolean
 	is_checked: boolean
 	valid_arguments: SimpleRoleArgResult
 	extra_arguments: SimpleRoleArgResult
 	missing_arguments: RoleTag[]
+	possible_roles: RoleTag[]
+	required_roles: RoleTag[]
 }
 
 type SimpleRoleArgResult = {


### PR DESCRIPTION
Check that complex pairings have a compatible case frame with the simple word. Select the sense accordingly. Flag as an error otherwise. Resolves #159 .
Also refactored a bit and improved type definitions.

- `John told/announced the people about the new law.` ✅ 
  - the sense of announce compatible with the selected sense of tell is selected
![image](https://github.com/user-attachments/assets/b0ed5d23-1d4c-4f0e-9d4c-3e0153f87e41)

- `John said/announced to the people [John was angry].` ❌ 
  - announce-B, which is the expected pairing, does not support a destination, and so is flagged
![image](https://github.com/user-attachments/assets/fa49b2c7-eabf-45ed-847e-da2a33255aaa)

- `John said/announced [John was angry].` ✅ 
  - The above sentence is corrected, and the correct sense of announce is selected
![image](https://github.com/user-attachments/assets/85fae4cb-7bd6-4e5a-9c7e-de763411dea0)

- `John said/announced, ["I(John) am angry."]` ✅ 
  - Again, the correct sense of announce is selected
![image](https://github.com/user-attachments/assets/bf6e8ab4-3612-47f5-a296-ac2f44c045ce)

- `Jesus saves/saves-C people from enemies.` ❌ 
  - save-C cannot take a source argument, and so is an error
![image](https://github.com/user-attachments/assets/58c412c0-0582-4fe3-971f-51b9a3d22032)

- `Jesus saves/saves-C people.` ✅ 
  - save-C is properly selected and compatible
![image](https://github.com/user-attachments/assets/67a6d26c-39f7-4819-b1e3-720c2e546891)

- `Jesus saves/saves-C.` ❌ 
  - the complex pairing is not checked at all because the simple word has an error
![image](https://github.com/user-attachments/assets/f697891b-4880-496c-9c01-6f4a7e1289a1)

- `Jesus told/proclaimed people about the Good-News.` ✅ 
  - 'proclaim' has no rules for it yet, so is not checked for now
![image](https://github.com/user-attachments/assets/2c7f1f9e-38d4-41cf-9169-daf026cecfea)


Right now, not too many complex words will get checked, but this will be done in #160 