### PR TITLE
Fix issue with capitalized pairings

### DIFF
--- a/src/lib/backtranslator/structural_rules.js
+++ b/src/lib/backtranslator/structural_rules.js
@@ -339,6 +339,21 @@ const structural_rules_json = [
 		},
 	},
 	{
+		name: 'Capitalize the pairing if it is the first word in a sentence.',
+		comment: '',
+		rule: {
+			trigger: token => is_first_word(token) && !!token.complex_pairing,
+			context: create_context_filter({ }),
+			action: simple_rule_action(({ trigger_token }) => {
+				if (!trigger_token.complex_pairing) {
+					// makes the compiler happy, but this should never happen
+					return
+				}
+				trigger_token.complex_pairing.token = capitalize_token(trigger_token.complex_pairing)
+			}),
+		},
+	},
+	{
 		name: 'Simple text mappings',
 		comment: '',
 		rule: {
@@ -505,26 +520,26 @@ function fix_capitalization(old_tokens, new_tokens, decapitalize=false) {
 		}
 		return `${token.token[0].toLowerCase()}${token.token.slice(1)}`
 	}
+}
 
-	/**
-	 *
-	 * @param {Token} token
-	 * @returns {string}
-	 */
-	function capitalize_token({ token }) {
-		if (REGEXES.STARTS_LOWERCASE.test(token)) {
-			return `${token[0].toUpperCase()}${token.slice(1)}`
-		}
-		return token
+/**
+ *
+ * @param {Token} token
+ * @returns {string}
+ */
+function capitalize_token({ token }) {
+	if (REGEXES.STARTS_LOWERCASE.test(token)) {
+		return `${token[0].toUpperCase()}${token.slice(1)}`
 	}
+	return token
+}
 
-	/**
-	 *
-	 * @param {Token} token
-	 */
-	function is_first_word(token) {
-		return create_token_filter({ 'tag': { 'position': 'first_word' } })(token)
-	}
+/**
+ *
+ * @param {Token} token
+ */
+function is_first_word(token) {
+	return create_token_filter({ 'tag': { 'position': 'first_word' } })(token)
 }
 
 

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -144,6 +144,9 @@ export function initialize_case_frame_rules({ trigger_token }, rule_info_getter)
 	 * @param {Token} token 
 	 */
 	function initialize_rules(token) {
+		if (token.lookup_results.length === 0) {
+			return
+		}
 		const { rules_by_sense, default_rule_getter, role_info_getter, should_check } = rule_info_getter(token)
 		if (!should_check) {
 			return
@@ -367,8 +370,8 @@ export function* validate_case_frame(trigger_context) {
 
 	// Flag a complex pairing that is invalid
 	// If the simple word is invalid, there's no point checking the pairing
-	if (case_frame.is_valid && token.complex_pairing && token.lookup_results.some(LOOKUP_FILTERS.HAS_INVALID_CASE_FRAME)) {
-		const complex_token = token.complex_pairing
+	const complex_token = token.complex_pairing
+	if (case_frame.is_valid && complex_token && complex_token.lookup_results.some(LOOKUP_FILTERS.HAS_INVALID_CASE_FRAME)) {
 		const selected_complex_result = complex_token.lookup_results[0]
 		const simple_sense = stem_with_sense(selected_result)
 		if (no_matches_and_ambiguous_sense(complex_token)) {

--- a/src/lib/rules/syntax_rules.js
+++ b/src/lib/rules/syntax_rules.js
@@ -33,6 +33,9 @@ const builtin_syntax_rules = [
 				}
 
 				add_tag_to_token(word_token, { 'position': 'first_word' })
+				if (word_token.complex_pairing) {
+					add_tag_to_token(word_token.complex_pairing, { 'position': 'first_word' })
+				}
 			}),
 		},
 	},


### PR DESCRIPTION
Resolved #164 

- `Proud/Arrogant people laugh at me(person).`
  - The complex pairing wasn't tagged as 'first_word', so any results that weren't capitalized were being removed. This is now fixed.
<img width="830" height="191" alt="image" src="https://github.com/user-attachments/assets/39f976ce-069e-494d-8d29-6574f4240f69" />

- `Friend/Brother-D [whom I(Paul) love] greets you(friends).`
  - Another example
<img width="1047" height="195" alt="image" src="https://github.com/user-attachments/assets/0a40ab8d-b2f4-4f85-8574-5cd05b99e1d4" />

- `The proud/arrogant people laugh at me(person).`
  - Uncapitalized pairings still work
<img width="824" height="250" alt="image" src="https://github.com/user-attachments/assets/def91320-b497-41ee-9364-b33c0bf9b085" />

- `Proud/arrogant people laugh at me(person).`
  - A complex pairing now gets capitalized at the start of a sentence, if it isn't already.
<img width="925" height="368" alt="image" src="https://github.com/user-attachments/assets/93ab5d0d-b69b-4420-8bc9-4d88a52a89b4" />
