### PR TITLE
Add more verb theta grids

### DIFF
--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -349,7 +349,8 @@ export function* validate_case_frame(trigger_context) {
 		// flag any extra roles common to all lookup results
 		const extra_roles_for_all = selected_result.case_frame.result.extra_arguments.filter(({ role_tag }) => role_is_extra_for_all(role_tag, token))
 		for (const extra_argument of extra_roles_for_all) {
-			const extra_message = ALL_HAVE_EXTRA_ARGUMENT_MESSAGES.get(extra_argument.role_tag) || extra_argument.rule.extra_message
+			const extra_message_template = ALL_HAVE_EXTRA_ARGUMENT_MESSAGES.get(extra_argument.role_tag) || extra_argument.rule.extra_message
+			const extra_message = extra_message_template.replaceAll('{sense}', '{stem}')
 			// put the error message on both the trigger token AND the argument token
 			yield { error: extra_message }
 			yield flag_extra_argument(trigger_context, extra_argument, extra_message)

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -349,8 +349,8 @@ export function* validate_case_frame(trigger_context) {
 		// flag any extra roles common to all lookup results
 		const extra_roles_for_all = selected_result.case_frame.result.extra_arguments.filter(({ role_tag }) => role_is_extra_for_all(role_tag, token))
 		for (const extra_argument of extra_roles_for_all) {
-			const extra_message_template = ALL_HAVE_EXTRA_ARGUMENT_MESSAGES.get(extra_argument.role_tag) || extra_argument.rule.extra_message
-			const extra_message = extra_message_template.replaceAll('{sense}', '{stem}')
+			const extra_message = ALL_HAVE_EXTRA_ARGUMENT_MESSAGES.get(extra_argument.role_tag)
+				|| extra_argument.rule.extra_message.replaceAll('{sense}', "'{stem}'")
 			// put the error message on both the trigger token AND the argument token
 			yield { error: extra_message }
 			yield flag_extra_argument(trigger_context, extra_argument, extra_message)

--- a/src/lib/rules/case_frame/rules.js
+++ b/src/lib/rules/case_frame/rules.js
@@ -1,10 +1,10 @@
 import { add_tag_to_token, is_one_part_of_speech, token_has_tag } from '$lib/token'
-import { create_context_filter, create_token_filter, simple_rule_action } from '../rules_parser'
+import { create_context_filter, create_token_filter, simple_rule_action } from '$lib/rules/rules_parser'
+import { LOOKUP_FILTERS } from '$lib/lookup_filters'
 import { select_pairing_sense, select_sense } from './sense_selection'
 import { get_adjective_case_frame_rules } from './adjectives/case_frames'
 import { get_verb_case_frame_rules, get_passive_verb_case_frame_rules } from './verbs/case_frames'
 import { get_adposition_case_frame_rules } from './adpositions/case_frames'
-import { LOOKUP_FILTERS } from '$lib/lookup_filters'
 import { initialize_case_frame_rules, check_case_frames, check_pairing_case_frames } from './common'
 
 

--- a/src/lib/rules/case_frame/sense_selection.js
+++ b/src/lib/rules/case_frame/sense_selection.js
@@ -98,6 +98,9 @@ const verb_sense_priority_overrides = [
 	['believe', [
 		['believe-B', { 'patient': { 'stem': 'Christ|God|Jesus' } }],
 	]],
+	['blame', [
+		['blame-C', { 'patient_clause_different_participant': { } }],
+	]],
 	['break', [
 		['break-C', { 'patient': { 'stem': 'law' } }],
 		['break-E', { 'patient': { 'stem': 'promise|agreement' } }],
@@ -178,6 +181,10 @@ const verb_sense_priority_overrides = [
 	['hurt', [
 		['hurt-C', { 'be_auxiliary': { } }],
 	]],
+	['increase', [
+		['increase-B', { 'patient': { } }],
+		// increase-A is wrongly flagged as allowing a patient, so this correctly prioritizes increase-B
+	]],
 	['know', [
 		['know-C', { 'patient': { 'stem': 'law|meaning|name|secret|thing' } }],
 	]],
@@ -195,6 +202,18 @@ const verb_sense_priority_overrides = [
 		['make-C', { 'patient': { 'stem': 'command|fire|god|peace|promise|wave|covenant' } }],
 		['make-E', { 'patient': { 'stem': 'bread|food' } }],
 	]],
+	['move', [
+		['move-C', { 'patient': { 'stem': 'foot|hand|leg' } }],
+	]],
+	['open', [
+		['open-B', { 'patient': { 'stem': 'door|gate|window' } }],
+		['open-C', { 'patient': { 'stem': 'book' } }],
+		['open-D', { 'patient': { 'stem': 'eye' } }],
+		['open-E', { 'patient': { 'stem': 'mouth' } }],
+	]],
+	['pay', [
+		['pay-C', { 'patient': { 'stem': 'tax' } }],
+	]],
 	['pray', [
 		['pray-D', { }],
 	]],
@@ -202,11 +221,26 @@ const verb_sense_priority_overrides = [
 		['prepare-B', { 'patient': { 'stem': 'feast|food|meal' } }],
 		['prepare-C', { }],
 	]],
+	['pull', [
+		['pull-B', { 'patient': { 'stem': 'net' }, 'destination': { 'stem': 'boat|ship' } }],
+	]],
 	['return', [
 		['return-D', { 'destination': { 'stem': 'king|person' } }],
 	]],
+	['remember', [
+		['remember-B', { 'patient': { 'stem': 'day|event|holiday' } }],
+		['remember-C', { 'patient': { 'level': '4' } }],	// TODO use a lexicon feature to check for any person.
+		['remember-D', { 'patient': { } }],
+	]],
+	['run', [
+		['run-B', { 'patient': { 'stem': 'army|God|king' } }],
+		['run-D', { 'agent': { 'stem': 'nose' } }],
+	]],
 	['say', [
 		['say-D', { 'agent': { 'stem': 'law' } }],
+	]],
+	['save', [
+		['save-B', { 'patient': { 'stem': 'money' } }],
 	]],
 	['see', [
 		['see-D', { 'patient': { 'stem': 'dream|vision' } }],
@@ -214,6 +248,12 @@ const verb_sense_priority_overrides = [
 	]],
 	['send', [
 		['send-B', { 'patient': { 'stem': 'letter|message' } }],
+	]],
+	['shout', [
+		['shout-C', { 'agent': { 'stem': 'lion|dog|sheep|cow' } }],
+	]],
+	['show', [
+		['show-C', { 'patient': { 'stem': 'dream|vision|event|power' } }],
 	]],
 	['speak', [
 		['speak-B', { }],
@@ -224,6 +264,15 @@ const verb_sense_priority_overrides = [
 		['take-C', { 'patient': { 'stem': 'rooster|sheep|horse' } }],
 		['take-D', { 'source': { 'stem': 'person|man|woman|child|son|daughter' } }], // TODO use a lexicon feature to check for any person.
 		['take-E', { 'destination': { 'stem': 'person|man|woman|child|son|daughter' } }], // TODO use a lexicon feature to check for any person.
+	]],
+	['take-away', [
+		['take-away-A', { 'source': { 'level': '4' } }], // TODO use a lexicon feature to check for any person.
+		['take-away-A', { 'source': { 'stem': 'person|man|woman|child|son|daughter' } }],
+		['take-away-B', { 'patient': { 'stem': 'honor|power' } }],
+		['take-away-C', { }],	// this is the default sense of take-away
+	]],
+	['talk', [
+		['talk-B', { }],
 	]],
 	['teach', [
 		['teach-A', { 'patient': { } }],	// when teach-A has a patient, prioritize it over teach-B
@@ -239,14 +288,28 @@ const verb_sense_priority_overrides = [
 		['throw-D', { 'destination': { 'stem': 'ground|floor' } }],
 		['throw-E', { 'destination': { 'stem': 'air' } }],
 	]],
+	['understand', [
+		['understand-C', { }],
+	]],
 	['unite', [
 		['unite-B', { }],
+	]],
+	['wait', [
+		['wait-C', { 'patient': { } }],
 	]],
 	['want', [
 		['want-D', { 'patient': { 'stem': 'peace|health|life' } }],
 	]],
+	['weigh', [
+		['weigh-A', { 'patient': { 'stem': 'gram|kilogram|amount' } }],
+		['weigh-B', { }],
+	]],
 	['worry', [
 		['worry-B', { }],
+	]],
+	['write', [
+		['write-F', { 'patient': { 'stem': 'law|command|commandment' } }],
+		['write-G', { 'patient': { 'stem': 'name' } }],
 	]],
 ]
 

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -1,6 +1,6 @@
 import { TOKEN_TYPE } from '$lib/token'
 import { parse_case_frame_rule, parse_sense_rules } from '../common'
-import { by_adposition, by_clause_tag, by_complementizer, by_relative_context, directly_after_verb, directly_after_verb_with_adposition, directly_before_verb, patient_from_subordinate_clause, predicate_adjective, with_be_auxiliary, with_no_double_patient } from './presets'
+import { by_adposition, by_clause_tag, by_complementizer, by_adposition_concept, by_relative_context, directly_after_verb, directly_after_verb_with_adposition, directly_before_verb, patient_from_subordinate_clause, predicate_adjective, with_be_auxiliary, with_no_double_patient } from './presets'
 
 /** @type {RoleRuleJson<VerbRoleTag>} */
 const default_verb_case_frame_json = {
@@ -290,6 +290,10 @@ const verb_case_frames = new Map([
 			],
 		}],
 	]],
+	['beg', [
+		['beg-C', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['begin', []],
 	['believe', [
 		['believe-B', { 'patient': directly_after_verb_with_adposition('in') }],
 	]],
@@ -304,10 +308,20 @@ const verb_case_frames = new Map([
 			'destination': { },	// clear the rule so the 'to' doesn't trigger it
 		}],
 	]],
+	['blame', [
+		['blame-A', patient_from_subordinate_clause()],
+		['blame-C', {
+			'patient_clause_different_participant': [
+				by_complementizer('for'),
+				by_clause_tag('patient_clause_different_participant'),
+			],
+		}],
+	]],
 	['blow', []],
 	['born', [
 		['born-A', with_be_auxiliary()],
 	]],
+	['borrow', []],
 	['break', [
 		['break-A', { 'destination': by_adposition('to|into') }],
 	]],
@@ -315,8 +329,12 @@ const verb_case_frames = new Map([
 		['breathe-B', { 'destination': by_adposition('to|into') }],
 	]],
 	['bring', []],
+	['build', []],
 	['burn', [
 		['burn-A', { 'instrument': by_adposition('with') }],
+	]],
+	['bury', [
+		['bury-A', { 'destination': by_adposition('in') }],
 	]],
 	['buy', [
 		['buy-A', { 'instrument': by_adposition('with|for') }],
@@ -354,6 +372,10 @@ const verb_case_frames = new Map([
 		['carry-C', { 'instrument': by_adposition('with') }],
 		['carry-E', { 'instrument': by_adposition('with') }],
 	]],
+	['catch', [
+		['catch-B', { 'instrument': by_adposition('with') }],
+		['catch-C', { 'instrument': by_adposition('with') }],
+	]],
 	['cause', []],
 	['celebrate', [
 		['celebrate-A', { 'instrument': by_adposition('with') }],
@@ -379,6 +401,8 @@ const verb_case_frames = new Map([
 		['change-C', { 'destination': by_adposition('to|into') }],
 		['change-E', { 'destination': by_adposition('to|into') }],
 	]],
+	['chase', []],
+	['chase-away', []],
 	['choose', [
 		['choose-B', patient_from_subordinate_clause()],
 		['choose-C', { 'patient_clause_type': 'patient_clause_same_participant' }],
@@ -438,7 +462,7 @@ const verb_case_frames = new Map([
 	]],
 	['doubt', []],
 	['drop', [
-		['drop-A', { 'destination': by_adposition('to|on|into') }],
+		['drop-A', { 'destination': by_adposition_concept('to|on|into') }],
 	]],
 	['eat', [
 		['eat-A', { 'instrument': by_adposition('with') }],
@@ -462,10 +486,10 @@ const verb_case_frames = new Map([
 		['fail-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
 	['fall', [
-		['fall-A', { 'destination': by_adposition('to|on|into') }],
-		['fall-B', { 'destination': by_adposition('to|on|into') }],
-		['fall-D', { 'destination': by_adposition('to|on|into') }],
-		['fall-E', { 'destination': by_adposition('to|on|into') }],
+		['fall-A', { 'destination': by_adposition_concept('to|on|into') }],
+		['fall-B', { 'destination': by_adposition_concept('to|on|into') }],
+		['fall-D', { 'destination': by_adposition_concept('to|on|into') }],
+		['fall-E', { 'destination': by_adposition_concept('to|on|into') }],
 	]],
 	['fight', [
 		['fight-A', {
@@ -522,6 +546,13 @@ const verb_case_frames = new Map([
 			'comment': 'The boys grew up. OR The boys grew-B.',
 		}],
 	]],
+	['hang', [
+		['hang-B', { 'destination': by_adposition('on') }],
+		['hang-C', { 'destination': by_adposition('on') }],
+	]],
+	['hate', [
+		['hate-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
 	['have', [
 		['have-J', { 'instrument': by_adposition('with') }],
 	]],
@@ -534,24 +565,52 @@ const verb_case_frames = new Map([
 	['help', [
 		['help-B', patient_from_subordinate_clause()],
 	]],
+	['hide', [
+		['hide-A', { 'destination': by_adposition_concept() }],
+	]],
+	['hope', [
+		['hope-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
 	['hurt', [
 		['hurt-C', with_be_auxiliary()],
+	]],
+	['increase', []],
+	['invite', [
+		['invite-A', patient_from_subordinate_clause()],
+	]],
+	['join', []],
+	['keep', [
+		['keep-A', { 'destination': by_adposition_concept('in') }],
+		['keep-C', { 'destination': by_adposition('in') }],
 	]],
 	['kill', []],
 	['know', [
 		['know-D', { 'patient': directly_after_verb_with_adposition('about') }],
 		['know-B', { 'instrument': by_adposition('with') }],
 	]],
+	['know-how', [
+		['know-how-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
 	['laugh', [
 		['laugh-B', { 'patient': directly_after_verb_with_adposition('at') }],
 	]],
+	['lead', []],
 	['learn', [
 		['learn-C', { 'patient': directly_after_verb_with_adposition('about') }],
 	]],
+	['learn-how', [
+		['learn-how-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
 	['leave', []],
+	['let', []],
+	['lie', []],
 	['lift', []],
 	['like', [
 		['like-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['listen', [
+		['listen-A', { 'patient': directly_after_verb_with_adposition('to') }],
+		['listen-B', { 'patient': directly_after_verb_with_adposition('to') }],
 	]],
 	['live', [
 		['live-A', {
@@ -630,11 +689,65 @@ const verb_case_frames = new Map([
 	['marry', [
 		['marry-B', with_be_auxiliary()],
 	]],
+	['mean', [
+		['mean-A', { 'other_optional': 'predicate_adjective' }],
+		['mean-D', {
+			'patient_clause_type': 'patient_clause_same_participant',
+			'comment': "'X means [to go]' - technically just an infinitive verb, but looks like a 'same participant' clause",
+		}],
+		['mean-E', { 'other_optional': 'patient_clause_different_participant' }],
+	]],
+	['move', []],
+	['need', [
+		['need-C', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['notice', [
+		['notice-A', { 'other_optional': 'patient_clause_simultaneous' }],
+	]],
+	['offer', [
+		['offer-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['open', []],
+	['order', [
+		['order-A', patient_from_subordinate_clause()],
+	]],
+	['pass', []],
+	['pay', []],
+	['persuade', [
+		['persuade-A', patient_from_subordinate_clause()],
+	]],
+	['plan', [
+		['plan-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+		['plan-C', {
+			'patient_clause_different_participant': [
+				by_clause_tag('patient_clause_different_participant'),
+				by_complementizer('for'),	// 'John planned [for Mary to come].'
+			],
+			'comment': "eg. 'John planned [for Mary to come].'"
+		}],
+	]],
+	['please', []],
+	['point', [
+		['point-A', {
+			'patient': directly_after_verb_with_adposition('to'),
+			'destination': { },	// clear the destination so it doesn't get confused with the patient
+		}],
+		['point-B', { 'patient': directly_after_verb_with_adposition('at') }],
+		['point-C', { 'destination': by_adposition('to|at') }],
+	]],
+	['pour', [
+		['pour-A', { 'destination': by_adposition_concept('in|into|on') }],
+	]],
+	['pour-out', [
+		['pour-out-B', { 'destination': by_adposition('on|onto') }],
+	]],
+	['praise', []],
 	['pray', [
 		['pray-A', { 'patient': by_adposition('about') }],
 		['pray-C', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 	]],
 	['prepare', []],
+	['prevent', []],
 	['promise', [
 		['promise-A', { 'instrument': by_adposition('with') }],
 		['promise-B', {
@@ -642,7 +755,45 @@ const verb_case_frames = new Map([
 			'patient_clause_type': 'patient_clause_quote_begin',
 		}],
 	]],
+	['protect', [
+		['protect-B', patient_from_subordinate_clause()],
+	]],
+	['pull', [
+		['pull-B', { 'destination': by_adposition('in|into|onto') }],
+	]],
+	['put', [
+		['put-A', { 'destination': by_adposition_concept() }],
+	]],
+	['read', [
+		['read-B', { 'patient': by_adposition('about') }],
+	]],
 	['return', []],
+	['refuse', [
+		['refuse-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['remember', [
+		['remember-E', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['remind', [
+		['remind-A', {
+			'destination': directly_after_verb(),
+			'patient': { },
+		}],
+		['remind-B', patient_from_subordinate_clause()],
+		['remind-C', { 'destination': by_adposition('about') }],
+	]],
+	['reply', [
+		['reply-A', {
+			'patient': by_adposition('to'),
+			'destination': { },
+			'patient_clause_type': 'patient_clause_quote_begin',
+		}],
+		['reply-B', {
+			'patient': by_adposition('to'),
+			'destination': { },
+		}],
+	]],
+	['run', []],
 	['save', []],
 	['say', [
 		['say-A', {
@@ -657,6 +808,7 @@ const verb_case_frames = new Map([
 		['say-E', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 		['say-F', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 	]],
+	['scream', []],
 	['search', [
 		['search-A', {
 			'patient': directly_after_verb_with_adposition('for'),
@@ -667,10 +819,52 @@ const verb_case_frames = new Map([
 	['see', [
 		['see-B', { 'other_optional': 'patient_clause_simultaneous' }],
 	]],
+	['seem', [
+		['seem-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+		['seem-C', { 'patient': directly_after_verb_with_adposition('like') }],
+	]],
+	['sell', [
+		['sell-A', {
+			'instrument': {
+				...by_adposition('for'),
+				'trigger': { 'tag': { 'syntax': 'head_np' }, 'level': '0|1' },
+				'comment': "don't confuse the instrument with a beneficiary, which currently must be level 4",
+			},
+		}],
+	]],
 	['send', [
 		['send-A', with_no_double_patient()],
 		['send-B', with_no_double_patient()],
 		['send-C', with_no_double_patient()],
+	]],
+	['separate', []],
+	['shine', [
+		['shine-B', { 'destination': by_adposition('on|onto') }],
+	]],
+	['shoot', [
+		['shoot-B', { 'destination': by_adposition('to|at') }],
+	]],
+	['shout', [
+		['shout-A', {
+			'patient': by_adposition('to'),
+			'destination': { },
+			'patient_clause_type': 'patient_clause_quote_begin',
+		}],
+		['shout-B', { 'destination': by_adposition('to|at') }],
+		['shout-C', { 'destination': by_adposition('to|at') }],
+	]],
+	['show', []],
+	['show-how', [
+		['show-how-A', {
+			'patient': [
+				directly_after_verb(),
+				by_clause_tag('patient_clause_different_participant'),
+			],
+			'comment': "support both 'show-how [Y V]' or 'show-how Y [Y V]'",
+		}],
+	]],
+	['sing', [
+		['sing-A', { 'patient_clause_type': 'patient_clause_quote_begin' }],
 	]],
 	['speak', [
 		['speak-A', {
@@ -684,13 +878,65 @@ const verb_case_frames = new Map([
 			},
 		}],
 	]],
+	['smell', [
+		['smell-B', { 'other_optional': 'predicate_adjective' }],
+		['smell-C', { 'patient': directly_after_verb_with_adposition('like') }],
+	]],
+	['sound-like', [
+		['sound-like-A', { 'destination': by_adposition('in') }],
+		['sound-like-B', { 'destination': by_adposition('in') }],
+	]],
+	['spill', [
+		['spill-A', { 'destination': by_adposition('on') }],
+	]],
+	['sprinkle', [
+		['sprinkle-A', { 'destination': by_adposition('on') }],
+	]],
+	['start', []],
+	['struggle', [
+		['struggle-A', { 'patient': by_adposition('with|against') }],
+	]],
+	['suggest', []],
 	['take', []],
+	['take-away', []],
+	['talk', [
+		['talk-A', { 'patient': by_adposition('about') }],
+		['talk-B', {
+			'patient_clause_different_participant': [
+				by_clause_tag('patient_clause_different_participant'),
+				by_complementizer('about'),
+			],
+			'comment': "eg. 'John talked about Mary dancing.'",
+		}],
+	]],
+	['taste', [
+		['taste-B', {
+			'patient': by_adposition('like'),
+			'other_optional': 'predicate_adjective',
+			'comment': 'eg. "The soup tastes like chicken" or "The soup tastes bitter"',
+		}],
+	]],
 	['teach', [
 		['teach-A', {
 			'destination': directly_after_verb(),
 			'patient': by_adposition('about'),
 		}],
 		['teach-D', patient_from_subordinate_clause()],
+	]],
+	['teach-how', [
+		['teach-how-A', {
+			'patient': [
+				directly_after_verb(),
+				by_clause_tag('patient_clause_different_participant'),
+			],
+			'comment': "support both 'teach-how [Y V]' or 'teach-how Y [Y V]'",
+		}],
+	]],
+	['tear', [
+		['tear-A', { 'destination': by_adposition('to|into') }],
+	]],
+	['thank', [
+		['thank-A', { 'destination': by_adposition('for') }],
 	]],
 	['tell', [
 		['tell-A', {
@@ -707,8 +953,9 @@ const verb_case_frames = new Map([
 		['tell-D', { 'instrument': by_adposition('with') }],
 		['tell-E', {
 			'destination': directly_after_verb(),
-			'patient': { 'trigger': 'none' },		// clear the patient so it doesn't get confused with the destination
+			'patient': { 'trigger': 'none' },		
 			'patient_clause_type': 'patient_clause_quote_begin',
+			'comment': "clear the patient so it doesn't get confused with the destination",
 		}],
 	]],
 	['think', [
@@ -758,6 +1005,38 @@ const verb_case_frames = new Map([
 		}],
 		['tie-C', { 'instrument': by_adposition('with') }],
 	]],
+	['trust', [
+		['trust-A', {
+			'patient': by_adposition('in'),
+			'instrument': by_adposition('with'),
+		}],
+		['trust-B', { 'instrument': by_adposition('with') }],
+		['trust-C', { 'instrument': by_adposition('with') }],
+		['trust-D', patient_from_subordinate_clause()],
+	]],
+	['try', [
+		['try-A', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
+	['turn', []],
+	['understand', [
+		['understand-C', {
+			'patient_clause_type': 'patient_clause_same_participant',
+			'patient_clause_same_participant': [
+				by_clause_tag('patient_clause_same_participant'),
+				{
+					'trigger': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': 'patient_clause_different_participant|adverbial_clause' } },
+					'context': {
+						'subtokens': [{ 'token': 'how', 'skip': 'clause_start' }, { 'token': 'to' }],
+					},
+					'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'patient_clause_same_participant' } },
+					'subtoken_transform': { 'function': { 'syntax': 'complementizer' } },
+					'missing_message': `'[(how) to...]'`,
+				},
+			],
+			'patient_clause_different_participant': {},
+			'comment': "'John understood [how to dance].' OR 'John understood [to dance].'",
+		}],
+	]],
 	['unite', [
 		['unite-B', { 'destination': by_adposition('to|with') }],
 		['unite-C', {
@@ -765,9 +1044,45 @@ const verb_case_frames = new Map([
 			'destination': { },
 		}],
 	]],
+	['wait', [
+		['wait-B', {
+			'patient_clause_same_participant': [
+				by_clause_tag('patient_clause_same_participant'),
+				by_complementizer('for'),
+			],
+			'comment': "'John waited [for Mary to come].' OR 'John waited [Mary to come].'",
+		}],
+		['wait-C', {
+			'patient': {
+				...by_adposition('for'),
+				'trigger': { 'tag': { 'syntax': 'head_np' }, 'level': '4' },
+			},
+			'beneficiary': { },
+		}],
+		['wait-D', { 'patient_clause_type': 'patient_clause_same_participant' }],
+	]],
 	['want', [
 		['want-B', { 'patient_clause_type': 'patient_clause_same_participant' }],
 	]],
+	['walk', []],
+	['warn', [
+		['warn-A', {
+			'patient': [
+				directly_after_verb(),
+				by_clause_tag('patient_clause_different_participant'),
+			],
+			'comment': "support both 'warn [Y V]' or 'warn Y [Y V]'",
+		}],
+		['warn-C', { 'destination': by_adposition('about') }],
+		['warn-D', { 'patient_clause_type': 'patient_clause_quote_begin' }],
+	]],
+	['watch', [
+		['watch-A', { 'other_optional': 'patient_clause_simultaneous' }],
+	]],
+	['watch-out', [
+		['watch-out-A', { 'patient': by_adposition('for') }],
+	]],
+	['weigh', []],
 	['work', [
 		['work-A', { 'instrument': by_adposition('with') }],
 	]],
@@ -777,6 +1092,24 @@ const verb_case_frames = new Map([
 			'patient': directly_after_verb_with_adposition('about'),
 		}],
 		['worry-B', with_be_auxiliary()],
+	]],
+	['wrap', [
+		['wrap-A', { 'instrument': by_adposition('with') }],
+	]],
+	['write', [
+		['write-A', { 'instrument': by_adposition('with') }],
+		['write-B', { 'instrument': by_adposition('with') }],
+		['write-C', {
+			'patient': by_adposition('about'),
+			'patient_clause_type': 'patient_clause_quote_begin',
+		}],
+		['write-D', {
+			'patient': by_adposition('about'),
+		}],
+		['write-E', {
+			'patient_clause_different_participant': by_clause_tag('patient_clause_different_participant|relative_clause_that'),
+			'comment': 'the patient clause may have been interpreted as a relative clause if \'that\' was present',
+		}],
 	]],
 ])
 

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -721,9 +721,9 @@ const verb_case_frames = new Map([
 		['plan-C', {
 			'patient_clause_different_participant': [
 				by_clause_tag('patient_clause_different_participant'),
-				by_complementizer('for'),	// 'John planned [for Mary to come].'
+				by_complementizer('for'),
 			],
-			'comment': "eg. 'John planned [for Mary to come].'"
+			'comment': "eg. 'John planned [for Mary to come].'",
 		}],
 	]],
 	['please', []],
@@ -1030,7 +1030,7 @@ const verb_case_frames = new Map([
 					},
 					'transform': { 'tag': { 'clause_type': 'patient_clause_same_participant', 'role': 'patient_clause_same_participant' } },
 					'subtoken_transform': { 'function': { 'syntax': 'complementizer' } },
-					'missing_message': `'[(how) to...]'`,
+					'missing_message': "'[(how) to...]'",
 				},
 			],
 			'patient_clause_different_participant': {},

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -28,10 +28,15 @@ const default_verb_case_frame_json = {
 	},
 	'beneficiary': {
 		// TODO check feature on lexicon word like the Analyzer does. beneficiaries have to be animate, not things.
-		// For now only accept proper names. Not a big deal because the beneficiary is rarely required (only provide-A requires it)
-		'trigger': { 'tag': { 'syntax': 'head_np' }, 'level': '4' },	
-		'context': { 'precededby': { 'token': 'for', 'skip': 'np_modifiers' } },
-		'context_transform': { 'function': { } },
+		// For now only accept proper names. Not a big deal because the beneficiary is never required, and could be used for most verbs.
+		...by_relative_context({
+			'followedby': [
+				{ 'token': 'for', 'skip': 'all' },
+				{ 'tag': { 'syntax': 'head_np' }, 'level': '4', 'skip': 'np_modifiers' },
+			],
+		}),
+		'argument_context_index': 1,
+		'context_transform': { 'function': { 'pre_np_adposition': 'verb_argument' } },
 		'comment': '"for" could mean other things as well. TODO These should be set in the transform rules',
 	},
 	'agent_clause': by_clause_tag('agent_clause'),
@@ -915,7 +920,7 @@ function get_verb_usage_info(categorization, { other_optional, other_required, p
 	const possible_roles = role_letters
 		.map(c => VERB_LETTER_TO_ROLE.get(c.toUpperCase()))
 		.map(role => role === 'patient_clause' ? patient_clause_type : role)
-		.concat([...other_optional, ...other_required])
+		.concat([...other_optional, ...other_required, 'beneficiary'])	// beneficiaries are always possible
 		.filter(role => role)
 
 	/** @type {string[]} */

--- a/src/lib/rules/case_frame/verbs/presets.js
+++ b/src/lib/rules/case_frame/verbs/presets.js
@@ -71,6 +71,44 @@ export function by_adposition(adposition) {
 }
 
 /**
+ * Different from by_adposition() in that the adposition remains a lexical concept as opposed to becoming a function word.
+ * @param {string} adposition
+ * @returns {RoleRuleValueJson}
+ */
+export function by_adposition_concept(adposition='') {
+	if (adposition) {
+		// If specific adpositions are provided, filter by those only.
+		return {
+			'trigger': { 'tag': { 'syntax': 'head_np' } },
+			'context': {
+				'precededby': [
+					{ 'category': 'Verb', 'skip': 'all' },
+					{ 'token': adposition, 'skip': 'np_modifiers' },
+				],
+			},
+			'context_transform': [{}, { 'tag': { 'pre_np_adposition': 'verb_argument' } }],
+		}
+	} else {
+		// Filter for any 'Adposition', and allow the possibility of 'to'
+		return [
+			by_adposition('to'), // 'to' is also valid, but does not have a concept associated with it
+			{
+				'trigger': { 'tag': { 'syntax': 'head_np' } },
+				'context': {
+					'precededby': [
+						{ 'category': 'Verb', 'skip': 'all' },
+						{ 'category': 'Adposition', 'skip': 'np_modifiers' },
+					],
+					'notprecededby' : { 'token': 'with|for', 'skip': 'np_modifiers' },
+				},
+				'context_transform': [{}, { 'tag': { 'pre_np_adposition': 'verb_argument' } }],
+				'comment': 'Could have any adposition except with/for (eg "in Egypt", "along the Nile", "by the river", etc)',
+			},
+		]
+	}
+}
+
+/**
  * 
  * @param {string} clause_type 
  * @returns {CaseFrameRuleJson}

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -613,6 +613,9 @@ const builtin_checker_rules = [
 				 * @return {MessageInfo}
 				 */
 				function check_for_empty_theta_grid(token) {
+					if (token.lookup_results.length === 0) {
+						return {}
+					}
 					if (token.lookup_results.every(lookup => lookup.categorization.length === 0)) {
 						return { token_to_flag: token, warning: "'{stem}' has no theta grid information to check with. Double check the expected arguments with a colleague." }
 					} else if (token.lookup_results[0].categorization.length === 0) {

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -597,6 +597,33 @@ const builtin_checker_rules = [
 		},
 	},
 	{
+		name: 'Check if a Verb has no theta grid information',
+		comment: '',
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({ }),
+			action: message_set_action(function* ({ trigger_token }) {
+				yield check_for_empty_theta_grid(trigger_token)
+				if (trigger_token.complex_pairing) {
+					yield check_for_empty_theta_grid(trigger_token.complex_pairing)
+				}
+
+				/**
+				 * @param {Token} token 
+				 * @return {MessageInfo}
+				 */
+				function check_for_empty_theta_grid(token) {
+					if (token.lookup_results.every(lookup => lookup.categorization.length === 0)) {
+						return { token_to_flag: token, warning: "'{stem}' has no theta grid information to check with. Double check the expected arguments with a colleague." }
+					} else if (token.lookup_results[0].categorization.length === 0) {
+						return { token_to_flag: token, warning: "'{sense}' has no theta grid information to check with. Double check the expected arguments with a colleague." }
+					}
+					return {}
+				}
+			}),
+		},
+	},
+	{
 		name: 'Check that level 2/3 words are within a (complex) alternate',
 		comment: 'The complex word may be in a nested clause within the clause that has the (complex) tag',
 		rule: {


### PR DESCRIPTION
### Added empty theta grid warning

- `John attracted many people.` - no sense has a theta grid
<img width="640" height="210" alt="image" src="https://github.com/user-attachments/assets/5f1da3d6-11db-4d0f-b2b3-432811691ac8" />

- `John caught-E the ball.` - the selected sense has no theta grid
<img width="563" height="186" alt="image" src="https://github.com/user-attachments/assets/1384cc8d-ed04-4f8d-b6e0-3e78679741c6" />

- `John will destroy/demolish the building.` - the complex pairing has no theta grid
<img width="765" height="191" alt="image" src="https://github.com/user-attachments/assets/5627d214-51e6-4bec-972b-fbb182de1b4d" />

### Improved Beneficiary/Instrument warning

- `John ate the bread for Mary.`
<img width="807" height="185" alt="image" src="https://github.com/user-attachments/assets/6cc74d92-8137-486f-b558-d89897e5bad9" />

### More Verb Case Frames

beg
begin
blame
borrow
build
bury
catch
chase
chase-away
hang
hate
hide
hope
increase
invite
join
keep
know-how
lead
learn-how
let
lie
listen
mean
move
need
notice
offer
open
order
pass
pay
persuade
plan
please
point
pour
pour-out
praise
prevent
protect
pull
put
read
refuse
remember
remind
reply
run
scream
seem
sell
separate
shine
shoot
shout
show
show-how
sing
smell
sound-like
spill
sprinkle
start
struggle
suggest
take-away
talk
taste
teach-how
tear
thank
trust
try
turn
understand
wait
walk
warn
watch
watch-out
weigh
wrap
write