### PR TITLE
Check for nested independent clauses

### DIFF
--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -612,10 +612,21 @@ const builtin_checker_rules = [
 		},
 	},
 	{
+		name: 'Check Verb argument structure/case frame',
+		comment: "Don't validate Verbs that are in the same clause as another Verb, since there is already an error that will show for that",
+		rule: {
+			trigger: create_token_filter({ 'category': 'Verb' }),
+			context: create_context_filter({
+				'notprecededby': { 'category': 'Verb', 'skip': 'all' },
+			}),
+			action: message_set_action(validate_case_frame),
+		},
+	},
+	{
 		name: 'Check argument structure/case frame',
 		comment: 'case frame rules can eventually be used for verbs, adjectives, adverbs, adpositions, and even conjunctions',
 		rule: {
-			trigger: token => token.lookup_results.length > 0,
+			trigger: create_token_filter({ 'category': 'Adjective|Adposition' }),
 			context: create_context_filter({ }),
 			action: message_set_action(validate_case_frame),
 		},

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -569,6 +569,30 @@ const checker_rules_json = [
 		},
 		'comment': 'eg. "Not all of the people of Israel are true people of God." But something like "John is not happy" is still valid.',
 	},
+	{
+		'name': 'Check for nested independent clauses with "and" or "but", when not preceded by a clause',
+		'trigger': { 'type': TOKEN_TYPE.CLAUSE },
+		'context': {
+			'subtokens': [{ 'token': '[' }, { 'token': 'and|but' }],
+			'notprecededby': { 'type': TOKEN_TYPE.CLAUSE },
+		},
+		'error': {
+			'on': 'subtokens:0',
+			'message': "Cannot have a nested independent clause. Instead, split the sentence into two.",
+		},
+	},
+	{
+		'name': 'Check for nested independent clauses with "and" or "but", when preceded by a relative clause',
+		'trigger': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': 'patient_clause_different_participant' } },
+		'context': {
+			'subtokens': [{ 'token': '[' }, { 'token': 'and|but' }],
+			'precededby': { 'type': TOKEN_TYPE.CLAUSE, 'tag': { 'clause_type': 'relative_clause' } },
+		},
+		'error': {
+			'on': 'subtokens:0',
+			'message': "Cannot have a nested independent clause. Instead, split the sentence into two.",
+		},
+	},
 ]
 
 /** @type {BuiltInRule[]} */


### PR DESCRIPTION
Show an error if a subordinate clause starting with 'and/but' does not follow another subordinate clause, or one of the same type. This is invalid nesting of independent clauses.

Progression of errors from natural English to accepted TBTAese:

1. `John went to the store and bought some food.`
<img width="908" height="182" alt="image" src="https://github.com/user-attachments/assets/1ab86771-73a2-48d0-b830-a738bb679808" />

2. `John went to the store [and bought some food].`
<img width="1089" height="205" alt="image" src="https://github.com/user-attachments/assets/427d1bad-7a9d-4967-b008-735935ed5368" />

3. `John went to the store [and John bought some food].` (new this PR)
<img width="1093" height="199" alt="image" src="https://github.com/user-attachments/assets/3d7931af-b97f-4271-b417-b1970944fc08" />

4. `John went to the store. And John bought some food.`
<img width="998" height="196" alt="image" src="https://github.com/user-attachments/assets/cf79c647-ab9d-4d53-b7b1-ff486bfbbe72" />

---

- `John saw the man [who was happy] [and who lived in Jerusalem] [and John talked to that man].` - Does not affect legitimate coordinate subordinate clauses.
<img width="1235" height="284" alt="image" src="https://github.com/user-attachments/assets/bc691894-cdcd-49b8-a2e0-f6b9d63c9126" />
