### PR TITLE
Minor fixes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-type TokenType = 'Punctuation' | 'Note' | 'FunctionWord' | 'Word' | 'Clause' | 'Added' | 'Phrase'
+type TokenType = 'Punctuation' | 'Note' | 'FunctionWord' | 'Word' | 'Clause' | 'Added' | 'Phrase' | 'Gap'
 
 type TokenBase = {
 	token: string

--- a/src/lib/backtranslator/index.js
+++ b/src/lib/backtranslator/index.js
@@ -55,6 +55,8 @@ export function textify(sentences) {
 			return ''
 		} else if (token.type === TOKEN_TYPE.PHRASE) {
 			return ''
+		} else if (token.type === TOKEN_TYPE.GAP) {
+			return ''
 		} else if (token.token.startsWith('_')) {
 			return ''
 		} else if (['[', ']'].includes(token.token)) {

--- a/src/lib/lookups/index.js
+++ b/src/lib/lookups/index.js
@@ -74,12 +74,7 @@ const result_filter_rules = [
 			trigger: token => token.type === TOKEN_TYPE.LOOKUP_WORD && !token_has_tag(token, { 'position': 'first_word' }),
 			context: create_context_filter({}),
 			action: simple_rule_action(({ trigger_token: token }) => {
-				if (token.token !== 'null') {
-					// 'null' is used for some double pairings like 'friends/brothers and null/sisters'.
-					// But the concept in the ontology is NULL, so should not be filtered by capitalization
-					filter_results_by_capitalization(token)
-				}
-
+				filter_results_by_capitalization(token)
 				if (token.pairing) {
 					filter_results_by_capitalization(token.pairing)
 				}
@@ -113,6 +108,12 @@ function starts_lowercase(text) {
  * @param {Token} token 
  */
 function filter_results_by_capitalization(token) {
+	if (token.token === 'null') {
+		// 'null' is used for some double pairings like 'friends/brothers and null/sisters', and for some dynamic\literal pairings.
+		// But the concept in the ontology is NULL, so should not be filtered by capitalization
+		return
+	}
+
 	token.lookup_results = starts_lowercase(token.token)
 		? token.lookup_results.filter(result => starts_lowercase(result.stem))
 		: token.lookup_results.filter(result => !starts_lowercase(result.stem))

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -318,8 +318,13 @@ function check_usage(lookup, role_matches) {
 
 	const { possible_roles, required_roles } = lookup.case_frame.usage
 
+	// Sometimes the same token matches multiple roles, especially with clauses. So if an 'extra' argument
+	// also matched a valid argument, remove it from the extras.
+
 	const valid_arguments = role_matches.filter(({ role_tag }) => possible_roles.includes(role_tag))
-	const extra_arguments = role_matches.filter(({ role_tag }) => !possible_roles.includes(role_tag))
+	const extra_arguments = role_matches.filter(({ role_tag, trigger_context }) => 
+		!possible_roles.includes(role_tag)
+		&& !valid_arguments.some(({ trigger_context: { trigger_index} }) => trigger_context.trigger_index === trigger_index))
 	const missing_arguments = required_roles.filter(role => !role_matches.some(({ role_tag }) => role_tag === role))
 
 	const is_valid = extra_arguments.length === 0 && missing_arguments.length === 0

--- a/src/lib/rules/case_frame/common.js
+++ b/src/lib/rules/case_frame/common.js
@@ -151,15 +151,23 @@ export function initialize_case_frame_rules({ trigger_token }, rule_info_getter)
 			return
 		}
 		const { rules_by_sense, default_rule_getter, role_info_getter, should_check } = rule_info_getter(token)
-		if (!should_check) {
-			return
-		}
+
 		for (const lookup of token.lookup_results.filter(LOOKUP_FILTERS.IS_IN_ONTOLOGY)) {
-			const rules_for_sense = get_rules_for_sense(rules_by_sense, default_rule_getter)(lookup)
-			lookup.case_frame = {
-				rules: rules_for_sense.role_rules,
-				usage: role_info_getter(lookup.categorization, rules_for_sense),
-				result: create_case_frame(),
+			if (should_check) {
+				const rules_for_sense = get_rules_for_sense(rules_by_sense, default_rule_getter)(lookup)
+				lookup.case_frame = {
+					rules: rules_for_sense.role_rules,
+					usage: role_info_getter(lookup.categorization, rules_for_sense),
+					result: create_case_frame(),
+				}
+			} else {
+				// still initialize the usage even if we won't perform the check
+				const empty_rules = { sense: '', role_rules: [], other_required: [], other_optional: [], patient_clause_type: '' }
+				lookup.case_frame = {
+					rules: [],
+					usage: role_info_getter(lookup.categorization, empty_rules),
+					result: create_case_frame(),
+				}
 			}
 		}
 	}

--- a/src/lib/rules/case_frame/rules.js
+++ b/src/lib/rules/case_frame/rules.js
@@ -77,9 +77,10 @@ const argument_and_sense_rules = [
 		comment: 'For now, only trigger when not within a relative clause or a question since arguments get moved around or are missing',
 		rule: {
 			trigger: token => create_token_filter({ 'category': 'Verb' })(token)
-					&& token.lookup_results.every(({ case_frame }) => case_frame.result.status === 'invalid'),
+					&& token.lookup_results.some(({ case_frame }) => case_frame.result.status === 'invalid'),
 			context: create_context_filter({
 				'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
+				'followedby': { 'tag': { 'pre_np_adposition': 'agent_of_passive' }, 'skip': 'all' },
 				'notprecededby': { 'tag': ['in_relative_clause', 'in_interrogative'], 'skip': 'all' },
 			}),
 			action: simple_rule_action(trigger_context => {

--- a/src/lib/rules/case_frame/rules.js
+++ b/src/lib/rules/case_frame/rules.js
@@ -1,14 +1,33 @@
-import { add_tag_to_token, is_one_part_of_speech, token_has_tag } from '$lib/token'
-import { create_context_filter, create_token_filter, from_built_in_rule, simple_rule_action } from '$lib/rules/rules_parser'
+import { add_tag_to_token, create_gap_token, is_one_part_of_speech, token_has_tag } from '$lib/token'
+import { create_context_filter, create_skip_filter, create_token_filter, from_built_in_rule, simple_rule_action } from '$lib/rules/rules_parser'
 import { select_pairing_sense, select_sense } from './sense_selection'
 import { get_adjective_case_frame_rules } from './adjectives/case_frames'
-import { get_verb_case_frame_rules, get_passive_verb_case_frame_rules, get_same_subject_verb_case_frame_rules } from './verbs/case_frames'
+import { get_verb_case_frame_rules, get_passive_verb_case_frame_rules } from './verbs/case_frames'
 import { get_adposition_case_frame_rules } from './adpositions/case_frames'
 import { initialize_case_frame_rules, check_case_frames, check_pairing_case_frames } from './common'
 
 
 /** @type {BuiltInRule[]} */
 const argument_and_sense_rules = [
+	{
+		name: 'Fill gap in same-subject clauses',
+		comment: '',
+		rule: {
+			trigger: create_token_filter({ 'tag': { 'clause_type': 'patient_clause_same_participant|patient_clause_same_subject_passive|adverbial_clause_same_subject' } }),
+			context: create_context_filter({}),
+			action: simple_rule_action(({ trigger_token, rule_id }) => {
+				// place the gap token right after any conjunction or adposition
+				const skip_filter = create_skip_filter(['clause_start', { 'category': 'Adposition' }])
+				let gap_position = 0
+				while (skip_filter(trigger_token.sub_tokens[gap_position])) {
+					gap_position += 1
+				}
+
+				const gap_token = create_gap_token(rule_id, { 'syntax': 'head_np' })
+				trigger_token.sub_tokens.splice(gap_position, 0, gap_token)
+			}),
+		},
+	},
 	{
 		name: 'Initialize case frame rules and usage',
 		comment: '',
@@ -86,31 +105,6 @@ const argument_and_sense_rules = [
 			action: simple_rule_action(trigger_context => {
 				initialize_case_frame_rules(trigger_context, get_passive_verb_case_frame_rules)
 				check_case_frames(trigger_context)
-			}),
-		},
-	},
-	{
-		name: 'Verb case frame, same-participant patient clauses',
-		comment: '',
-		rule: {
-			trigger: create_token_filter({ 'tag': { 'clause_type': 'patient_clause_same_participant|adverbial_clause_same_subject' } }),
-			context: create_context_filter({
-				'notprecededby': { 'tag': ['in_relative_clause', 'in_interrogative'], 'skip': 'all' },
-				'subtokens': { 'category': 'Verb', 'skip': 'all' },
-			}),
-			action: simple_rule_action(({ trigger_token, subtoken_indexes, rule_id }) => {
-				const verb_trigger_context = {
-					tokens: trigger_token.sub_tokens,
-					trigger_token: trigger_token.sub_tokens[subtoken_indexes[0]],
-					trigger_index: subtoken_indexes[0],
-					context_indexes: [],
-					subtoken_indexes: [],
-					rule_id,
-				}
-
-				// TODO insert a 'placeholder' token as the agent
-				initialize_case_frame_rules(verb_trigger_context, get_same_subject_verb_case_frame_rules)
-				check_case_frames(verb_trigger_context)
 			}),
 		},
 	},

--- a/src/lib/rules/case_frame/sense_selection.js
+++ b/src/lib/rules/case_frame/sense_selection.js
@@ -449,7 +449,7 @@ export function select_sense(trigger_context) {
 		valid_argument.rule.trigger_rule.action(valid_argument.trigger_context)
 		valid_argument.trigger_context.trigger_token.applied_rules.push(`transform:argument - ${valid_argument.trigger_context.rule_id}`)
 		if (valid_argument.rule.main_word_tag) {
-			add_tag_to_token(token, valid_argument.rule.main_word_tag, trigger_context.rule_id)
+			add_tag_to_token(token, valid_argument.rule.main_word_tag, valid_argument.trigger_context.rule_id)
 		}
 	}
 }

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -1220,32 +1220,6 @@ export function get_passive_verb_case_frame_rules(token) {
 	}
 }
 
-/**
- * @param {Token} token 
- * @returns {CaseFrameRuleInfo}
- */
-export function get_same_subject_verb_case_frame_rules(token) {
-	// for a same-subject subordinate clause, the agent is always missing, so attach it to the opening bracket for now
-	const agent_rules = parse_case_frame_rule('verb_same_subject', 'agent', { 'trigger': { 'token': '[' }, 'tag_role': false })
-
-	const active_rules = get_verb_case_frame_rules(token)
-	return {
-		...active_rules,
-		rules_by_sense: active_rules.rules_by_sense
-			.map(rules_for_sense => ({ ...rules_for_sense, role_rules: replace_agent_rule(rules_for_sense.role_rules) })),
-		default_rule_getter: lookup => replace_agent_rule(active_rules.default_rule_getter(lookup)),
-	}
-
-	/**
-	 * 
-	 * @param {ArgumentRoleRule[]} role_rules 
-	 * @returns {ArgumentRoleRule[]}
-	 */
-	function replace_agent_rule(role_rules) {
-		return role_rules.filter(rule => !['agent'].includes(rule.role_tag)).concat(agent_rules)
-	}
-}
-
 const VERB_LETTER_TO_ROLE = new Map([
 	['A', 'agent'],
 	['B', 'patient'],

--- a/src/lib/rules/case_frame/verbs/case_frames.js
+++ b/src/lib/rules/case_frame/verbs/case_frames.js
@@ -1176,7 +1176,7 @@ export function get_verb_case_frame_rules(token) {
 		return {
 			rules_by_sense: [],
 			default_rule_getter: () => [],
-			role_info_getter: () => ({ possible_roles: [], required_roles: [] }),
+			role_info_getter: get_verb_usage_info,
 			should_check: false,
 		}
 	}

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -512,19 +512,6 @@ const checker_rules_json = [
 		'comment': 'While TBTA sometimes accepts it, using "that" as a complementizer is too inconsistent and so is not allowed in P1',
 	},
 	{
-		'name': "Don't allow passives in 'same subject' patient clauses",
-		'trigger': { 'tag': { 'clause_type': 'patient_clause_same_participant' } },
-		'context': {
-			'precededby': { 'category': 'Verb', 'skip': 'all' },
-			'subtokens': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
-		},
-		'error': {
-			'on': 'subtokens:0',
-			'message': 'Cannot use a passive within this patient clause because its subject is required to be the same as the outer Verb. Try making the subject explicit, or reword the sentence. See P1 Checklist 24.',
-		},
-		'comment': 'eg. John wanted XX[to be seen by Mary]XX.',
-	},
-	{
 		'name': "Don't allow passives in 'in-order-to' adverbial clauses",
 		'trigger': { 'tag': { 'auxiliary': 'passive' } },
 		'context': {

--- a/src/lib/rules/checker_rules.js
+++ b/src/lib/rules/checker_rules.js
@@ -21,7 +21,7 @@ const checker_rules_json = [
 	},
 	{
 		'name': 'Expect an agent of a passive',
-		'trigger': { 'category': 'Verb' },
+		'trigger': { 'category': 'Verb', 'form': 'perfect' },
 		'context': {
 			'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
 			'notfollowedby': { 'tag': [{ 'role': 'agent' }, { 'pre_np_adposition': 'agent_of_passive' }], 'skip': 'all' },
@@ -33,12 +33,25 @@ const checker_rules_json = [
 		'comment': 'A passive verb requires a "by X" agent.',
 	},
 	{
-		'name': 'Suggest avoiding the Perfect aspect',
-		'trigger': { 'tag': { 'auxiliary': 'flashback' } },
-		'info': {
-			'message': 'The perfect is only allowed if it would have the right meaning if changed to the simple past tense with "recently" or "previously".',
+		'name': 'Expect an agent of a passive (handles stem verbs)',
+		'trigger': { 'category': 'Verb', 'form': 'stem' },
+		'context': {
+			'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
+			'notfollowedby': { 'token': 'by|by X', 'skip': 'all' },
 		},
+		'warning': {
+			'message': 'If this verb is passive, it must have an explicit agent. Use _implicitActiveAgent if necessary.',
+		},
+		'comment': 'eg. "John was go-up the mountain by(close to) the river" is not a passive, but this situation is incredibly rare.',
 	},
+	// I've noticed this causes more confusion than it helps, so disabling it for now.
+	// {
+	// 	'name': 'Suggest avoiding the Perfect aspect',
+	// 	'trigger': { 'tag': { 'auxiliary': 'flashback' } },
+	// 	'info': {
+	// 		'message': 'The perfect is only allowed if it would have the right meaning if changed to the simple past tense with "recently" or "previously".',
+	// 	},
+	// },
 	{
 		'name': 'each other must be hyphenated',
 		'trigger': { 'stem': 'each' },

--- a/src/lib/rules/transform_rules.js
+++ b/src/lib/rules/transform_rules.js
@@ -426,7 +426,7 @@ const transform_rules_json = [
 	},
 	{
 		'name': 'by preceded by a passive be indicates the agent',
-		'trigger': { 'stem': 'by' },
+		'trigger': { 'token': 'by' },
 		'context': {
 			'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
 		},

--- a/src/lib/rules/transform_rules.js
+++ b/src/lib/rules/transform_rules.js
@@ -381,6 +381,17 @@ const transform_rules_json = [
 		'comment': 'skip all because it may be a question (eg. "Are those people going?"). We\'ll have to assume it\'s not an error.',
 	},
 	{
+		'name': 'be before a stem Verb, (especially one that contains a hyphen) indicates the clause is potentially passive',
+		'trigger': { 'stem': 'be' },
+		'context': {
+			'followedby': [
+				{ 'category': 'Verb', 'form': 'stem', 'skip': 'all' },
+			],
+		},
+		'transform': { 'function': { 'auxiliary': 'generic|passive' } },
+		'comment': 'eg. "John was go-up the mountain by(close to) the river" is not a passive, but this situation is incredibly rare.',
+	},
+	{
 		'name': 'be before a perfect Verb indicates passive',
 		'trigger': { 'stem': 'be' },
 		'context': {
@@ -408,7 +419,8 @@ const transform_rules_json = [
 		'context': {
 			'precededby': { 'tag': { 'auxiliary': 'passive' }, 'skip': 'all' },
 		},
-		'transform': { 'function': { 'pre_np_adposition': 'agent_of_passive' } },
+		'transform': { 'tag': { 'pre_np_adposition': 'agent_of_passive' } },
+		'comment': "Don't make it a function word yet in case it's not a passive. Let the case frame rules handle that part."
 	},
 	// Adpositions
 	{

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -10,6 +10,7 @@ export const TOKEN_TYPE = {
 	CLAUSE: 'Clause',
 	ADDED: 'Added',
 	PHRASE: 'Phrase',
+	GAP: 'Gap',
 }
 
 /** @type { { [key: string]: MessageType } } */
@@ -62,6 +63,17 @@ export function create_token(token, type, { message=null, tag={}, specified_sens
 export function create_added_token(token, message, rule_id=null) {
 	const rule_info = rule_id ? `add - ${rule_id}` : null
 	return create_token(token, TOKEN_TYPE.ADDED, { message, rule_info })
+}
+
+/**
+ * @param {string} rule_id
+ * @param {Tag} [tag={}]
+ * @returns {Token}
+ */
+export function create_gap_token(rule_id, tag={}) {
+	const gap_result = create_lookup_result({ stem: 'GAP', part_of_speech: 'Noun' })
+	const rule_info = `add - ${rule_id}`
+	return create_token('GAP', TOKEN_TYPE.GAP, { lookup_results: [gap_result], tag, rule_info })
 }
 
 /**


### PR DESCRIPTION
## Improve handling of same-subject passive clauses

A same-subject clause can be either active or passive. Instead of trying to use different rules for a same-subject clause, instead I added a 'gap' token where the subject should be, and the other rules find that as the appropriate argument/role. This also paves the way for more complicated gaps in relative clauses and questions that will be handled in #108 .

- `The animal is ready-C [to be killed by people _implicitActiveAgent].`

Before:
<img width="1251" height="195" alt="image" src="https://github.com/user-attachments/assets/3f6e4ea2-4abf-472d-bd83-8b6030904e3c" />
After:
<img width="1101" height="179" alt="image" src="https://github.com/user-attachments/assets/f3d72e65-0090-4fea-971b-1b47f88cb9e7" />

- `John wants [to go to Jerusalem] [in-order-to see the people].` Below shows the hidden GAP tokens through the API
<img width="789" height="425" alt="image" src="https://github.com/user-attachments/assets/3d75f224-1073-4f9c-98e5-3e67101e5dc4" />
<img width="760" height="130" alt="image" src="https://github.com/user-attachments/assets/26b2ee59-abe8-4b80-bdb3-a2b7675bafe1" />

## Improve handling of passive sentences to reduce false errors
- `The stone [that covered the entrance] had been take-away from that hole/tomb by people _implicitActiveAgent.`

Before:
<img width="1022" height="272" alt="image" src="https://github.com/user-attachments/assets/f2442433-dcd5-40e7-b757-8ee1fe361546" />
After:
<img width="1109" height="278" alt="image" src="https://github.com/user-attachments/assets/4ce3c061-d34e-40d5-a28d-16dd4ee21dee" />

### Add warning for ambiguously passive sentences
- `The clothes were put-on.`
<img width="646" height="172" alt="image" src="https://github.com/user-attachments/assets/8649476b-b3c0-4e88-8af8-b3a0b03d7375" />

- `John was chase-away those people.` this is not a passive, but there's not really a good way for the program to know that.
<img width="609" height="186" alt="image" src="https://github.com/user-attachments/assets/bbe4654b-641b-431e-a03e-886cdabf6c93" />

- `John was sit-down by-B that tree.` This is not a passive. The sense on 'by' shows that it's not indicating the agent. No warning because sit-down never takes a patient, and thus cannot be made passive.
<img width="622" height="180" alt="image" src="https://github.com/user-attachments/assets/4634505d-0cf0-469a-bb86-9114dfbcba12" />

## Handle 'null' in a literal pairing
- `You(people) (imp) eagerly\null serve the Lord.`
<img width="877" height="362" alt="image" src="https://github.com/user-attachments/assets/18f33ccc-281e-431c-b10a-568db9cad672" />
