### PR TITLE
Add support of the new literal\dynamic pairings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,10 +11,13 @@ type Token = TokenBase & {
 	specified_sense: string
 	lookup_terms: LookupTerm[]
 	lookup_results: LookupResult[]
-	complex_pairing: Token | null
+	pairing: Token | null
+	pairing_type: PairingType
 	pronoun: Token | null
 	sub_tokens: Token[]
 }
+
+type PairingType = 'none' | 'complex' | 'dynamic'
 
 type Tag = { [tag: string]: string }
 

--- a/src/lib/backtranslator/index.js
+++ b/src/lib/backtranslator/index.js
@@ -43,8 +43,12 @@ export function textify(sentences) {
 	function textify_token(token) {
 		if (token.sub_tokens.length) {
 			return textify_tokens(token.sub_tokens)
-		} else if (token.complex_pairing) {
-			return textify_token(token.complex_pairing)
+		} else if (token.pairing && token.pairing_type === 'complex') {
+			// Only show the complex word
+			return textify_lookup_word(token.pairing)
+		} else if (token.pairing && token.pairing_type === 'dynamic') {
+			// We want to show both the literal and dynamic words for now
+			return `${textify_lookup_word(token)}\\${textify_lookup_word(token.pairing)}`
 		} else if (token.pronoun) {
 			return textify_token(token.pronoun)
 		} else if (token.type === TOKEN_TYPE.ADDED) {
@@ -56,13 +60,21 @@ export function textify(sentences) {
 		} else if (['[', ']'].includes(token.token)) {
 			return ''
 		} else if (token.type === TOKEN_TYPE.LOOKUP_WORD) {
-			// Remove the sense from the token and any remaining hyphens
-			// We want to keep the hyphen in notes like (poetry-begin) so this is specific to lookup words
-			return token.token.replace(/-[A-Z]$/, '').replace(/(\w)-(\w)/g, '$1 $2')
+			return textify_lookup_word(token)
 		} else {
 			// Any remaining function words, punctuation, and notes
 			return token.token
 		}
+	}
+
+	/**
+	 * @param {Token} token
+	 * @returns {string}
+	 */
+	function textify_lookup_word(token) {
+		// Remove the sense from the token and any remaining hyphens
+		// We want to keep the hyphen in notes like (poetry-begin) so this is specific to lookup words
+		return token.token.replace(/-[A-Z]$/, '').replace(/(\w)-(\w)/g, '$1 $2')
 	}
 }
 

--- a/src/lib/backtranslator/structural_rules.js
+++ b/src/lib/backtranslator/structural_rules.js
@@ -342,14 +342,14 @@ const structural_rules_json = [
 		name: 'Capitalize the pairing if it is the first word in a sentence.',
 		comment: '',
 		rule: {
-			trigger: token => is_first_word(token) && !!token.complex_pairing,
+			trigger: token => is_first_word(token) && token.pairing_type === 'complex',
 			context: create_context_filter({ }),
 			action: simple_rule_action(({ trigger_token }) => {
-				if (!trigger_token.complex_pairing) {
+				if (!trigger_token.pairing) {
 					// makes the compiler happy, but this should never happen
 					return
 				}
-				trigger_token.complex_pairing.token = capitalize_token(trigger_token.complex_pairing)
+				trigger_token.pairing.token = capitalize_token(trigger_token.pairing)
 			}),
 		},
 	},
@@ -504,8 +504,8 @@ function fix_capitalization(old_tokens, new_tokens, decapitalize=false) {
 	const new_first_word = find_next_word(new_tokens, 0)
 	if (new_first_word) {
 		new_first_word.token = capitalize_token(new_first_word)
-		if (new_first_word.complex_pairing) {
-			new_first_word.complex_pairing.token = capitalize_token(new_first_word.complex_pairing)
+		if (new_first_word.pairing) {
+			new_first_word.pairing.token = capitalize_token(new_first_word.pairing)
 		}
 	}
 

--- a/src/lib/lookups/index.js
+++ b/src/lib/lookups/index.js
@@ -51,8 +51,8 @@ function flatten_for_lookup(sentence) {
 	function flatten_tokens(token) {
 		if (token.type === TOKEN_TYPE.CLAUSE) {
 			return token.sub_tokens.flatMap(flatten_tokens)
-		} else if (token.complex_pairing) {
-			return [token, token.complex_pairing]
+		} else if (token.pairing) {
+			return [token, token.pairing]
 		}
 		return [token]
 	}
@@ -82,8 +82,8 @@ const result_filter_rules = [
 					filter_results_by_capitalization(token)
 				}
 
-				if (token.complex_pairing) {
-					filter_results_by_capitalization(token.complex_pairing)
+				if (token.pairing) {
+					filter_results_by_capitalization(token.pairing)
 				}
 			}),
 		},

--- a/src/lib/parser/error_messages.js
+++ b/src/lib/parser/error_messages.js
@@ -5,7 +5,8 @@ const MISSING_OPENING_BRACKET = 'Missing an opening bracket somewhere in the fol
 const MISSING_CLOSING_BRACKET = 'Missing a closing bracket somewhere in the previous sentence.'
 const NO_SPACE_BEFORE_OPENING_BRACKET = 'Missing a space before [.'
 
-const INVALID_PAIRING_SYNTAX = 'Pairings should have the form simple/complex, e.g., follower/disciple.'
+const INVALID_COMPLEX_PAIRING_SYNTAX = 'Complex pairings should have the form simple/complex, e.g., follower/disciple.'
+const INVALID_DYNAMIC_PAIRING_SYNTAX = 'Dynamic pairings should have the form literal\\dynamic, e.g., reward\\prize.'
 const UNRECOGNIZED_CLAUSE_NOTATION = 'This clause notation is not recognized.' // TODO show what IS recognized
 const NO_SPACE_BEFORE_UNDERSCORE = 'Notes notation should have a space before the underscore, e.g., ⎕_implicit.'
 const UNRECOGNIZED_CHAR = 'Unrecognized character.'
@@ -36,7 +37,8 @@ export const ERRORS = {
 	FIRST_WORD_NOT_CAPITALIZED,
 	UNRECOGNIZED_CLAUSE_NOTATION,
 	NO_SPACE_BEFORE_UNDERSCORE,
-	INVALID_PAIRING_SYNTAX,
+	INVALID_COMPLEX_PAIRING_SYNTAX,
+	INVALID_DYNAMIC_PAIRING_SYNTAX,
 	UNRECOGNIZED_CHAR,
 	INVALID_TOKEN_END,
 	WORD_LEVEL_TOO_HIGH,

--- a/src/lib/parser/index.test.js
+++ b/src/lib/parser/index.test.js
@@ -122,7 +122,7 @@ describe('parse', () => {
 			expect_no_message(results[2])
 			expect(results[3].token).toBe('stupid')
 			expect(results[3].type).toBe(TOKEN_TYPE.LOOKUP_WORD)
-			expect(results[3].complex_pairing?.token).toBe('foolish')
+			expect(results[3].pairing?.token).toBe('foolish')
 			expect(results[3].messages.length).toBe(0)
 			expect(results[4].token).toBe('.')
 			expect(results[4].type).toBe(TOKEN_TYPE.PUNCTUATION)

--- a/src/lib/parser/tokenize.js
+++ b/src/lib/parser/tokenize.js
@@ -52,7 +52,10 @@ export function tokenize_input(text = '') {
 			return pronoun_referent()
 
 		} else if (match(REGEXES.FORWARD_SLASH)) {
-			return pairing()
+			return pairing('complex')
+
+		} else if (match(REGEXES.BACK_SLASH)) {
+			return pairing('dynamic')
 
 		} else if (match_two(/\.\d/)) {
 			// may be a decimal number like 2.5
@@ -72,15 +75,18 @@ export function tokenize_input(text = '') {
 		return check_boundary_for_token(pronoun_referent_token)
 	}
 
-	function pairing() {
+	/**
+	 * @param {PairingType} pairing_type
+	 */
+	function pairing(pairing_type) {
 		if (!match(REGEXES.WORD_START_CHAR)) {
-			// simple/
+			// simple/ or literal\
 			eat_until(REGEXES.TOKEN_END_BOUNDARY)
-			return error_token(ERRORS.INVALID_PAIRING_SYNTAX)
+			return error_token(pairing_type === 'complex' ? ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX : ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX)
 		}
-		// simple/complex
+		// simple/complex or literal\dynamic
 		eat(REGEXES.WORD_CHAR)
-		return check_boundary_for_token(pairing_token)
+		return check_boundary_for_token(pairing_token(pairing_type))
 	}
 
 	function decimal_number() {
@@ -149,7 +155,8 @@ export function tokenize_input(text = '') {
 
 		const messages = new Map([
 			[')', ERRORS.MISSING_OPENING_PAREN],
-			['/', ERRORS.INVALID_PAIRING_SYNTAX],
+			['/', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX],
+			['\\', ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX],
 		])
 
 		return error_token(messages.get(char) || ERRORS.UNRECOGNIZED_CHAR)
@@ -214,13 +221,17 @@ export function tokenize_input(text = '') {
 	}
 
 	/**
-	 * @param {string} token
-	 * @returns {Token}
+	 * @param {PairingType} pairing_type
+	 * @returns {(token: string) => Token}
 	 */
-	function pairing_token(token) {
-		const [left, right] = token.split('/').map(lookup_token)
-		left.complex_pairing = right
-		return left
+	function pairing_token(pairing_type) {
+		const pairing_regex = pairing_type === 'complex' ? REGEXES.FORWARD_SLASH : REGEXES.BACK_SLASH
+		return token => {
+			const [left, right] = token.split(pairing_regex).map(lookup_token)
+			left.pairing = right
+			left.pairing_type = pairing_type
+			return left
+		}
 	}
 
 	/**

--- a/src/lib/parser/tokenize.test.js
+++ b/src/lib/parser/tokenize.test.js
@@ -19,10 +19,12 @@ function create_word_token(token, { lookup_term=null, sense='' }={}) {
 /**
  * @param {Token} left_token
  * @param {Token} right_token
+ * @param {PairingType} pairing_type
  * @returns {Token}
  */
-function create_pairing(left_token, right_token) {
-	left_token.complex_pairing = right_token
+function create_pairing(left_token, right_token, pairing_type) {
+	left_token.pairing = right_token
+	left_token.pairing_type = pairing_type
 	return left_token
 }
 
@@ -365,7 +367,7 @@ describe('tokenize_input', () => {
 		const EXPECTED_OUTPUT = [
 			create_error_token('(', ERRORS.MISSING_CLOSING_PAREN),
 			create_error_token(')', ERRORS.MISSING_OPENING_PAREN),
-			create_error_token('/', ERRORS.INVALID_PAIRING_SYNTAX),
+			create_error_token('/', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX),
 			create_error_token('*', ERRORS.UNRECOGNIZED_CHAR),
 			create_error_token('+', ERRORS.UNRECOGNIZED_CHAR),
 			create_error_token(';', ERRORS.UNRECOGNIZED_CHAR),
@@ -374,48 +376,103 @@ describe('tokenize_input', () => {
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
 	})
 
-	test('valid pairing', () => {
+	test('valid complex pairing', () => {
 		const INPUT = "simple/complex simple's/complex's simples'/complexs' simples'-A/complexs' simple-A/complex-B. [simple/complex]"
 
 		const EXPECTED_OUTPUT = [
-			create_pairing(create_word_token('simple'), create_word_token('complex')),
+			create_pairing(create_word_token('simple'), create_word_token('complex'), 'complex'),
 			create_pairing(
 				create_word_token("simple's", { lookup_term: 'simple' }),
 				create_word_token("complex's", { lookup_term: 'complex' }),
+				'complex',
 			),
 			create_pairing(
 				create_word_token("simples'", { lookup_term: 'simples' }),
 				create_word_token("complexs'", { lookup_term: 'complexs' }),
+				'complex',
 			),
 			create_pairing(
 				create_word_token("simples'-A", { lookup_term: 'simples', sense: 'A' }),
 				create_word_token("complexs'", { lookup_term: 'complexs' }),
+				'complex',
 			),
 			create_pairing(
 				create_word_token('simple-A', { lookup_term: 'simple', sense: 'A' }),
 				create_word_token('complex-B', { lookup_term: 'complex', sense: 'B' }),
+				'complex',
 			),
 			create_token('.', TOKEN_TYPE.PUNCTUATION),
 			create_token('[', TOKEN_TYPE.PUNCTUATION),
-			create_pairing(create_word_token('simple'), create_word_token('complex')),
+			create_pairing(create_word_token('simple'), create_word_token('complex'), 'complex'),
 			create_token(']', TOKEN_TYPE.PUNCTUATION),
 		]
 
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
 	})
 
-	test('invalid pairing', () => {
+	test('invalid complex pairing', () => {
 		const INPUT = '/complex simple/ / simple//complex simple/.complex simple./complex'
 
 		const EXPECTED_OUTPUT = [
-			create_error_token('/complex', ERRORS.INVALID_PAIRING_SYNTAX),
-			create_error_token('simple/', ERRORS.INVALID_PAIRING_SYNTAX),
-			create_error_token('/', ERRORS.INVALID_PAIRING_SYNTAX),
-			create_error_token('simple//complex', ERRORS.INVALID_PAIRING_SYNTAX),
-			create_error_token('simple/', ERRORS.INVALID_PAIRING_SYNTAX),
+			create_error_token('/complex', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX),
+			create_error_token('simple/', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX),
+			create_error_token('/', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX),
+			create_error_token('simple//complex', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX),
+			create_error_token('simple/', ERRORS.INVALID_COMPLEX_PAIRING_SYNTAX),
 			create_error_token('.complex', ERRORS.INVALID_TOKEN_END('.')),
 			create_word_token('simple'),
 			create_error_token('./complex', ERRORS.INVALID_TOKEN_END('.')),
+		]
+
+		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
+	})
+
+	test('valid dynamic pairing', () => {
+		const INPUT = "literal\\dynamic literal's\\dynamic's literals'\\dynamics' literals'-A\\dynamics' literal-A\\dynamic-B. [literal\\dynamic]"
+
+		const EXPECTED_OUTPUT = [
+			create_pairing(create_word_token('literal'), create_word_token('dynamic'), 'dynamic'),
+			create_pairing(
+				create_word_token("literal's", { lookup_term: 'literal' }),
+				create_word_token("dynamic's", { lookup_term: 'dynamic' }),
+				'dynamic',
+			),
+			create_pairing(
+				create_word_token("literals'", { lookup_term: 'literals' }),
+				create_word_token("dynamics'", { lookup_term: 'dynamics' }),
+				'dynamic',
+			),
+			create_pairing(
+				create_word_token("literals'-A", { lookup_term: 'literals', sense: 'A' }),
+				create_word_token("dynamics'", { lookup_term: 'dynamics' }),
+				'dynamic',
+			),
+			create_pairing(
+				create_word_token('literal-A', { lookup_term: 'literal', sense: 'A' }),
+				create_word_token('dynamic-B', { lookup_term: 'dynamic', sense: 'B' }),
+				'dynamic',
+			),
+			create_token('.', TOKEN_TYPE.PUNCTUATION),
+			create_token('[', TOKEN_TYPE.PUNCTUATION),
+			create_pairing(create_word_token('literal'), create_word_token('dynamic'), 'dynamic'),
+			create_token(']', TOKEN_TYPE.PUNCTUATION),
+		]
+
+		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)
+	})
+
+	test('invalid dynamic pairing', () => {
+		const INPUT = '\\dynamic literal\\ \\ literal\\\\dynamic literal\\.dynamic literal.\\dynamic'
+
+		const EXPECTED_OUTPUT = [
+			create_error_token('\\dynamic', ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX),
+			create_error_token('literal\\', ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX),
+			create_error_token('\\', ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX),
+			create_error_token('literal\\\\dynamic', ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX),
+			create_error_token('literal\\', ERRORS.INVALID_DYNAMIC_PAIRING_SYNTAX),
+			create_error_token('.dynamic', ERRORS.INVALID_TOKEN_END('.')),
+			create_word_token('literal'),
+			create_error_token('.\\dynamic', ERRORS.INVALID_TOKEN_END('.')),
 		]
 
 		expect(tokenize_input(INPUT)).toEqual(EXPECTED_OUTPUT)

--- a/src/lib/regexes.js
+++ b/src/lib/regexes.js
@@ -13,6 +13,7 @@ const OPENING_BRACKET = /\[/
 const OPENING_PAREN = /\(/
 const CLOSING_PAREN = /\)/
 const FORWARD_SLASH = /\//
+const BACK_SLASH = /\\/
 
 // Could be you(son) your(son's) your(sons') you(son-C) your(son's-C) your(sons'-C)
 const EXTRACT_PRONOUN_REFERENT = /^(.+)\(([\w'-]+)\)$/
@@ -54,6 +55,7 @@ export const REGEXES = {
 	OPENING_PAREN,
 	CLOSING_PAREN,
 	FORWARD_SLASH,
+	BACK_SLASH,
 	TOKEN_END_BOUNDARY,
 	WORD_START_CHAR,
 	WORD_CHAR,

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -136,8 +136,8 @@ export function parse_sense_rules(rule_json, defaults) {
  */
 export function initialize_case_frame_rules({ trigger_token }, rule_info_getter) {
 	initialize_rules(trigger_token)
-	if (trigger_token.complex_pairing) {
-		initialize_rules(trigger_token.complex_pairing)
+	if (trigger_token.pairing) {
+		initialize_rules(trigger_token.pairing)
 	}
 
 	/**
@@ -182,7 +182,7 @@ export function check_case_frames(trigger_context) {
 export function check_pairing_case_frames({ trigger_token }) {
 	// check the usage of the complex pairing against the matched arguments of the selected result
 	const selected_result = trigger_token.lookup_results[0]
-	const lookups_to_check = trigger_token.complex_pairing?.lookup_results
+	const lookups_to_check = trigger_token.pairing?.lookup_results
 		.filter(LOOKUP_FILTERS.IS_IN_ONTOLOGY)
 		.filter(lookup => lookup.case_frame?.rules.length > 0)
 		?? []
@@ -386,29 +386,29 @@ export function* validate_case_frame(trigger_context) {
 		}
 	}
 
-	// Flag a complex pairing that is invalid
-	// If the simple word is invalid, there's no point checking the pairing
-	const complex_token = token.complex_pairing
-	if (case_frame.status === 'valid' && complex_token && complex_token.lookup_results.some(({ case_frame }) => case_frame.result.status === 'invalid')) {
-		const selected_complex_result = complex_token.lookup_results[0]
+	// Flag a pairing that is invalid
+	// If the base word is invalid, there's no point checking the pairing
+	const pairing_token = token.pairing
+	if (case_frame.status === 'valid' && pairing_token && pairing_token.lookup_results.some(({ case_frame }) => case_frame.result.status === 'invalid')) {
+		const selected_pairing_result = pairing_token.lookup_results[0]
 		const simple_sense = stem_with_sense(selected_result)
-		if (no_matches_and_ambiguous_sense(complex_token)) {
+		if (no_matches_and_ambiguous_sense(pairing_token)) {
 			yield {
-				token_to_flag: complex_token,
+				token_to_flag: pairing_token,
 				error: `'{stem}' may not be compatible with this usage of ${simple_sense}.`,
 			}
 
 			// show the invalid arguments for each lookup result
-			for (const result of complex_token.lookup_results) {
-				yield { token_to_flag: complex_token, ...show_invalid_roles(result) }
+			for (const result of pairing_token.lookup_results) {
+				yield { token_to_flag: pairing_token, ...show_invalid_roles(result) }
 			}
 
-		} else if (selected_complex_result.case_frame.result.status === 'invalid') {
+		} else if (selected_pairing_result.case_frame.result.status === 'invalid') {
 			yield {
-				token_to_flag: complex_token,
+				token_to_flag: pairing_token,
 				error: `{sense} may not be compatible with this usage of ${simple_sense}.`,
 			}
-			yield { token_to_flag: complex_token, ...show_invalid_roles(selected_complex_result) }
+			yield { token_to_flag: pairing_token, ...show_invalid_roles(selected_pairing_result) }
 		}
 	}
 }

--- a/src/lib/rules/case_frame/rules.js
+++ b/src/lib/rules/case_frame/rules.js
@@ -145,10 +145,10 @@ const argument_and_sense_rules = [
 		},
 	},
 	{
-		name: 'Complex Pairing compatibility and sense selection',
+		name: 'Pairing compatibility and sense selection',
 		comment: '',
 		rule: {
-			trigger: token => token.complex_pairing !== null,
+			trigger: token => token.pairing !== null,
 			context: create_context_filter({}),
 			action: simple_rule_action(trigger_context => {
 				if (trigger_context.trigger_token.lookup_results.at(0)?.case_frame.result.status === 'valid') {

--- a/src/lib/rules/case_frame/sense_selection.js
+++ b/src/lib/rules/case_frame/sense_selection.js
@@ -456,10 +456,10 @@ export function select_sense(trigger_context) {
  * @param {RuleTriggerContext} trigger_context 
  */
 export function select_pairing_sense(trigger_context) {
-	if (!trigger_context.trigger_token.complex_pairing) {
+	if (!trigger_context.trigger_token.pairing) {
 		return
 	}
-	select_word_sense(trigger_context.trigger_token.complex_pairing, trigger_context)
+	select_word_sense(trigger_context.trigger_token.pairing, trigger_context)
 }
 
 /**

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -639,8 +639,8 @@ const builtin_checker_rules = [
 			context: create_context_filter({ }),
 			action: message_set_action(function* ({ trigger_token }) {
 				yield check_for_empty_theta_grid(trigger_token)
-				if (trigger_token.complex_pairing) {
-					yield check_for_empty_theta_grid(trigger_token.complex_pairing)
+				if (trigger_token.pairing) {
+					yield check_for_empty_theta_grid(trigger_token.pairing)
 				}
 
 				/**
@@ -686,13 +686,19 @@ const builtin_checker_rules = [
 						if (complex_alternate_filter(token)) {
 							is_complex_alternate_stack = is_complex_alternate_stack.with(-1, true)
 
-						} else if (complex_word_filter(token) && !is_complex_alternate_stack.at(-1)) {
-							messages.push({ token_to_flag: token, error: ERRORS.WORD_LEVEL_TOO_HIGH })
-
 						} else if (token.sub_tokens.length) {
 							is_complex_alternate_stack.push(is_complex_alternate_stack.at(-1) ?? false)
 							search_clause_tokens(token.sub_tokens)
 							is_complex_alternate_stack.pop()
+
+						} else if (!is_complex_alternate_stack.at(-1)) {
+							if (complex_word_filter(token)) {
+								messages.push({ token_to_flag: token, error: ERRORS.WORD_LEVEL_TOO_HIGH })
+							}
+							// A dynamic pairing has the same restrictions as a normal word
+							if (token.pairing && token.pairing_type === 'dynamic' && complex_word_filter(token.pairing)) {
+								messages.push({ token_to_flag: token.pairing, error: ERRORS.WORD_LEVEL_TOO_HIGH })
+							}
 						}
 					}
 				}
@@ -704,20 +710,15 @@ const builtin_checker_rules = [
 		},
 	},
 	{
-		name: 'Check word complexity level of pairings',
+		name: 'Check word complexity level of complex pairings',
 		comment: '',
 		rule: {
-			trigger: token => token.complex_pairing !== null,
+			trigger: token => token.pairing_type === 'complex',
 			context: create_context_filter({}),
 			action: message_set_action(function* ({ trigger_token: token }) {
-				// the simple word should never be level 2 or 3
-				if (check_token_level(LOOKUP_FILTERS.IS_LEVEL_COMPLEX)(token)) {
-					yield { error: ERRORS.WORD_LEVEL_TOO_HIGH }
-				}
-
-				// the complex word should never be level 0 or 1
-				if (token.complex_pairing && check_token_level(LOOKUP_FILTERS.IS_LEVEL_SIMPLE)(token.complex_pairing)) {
-					yield { token_to_flag: token.complex_pairing, error: ERRORS.WORD_LEVEL_TOO_LOW }
+				// a complex pairing word should never be level 0 or 1
+				if (token.pairing && check_token_level(LOOKUP_FILTERS.IS_LEVEL_SIMPLE)(token.pairing)) {
+					yield { token_to_flag: token.pairing, error: ERRORS.WORD_LEVEL_TOO_LOW }
 				}
 			}),
 		},
@@ -735,11 +736,16 @@ const builtin_checker_rules = [
 				if (check_ambiguous_level(LOOKUP_FILTERS.IS_LEVEL(2))(token) || check_ambiguous_level(LOOKUP_FILTERS.IS_LEVEL(3))(token)) {
 					yield { warning: ERRORS.AMBIGUOUS_LEVEL }
 				}
+				// A dynamic pairing has the same restrictions as normal words
+				if (token.pairing && token.pairing_type === 'dynamic'
+						&& (check_ambiguous_level(LOOKUP_FILTERS.IS_LEVEL(2))(token.pairing) || check_ambiguous_level(LOOKUP_FILTERS.IS_LEVEL(3))(token.pairing))) {
+					yield { token_to_flag: token.pairing, warning: ERRORS.AMBIGUOUS_LEVEL }
+				}
 
 				// Alert if the first result is simple and there are also complex results (see 'son')
 				// If the first result is already complex, that will be selected by default and thus not ambiguous
-				if (token.complex_pairing && check_ambiguous_level(LOOKUP_FILTERS.IS_LEVEL_SIMPLE)(token.complex_pairing)) {
-					yield { token_to_flag: token.complex_pairing, warning: ERRORS.AMBIGUOUS_LEVEL }
+				if (token.pairing && token.pairing_type === 'complex' && check_ambiguous_level(LOOKUP_FILTERS.IS_LEVEL_SIMPLE)(token.pairing)) {
+					yield { token_to_flag: token.pairing, warning: ERRORS.AMBIGUOUS_LEVEL }
 				}
 			}),
 		},
@@ -753,8 +759,8 @@ const builtin_checker_rules = [
 			action: message_set_action(function* ({ trigger_token: token }) {
 				yield* check_ontology_status(token)
 
-				if (token.complex_pairing) {
-					yield* check_ontology_status(token.complex_pairing)
+				if (token.pairing) {
+					yield* check_ontology_status(token.pairing)
 				}
 			}),
 		},
@@ -768,8 +774,8 @@ const builtin_checker_rules = [
 			action: message_set_action(function* ({ trigger_token: token }) {
 				yield* check_gloss(token)
 
-				if (token.complex_pairing) {
-					yield* check_gloss(token.complex_pairing)
+				if (token.pairing) {
+					yield* check_gloss(token.pairing)
 				}
 
 				/**
@@ -954,7 +960,7 @@ function* check_ontology_status(token) {
 	}
 
 	if (token.lookup_results.length === 0) {
-		yield { token_to_flag: token, warning: '\'{token}\' is not recognized. Consult the How-To document or consider using a different word.' }
+		yield { token_to_flag: token, warning: "'{token}' is not recognized. Consult the How-To document or consider using a different word." }
 		yield { token_to_flag: token, warning: 'WARNING: Because this word is not recognized, errors and warnings within the same clause may not be accurate.' }
 		yield { token_to_flag: token, suggest: "Add '_noun', '_verb', '_adj', '_adv', '_adp', or '_conj' after the unknown word so the editor can check the syntax more accurately." }
 

--- a/src/lib/rules/checker_rules.test.js
+++ b/src/lib/rules/checker_rules.test.js
@@ -7,21 +7,23 @@ import { expect_error, expect_message_to_match, expect_no_message } from '$lib/t
 
 /**
  * 
- * @param {Token} left 
- * @param {Token} right 
+ * @param {Token} left
+ * @param {Token} right
+ * @param {PairingType} pairing_type
  * @returns {Token}
  */
-function create_pairing_token(left, right) {
-	left.complex_pairing = right
+function create_pairing_token(left, right, pairing_type='complex') {
+	left.pairing = right
+	left.pairing_type = pairing_type
 	return left
 }
 
 /**
  * 
- * @param {string} token 
- * @param {Object} [data={}] 
- * @param {LookupResult[]} [data.lookup_results=[]] 
- * @param {Tag} [data.tag={}] 
+ * @param {string} token
+ * @param {Object} [data={}]
+ * @param {LookupResult[]} [data.lookup_results=[]]
+ * @param {Tag} [data.tag={}]
  * @returns {Token}
  */
 function create_lookup_token(token, { lookup_results=[], tag={} }={}) {
@@ -30,7 +32,7 @@ function create_lookup_token(token, { lookup_results=[], tag={} }={}) {
 
 /**
  * 
- * @param {Token[]} tokens 
+ * @param {Token[]} tokens
  * @returns {Sentence}
  */
 function create_sentence(tokens) {
@@ -40,11 +42,11 @@ function create_sentence(tokens) {
 /**
  * 
  * @param {string} stem
- * @param {Object} [data={}] 
- * @param {string} [data.sense='A'] 
- * @param {string} [data.part_of_speech='Noun'] 
- * @param {number} [data.level=1] 
- * @param {number} [data.ontology_id=1] 
+ * @param {Object} [data={}]
+ * @param {string} [data.sense='A']
+ * @param {string} [data.part_of_speech='Noun']
+ * @param {number} [data.level=1]
+ * @param {number} [data.ontology_id=1]
  * @returns {LookupResult}
  */
 function lookup_result(stem, { sense='A', part_of_speech='Noun', level=1, ontology_id=1 }={}) {
@@ -92,7 +94,7 @@ describe('built-in checker rules', () => {
 	})
 
 	describe('complexity level check', () => {
-		const LEVEL_CHECK_RULES = CHECKER_RULES.slice(2, 5)
+		const LEVEL_CHECK_RULES = CHECKER_RULES.slice(4, 6)
 
 		test('different levels', () => {
 			const test_tokens = [create_sentence([
@@ -108,7 +110,7 @@ describe('built-in checker rules', () => {
 			expect_no_message(checked_tokens[0])
 			expect_no_message(checked_tokens[1])
 			expect_error(checked_tokens[2], ERRORS.WORD_LEVEL_TOO_HIGH)
-			//_error expect(checked_tokens[3], ERRORS.WORD_LEVEL_TOO_HIGH)	// TODO renable when the rule is fixed
+			expect_error(checked_tokens[3], ERRORS.WORD_LEVEL_TOO_HIGH)
 			expect_no_message(checked_tokens[4])
 		})
 		test('pairing: both words right level', () => {
@@ -116,10 +118,17 @@ describe('built-in checker rules', () => {
 				create_pairing_token(
 					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 0 })] }),
 					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 2 })] }),
+					'complex',
 				),
 				create_pairing_token(
 					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 1 })] }),
 					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 3 })] }),
+					'complex',
+				),
+				create_pairing_token(
+					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 1 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 1 })] }),
+					'dynamic',
 				),
 			])]
 	
@@ -149,14 +158,21 @@ describe('built-in checker rules', () => {
 					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 3 })] }),
 					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 3 })] }),
 				),
+				create_pairing_token(
+					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 3 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 1 })] }),
+					'dynamic',
+				),
 			])]
 	
 			const checked_tokens = apply_rules(test_tokens, LEVEL_CHECK_RULES).flatMap(flatten_sentence)
 	
 			expect_error(checked_tokens[0], ERRORS.WORD_LEVEL_TOO_HIGH)
-			expect_no_message(checked_tokens[0].complex_pairing)
+			expect_no_message(checked_tokens[0].pairing)
 			expect_error(checked_tokens[1], ERRORS.WORD_LEVEL_TOO_HIGH)
-			expect_no_message(checked_tokens[1].complex_pairing)
+			expect_no_message(checked_tokens[1].pairing)
+			expect_error(checked_tokens[2], ERRORS.WORD_LEVEL_TOO_HIGH)
+			expect_no_message(checked_tokens[2].pairing)
 		})
 		test('pairing: second word wrong level', () => {
 			const test_tokens = [create_sentence([
@@ -168,14 +184,21 @@ describe('built-in checker rules', () => {
 					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 1 })] }),
 					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 1 })] }),
 				),
+				create_pairing_token(
+					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 1 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 2 })] }),
+					'dynamic',
+				),
 			])]
 	
 			const checked_tokens = apply_rules(test_tokens, LEVEL_CHECK_RULES).flatMap(flatten_sentence)
 	
 			expect_no_message(checked_tokens[0])
-			expect_error(checked_tokens[0].complex_pairing, ERRORS.WORD_LEVEL_TOO_LOW)
+			expect_error(checked_tokens[0].pairing, ERRORS.WORD_LEVEL_TOO_LOW)
 			expect_no_message(checked_tokens[1])
-			expect_error(checked_tokens[1].complex_pairing, ERRORS.WORD_LEVEL_TOO_LOW)
+			expect_error(checked_tokens[1].pairing, ERRORS.WORD_LEVEL_TOO_LOW)
+			expect_no_message(checked_tokens[2])
+			expect_error(checked_tokens[2].pairing, ERRORS.WORD_LEVEL_TOO_HIGH)
 		})
 		test('pairing: both words wrong level', () => {
 			const test_tokens = [create_sentence([
@@ -187,19 +210,26 @@ describe('built-in checker rules', () => {
 					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 3 })] }),
 					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 1 })] }),
 				),
+				create_pairing_token(
+					create_lookup_token('first', { lookup_results: [lookup_result('first', { level: 3 })] }),
+					create_lookup_token('second', { lookup_results: [lookup_result('second', { level: 2 })] }),
+					'dynamic',
+				),
 			])]
 	
 			const checked_tokens = apply_rules(test_tokens, LEVEL_CHECK_RULES).flatMap(flatten_sentence)
 	
 			expect_error(checked_tokens[0], ERRORS.WORD_LEVEL_TOO_HIGH)
-			expect_error(checked_tokens[0].complex_pairing, ERRORS.WORD_LEVEL_TOO_LOW)
+			expect_error(checked_tokens[0].pairing, ERRORS.WORD_LEVEL_TOO_LOW)
 			expect_error(checked_tokens[1], ERRORS.WORD_LEVEL_TOO_HIGH)
-			expect_error(checked_tokens[1].complex_pairing, ERRORS.WORD_LEVEL_TOO_LOW)
+			expect_error(checked_tokens[1].pairing, ERRORS.WORD_LEVEL_TOO_LOW)
+			expect_error(checked_tokens[2], ERRORS.WORD_LEVEL_TOO_HIGH)
+			expect_error(checked_tokens[2].pairing, ERRORS.WORD_LEVEL_TOO_HIGH)
 		})
 	})
 	
 	describe('ambiguous level check', () => {
-		const AMBIGUOUS_LEVEL_CHECK = [CHECKER_RULES[5]]
+		const AMBIGUOUS_LEVEL_CHECK = CHECKER_RULES.slice(6, 7)
 
 		test('main token level check', () => {
 			const test_tokens = [create_sentence([
@@ -259,12 +289,12 @@ describe('built-in checker rules', () => {
 			expect_no_message(checked_tokens[0])
 			expect_no_message(checked_tokens[1])
 			expect_no_message(checked_tokens[2])
-			expect_message_to_match(checked_tokens[3].complex_pairing, 'warning', /^This word has multiple senses/)
+			expect_message_to_match(checked_tokens[3].pairing, 'warning', /^This word has multiple senses/)
 		})
 	})
 	
 	describe('no lookup check', () => {
-		const NO_LOOKUP_CHECK = CHECKER_RULES.slice(6, 7)
+		const NO_LOOKUP_CHECK = CHECKER_RULES.slice(7, 8)
 
 		test('no results, lookup error', () => {
 			const test_tokens = [create_sentence([
@@ -277,9 +307,9 @@ describe('built-in checker rules', () => {
 	
 			const checked_tokens = apply_rules(test_tokens, NO_LOOKUP_CHECK).flatMap(flatten_sentence)
 
-			expect_message_to_match(checked_tokens[0], 'warning', /^'token' is not in the Ontology/)
-			expect_message_to_match(checked_tokens[1], 'warning', /^'first' is not in the Ontology/)
-			expect_message_to_match(checked_tokens[1].complex_pairing, 'warning', /^'second' is not in the Ontology/)
+			expect_message_to_match(checked_tokens[0], 'warning', /^'token' is not recognized/)
+			expect_message_to_match(checked_tokens[1], 'warning', /^'first' is not recognized/)
+			expect_message_to_match(checked_tokens[1].pairing, 'warning', /^'second' is not recognized/)
 		})
 	})
 })

--- a/src/lib/rules/part_of_speech_rules.js
+++ b/src/lib/rules/part_of_speech_rules.js
@@ -479,12 +479,12 @@ const builtin_part_of_speech_rules = [
 		name: 'Filter lookup results for pairings based on part of speech',
 		comment: '',
 		rule: {
-			trigger: token => !!(token.lookup_results.length && token.complex_pairing?.lookup_results.length),
+			trigger: token => !!(token.lookup_results.length && token.pairing?.lookup_results.length),
 			context: create_context_filter({}),
 			action: message_set_action(({ trigger_token: token }) => {
 				/** @type {Token[]} */
 				// @ts-expect-error there will always be a pairing at this point
-				const [left, right] = [token, token.complex_pairing]
+				const [left, right] = [token, token.pairing]
 
 				// filter lookup results based on the overlap of the two concepts
 				const left_categories = new Set(left.lookup_results.map(result => result.part_of_speech))
@@ -624,8 +624,8 @@ export function parse_part_of_speech_rule(rule_json) {
 		return simple_rule_action(({ trigger_token }) => {
 			remove_action(trigger_token)
 
-			if (trigger_token.complex_pairing) {
-				remove_action(trigger_token.complex_pairing)
+			if (trigger_token.pairing) {
+				remove_action(trigger_token.pairing)
 			}
 		})
 	}

--- a/src/lib/rules/part_of_speech_rules.test.js
+++ b/src/lib/rules/part_of_speech_rules.test.js
@@ -7,19 +7,21 @@ import { expect_error } from '$lib/test_helps'
 
 /**
  * 
- * @param {Token} left 
- * @param {Token} right 
+ * @param {Token} left
+ * @param {Token} right
+ * @param {PairingType} pairing_type
  * @returns {Token}
  */
-function create_pairing_token(left, right) {
-	left.complex_pairing = right
+function create_pairing_token(left, right, pairing_type='complex') {
+	left.pairing = right
+	left.pairing_type = pairing_type
 	return left
 }
 
 /**
  * 
- * @param {string} token 
- * @param {Object} [data={}] 
+ * @param {string} token
+ * @param {Object} [data={}]
  * @param {LookupResult[]} [data.lookup_results=[]] 
  * @returns {Token}
  */
@@ -29,7 +31,7 @@ function create_lookup_token(token, { lookup_results=[] }={}) {
 
 /**
  * 
- * @param {Token[]} tokens 
+ * @param {Token[]} tokens
  * @returns {Sentence}
  */
 function create_sentence(tokens) {
@@ -39,11 +41,11 @@ function create_sentence(tokens) {
 /**
  * 
  * @param {string} stem
- * @param {Object} [data={}] 
- * @param {string} [data.sense='A'] 
- * @param {string} [data.part_of_speech='Noun'] 
- * @param {number} [data.level=1] 
- * @param {number} [data.ontology_id=1] 
+ * @param {Object} [data={}]
+ * @param {string} [data.sense='A']
+ * @param {string} [data.part_of_speech='Noun']
+ * @param {number} [data.level=1]
+ * @param {number} [data.ontology_id=1]
  * @returns {LookupResult}
  */
 function lookup_result(stem, { sense='A', part_of_speech='Noun', level=1, ontology_id=1 }={}) {
@@ -87,9 +89,9 @@ describe('pairing part_of_speech disambiguation', () => {
 		expect(checked_tokens[1].lookup_results.length).toBe(1)
 		expect(checked_tokens[1].lookup_results[0].part_of_speech).toBe('Verb')
 
-		expect(checked_tokens[1].complex_pairing?.messages.length).toBe(0)
-		expect(checked_tokens[1].complex_pairing?.lookup_results.length).toBe(1)
-		expect(checked_tokens[1].complex_pairing?.lookup_results[0].part_of_speech).toBe('Verb')
+		expect(checked_tokens[1].pairing?.messages.length).toBe(0)
+		expect(checked_tokens[1].pairing?.lookup_results.length).toBe(1)
+		expect(checked_tokens[1].pairing?.lookup_results[0].part_of_speech).toBe('Verb')
 	})
 	test('overlap with two part_of_speech', () => {
 		const test_tokens = [create_sentence([
@@ -132,8 +134,8 @@ describe('pairing part_of_speech disambiguation', () => {
 		expect_error(checked_tokens[1], ERRORS.PAIRING_DIFFERENT_PARTS_OF_SPEECH)
 		expect(checked_tokens[1].lookup_results.length).toBe(2)
 
-		expect(checked_tokens[1].complex_pairing?.messages.length).toBe(0)
-		expect(checked_tokens[1].complex_pairing?.lookup_results.length).toBe(2)
+		expect(checked_tokens[1].pairing?.messages.length).toBe(0)
+		expect(checked_tokens[1].pairing?.lookup_results.length).toBe(2)
 	})
 })
 

--- a/src/lib/rules/syntax_rules.js
+++ b/src/lib/rules/syntax_rules.js
@@ -33,8 +33,8 @@ const builtin_syntax_rules = [
 				}
 
 				add_tag_to_token(word_token, { 'position': 'first_word' })
-				if (word_token.complex_pairing) {
-					add_tag_to_token(word_token.complex_pairing, { 'position': 'first_word' })
+				if (word_token.pairing) {
+					add_tag_to_token(word_token.pairing, { 'position': 'first_word' })
 				}
 			}),
 		},

--- a/src/lib/rules/syntax_rules.test.js
+++ b/src/lib/rules/syntax_rules.test.js
@@ -102,7 +102,7 @@ describe('sentence syntax: first_word detection', () => {
 		const result_tokens = apply_rules(test_tokens, SYNTAX_RULES).flatMap(flatten_sentence)
 
 		expect(result_tokens[0].tag).toHaveProperty('position', 'first_word')
-		expect(result_tokens[0].complex_pairing?.tag).not.toHaveProperty('position', 'first_word')
+		expect(result_tokens[0].pairing?.tag).toHaveProperty('position', 'first_word')
 		expect(result_tokens[1].tag).not.toHaveProperty('position', 'first_word')
 		expect(result_tokens[2].tag).not.toHaveProperty('position', 'first_word')
 	})

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -31,10 +31,11 @@ export const MESSAGE_TYPE = {
  * @param {LookupResult[]} [other_data.lookup_results=[]]
  * @param {Token[]} [other_data.sub_tokens=[]]
  * @param {Token?} [other_data.pairing=null]
+ * @param {PairingType} [other_data.pairing_type='none']
  * @param {Token?} [other_data.pronoun=null]
  * @return {Token}
  */
-export function create_token(token, type, { message=null, tag={}, specified_sense='', lookup_term='', lookup_results=[], sub_tokens=[], pairing=null, pronoun=null }={}) {
+export function create_token(token, type, { message=null, tag={}, specified_sense='', lookup_term='', lookup_results=[], sub_tokens=[], pairing=null, pairing_type='none', pronoun=null }={}) {
 	return {
 		token,
 		type,
@@ -44,7 +45,8 @@ export function create_token(token, type, { message=null, tag={}, specified_sens
 		lookup_terms: lookup_term ? [lookup_term] : [],
 		lookup_results,
 		sub_tokens,
-		complex_pairing: pairing,
+		pairing,
+		pairing_type,
 		pronoun,
 	}
 }

--- a/src/lib/tokens/LookupWord.svelte
+++ b/src/lib/tokens/LookupWord.svelte
@@ -7,7 +7,7 @@
 	export let token
 </script>
 
-{#if token.complex_pairing}
+{#if token.pairing}
 	<Pairing {token} />
 {:else if token.pronoun}
 	<PronounReferent {token} />

--- a/src/lib/tokens/Pairing.svelte
+++ b/src/lib/tokens/Pairing.svelte
@@ -14,14 +14,14 @@
 
 	/** @type {SimpleToken} */
 	// @ts-expect-error the pairing will always be non-null at this point
-	$: pairing_token = token.complex_pairing
+	$: pairing_token = token.pairing
 </script>
 
 <div class="join">
 	<Message {token} />
 	<Word {token} classes="join-item" />
 
-	<TokenDisplay classes="!px-1.5 [font-family:cursive] join-item">/</TokenDisplay>
+	<TokenDisplay classes="!px-1.5 [font-family:cursive] join-item">{token.pairing_type === 'complex' ? '/' : '\\'}</TokenDisplay>
 
 	<Message token={pairing_token} />
 	<Word token={pairing_token} classes="join-item" />

--- a/src/routes/check/+server.js
+++ b/src/routes/check/+server.js
@@ -48,8 +48,8 @@ function get_status(tokens) {
  * @returns {SimpleToken[]}
  */
 function expand_token(token) {
-	if (token.complex_pairing) {
-		return [token, token.complex_pairing]
+	if (token.pairing) {
+		return [token, token.pairing]
 	} else if (token.pronoun) {
 		return [token, token.pronoun]
 	} else if (token.sub_tokens.length) {
@@ -72,14 +72,15 @@ function simplify_tokens(sentences) {
 	 * @param {Token} token 
 	 * @returns {SimpleToken}
 	 */
-	function simplify_token({ token, type, tag, messages, lookup_results, complex_pairing, pronoun, sub_tokens }) {
+	function simplify_token({ token, type, tag, messages, lookup_results, pairing, pairing_type, pronoun, sub_tokens }) {
 		return {
 			token,
 			type,
 			tag,
 			messages: messages.toSorted((a, b) => a.severity - b.severity),
 			lookup_results: lookup_results.map(simplify_lookup),
-			complex_pairing: complex_pairing ? simplify_token(complex_pairing) : null,
+			pairing: pairing ? simplify_token(pairing) : null,
+			pairing_type,
 			pronoun: pronoun ? simplify_token(pronoun) : null,
 			sub_tokens: sub_tokens.map(simplify_token),
 		}

--- a/src/routes/check/api.d.ts
+++ b/src/routes/check/api.d.ts
@@ -8,7 +8,8 @@ type CheckStatus = 'ok' | 'error' | 'warning'
 
 type SimpleToken = TokenBase & {
 	lookup_results: SimpleLookupResult[]
-	complex_pairing: SimpleToken | null
+	pairing: SimpleToken | null
+	pairing_type: PairingType
 	pronoun: SimpleToken | null
 	sub_tokens: SimpleToken[]
 }


### PR DESCRIPTION
Resolves #172 

Add support for the new literal\dynamic pairing syntax, with simple back-translation handling.
<img width="798" height="362" alt="image" src="https://github.com/user-attachments/assets/14d5d7df-143d-4c8a-b88f-e8ca9263e1b8" />

Add appropriate error messages for syntax issues
<img width="706" height="165" alt="image" src="https://github.com/user-attachments/assets/9dc6c10d-4b4b-4d2a-9e80-834d3898e68e" />

Perform level checking on the dynamic pairing. Unlike complex pairings, the dynamic pairing has the same restrictions as the base word.
- Must be a simple word
<img width="893" height="186" alt="image" src="https://github.com/user-attachments/assets/ae31674f-1058-4eff-b80c-e1ee15ed40df" />

- Unless in a complex alternate
<img width="1188" height="174" alt="image" src="https://github.com/user-attachments/assets/3eba4563-4a6c-45c2-897f-eb60ac2b74c4" />

Fixed the broken tests as well